### PR TITLE
feat/sidebar-nav

### DIFF
--- a/app/AppInit.tsx
+++ b/app/AppInit.tsx
@@ -5,12 +5,25 @@
  * functions when the web app first loads.
  */
 
-import { useEffect } from 'react'
+import useHordeApiKey from './_hooks/useHordeApiKey'
+import { AppSettings } from './_data-models/AppSettings'
+import { useEffectOnce } from './_hooks/useEffectOnce'
 
 export default function AppInit() {
-  useEffect(() => {
-    console.log('ArtBot v2.0.0_beta')
-  }, [])
+  const [handleLogin] = useHordeApiKey()
+
+  const getUserInfoOnLoad = async () => {
+    const apiKey = AppSettings.get('apiKey')
+
+    if (apiKey === '0000000000') return
+
+    await handleLogin(apiKey)
+  }
+
+  useEffectOnce(() => {
+    console.log(`ArtBot v2.0.0_beta is online: ${new Date().toLocaleString()}`)
+    getUserInfoOnLoad()
+  })
 
   return null
 }

--- a/app/AppInit.tsx
+++ b/app/AppInit.tsx
@@ -1,0 +1,16 @@
+'use client'
+
+/**
+ * This component is used to initialize various
+ * functions when the web app first loads.
+ */
+
+import { useEffect } from 'react'
+
+export default function AppInit() {
+  useEffect(() => {
+    console.log('ArtBot v2.0.0_beta')
+  }, [])
+
+  return null
+}

--- a/app/_components/HamburgerNavButton.tsx
+++ b/app/_components/HamburgerNavButton.tsx
@@ -1,0 +1,259 @@
+'use client'
+import useLockedBody from '@/app/_hooks/useLockedBody'
+import {
+  IconCamera,
+  IconHelp,
+  IconHourglass,
+  IconInfoCircle,
+  IconLayoutDashboard,
+  IconMenuDeep,
+  IconNotes,
+  IconPencil,
+  IconPhoto,
+  IconPointFilled,
+  IconQuestionMark,
+  IconRobot,
+  IconSettings,
+  IconStars,
+  IconX,
+  IconZoomQuestion
+} from '@tabler/icons-react'
+import Link from 'next/link'
+import { useEffect, useState } from 'react'
+
+export default function HamburgerNavButton() {
+  const [, setLocked] = useLockedBody(false)
+  const [open, setOpen] = useState(false)
+
+  useEffect(() => {
+    const handleEscape = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        setOpen(false)
+        setLocked(false)
+      }
+    }
+
+    document.addEventListener('keydown', handleEscape)
+
+    return () => {
+      document.removeEventListener('keydown', handleEscape)
+    }
+  }, [setLocked])
+
+  const handleOpenMenu = () => {
+    setLocked(true)
+    setOpen(true)
+  }
+
+  const handleCloseMenu = () => {
+    setLocked(false)
+    setOpen(false)
+  }
+
+  const MenuOptionCss = `row font-bold text-lg tracking-wide cursor-pointer hover:primary-color`
+  const MenuSubOptionsCss = `col pl-4 w-full mb-2`
+  const MenuSubOptionCss = `row cursor-pointer hover:primary-color`
+
+  return (
+    <div className="inline-flex relative items-center">
+      <button
+        className="cursor-pointer text-black dark:text-white hover:primary-color select-none"
+        onClick={handleOpenMenu}
+      >
+        <IconMenuDeep size={28} stroke={2} />
+      </button>
+      {open && (
+        <div
+          onClick={handleCloseMenu}
+          id="SlidingOverlay"
+          className="fixed top-0 right-0 bg-transparent w-0 h-full overflow-x-hidden z-10"
+          style={{
+            width: open ? '100%' : '0'
+          }}
+        />
+      )}
+
+      <div
+        className={`top-0 w-[300px] bg-[#484848]  text-white fixed h-full z-40 ease-in-out duration-300 pb-4 ${
+          open ? 'translate-x-0 left-0' : 'left-[-900px] translate-x-full'
+        }`}
+      >
+        <div className="col w-full items-start">
+          <div className="p-2">
+            <button
+              onClick={handleCloseMenu}
+              className="cursor-pointer hover:primary-color select-none"
+              tabIndex={open ? 0 : -1}
+            >
+              <IconX size={28} stroke={2} />
+            </button>
+          </div>
+          <div
+            className="col gap-3 pl-6 max-h-screen overflow-y-auto w-full pb-[156px] md:pb-[72px]"
+            id="menu-links-list"
+          >
+            <Link
+              className={MenuOptionCss}
+              href="/create"
+              onClick={handleCloseMenu}
+              tabIndex={open ? 0 : -1}
+            >
+              <IconCamera stroke={1.5} />
+              Create
+            </Link>
+            <Link
+              className={MenuOptionCss}
+              href="/pending"
+              onClick={handleCloseMenu}
+              tabIndex={open ? 0 : -1}
+            >
+              <IconHourglass stroke={1.5} />
+              Pending
+            </Link>
+            <Link
+              className={MenuOptionCss}
+              href="/images"
+              onClick={handleCloseMenu}
+              tabIndex={open ? 0 : -1}
+            >
+              <IconPhoto stroke={1.5} />
+              Images
+            </Link>
+            <Link
+              className={MenuOptionCss}
+              href="/info"
+              onClick={handleCloseMenu}
+              tabIndex={open ? 0 : -1}
+            >
+              <IconInfoCircle stroke={1.5} />
+              Info
+            </Link>
+            <ul className={MenuSubOptionsCss}>
+              <Link
+                className={MenuSubOptionCss}
+                href="/info/models"
+                onClick={handleCloseMenu}
+                tabIndex={open ? 0 : -1}
+              >
+                <IconPointFilled size={12} stroke={1.5} />
+                Model Details
+              </Link>
+              <Link
+                className={MenuSubOptionCss}
+                href="/info/models/updates"
+                onClick={handleCloseMenu}
+                tabIndex={open ? 0 : -1}
+              >
+                <IconPointFilled size={12} stroke={1.5} />
+                Model Updates
+              </Link>
+              <Link
+                className={MenuSubOptionCss}
+                href="/info/models?show=favorite-models"
+                onClick={handleCloseMenu}
+                tabIndex={open ? 0 : -1}
+              >
+                <IconPointFilled size={12} stroke={1.5} />
+                Favorite Models
+              </Link>
+              <Link
+                className={MenuSubOptionCss}
+                href="/info/workers"
+                onClick={handleCloseMenu}
+                tabIndex={open ? 0 : -1}
+              >
+                <IconPointFilled size={12} stroke={1.5} />
+                Worker details
+              </Link>
+            </ul>
+            <Link
+              className={MenuOptionCss}
+              href="/faq"
+              onClick={handleCloseMenu}
+              tabIndex={open ? 0 : -1}
+            >
+              <IconQuestionMark stroke={1.5} />
+              FAQ
+            </Link>
+            <Link
+              className={MenuOptionCss}
+              href="/changelog"
+              onClick={handleCloseMenu}
+              tabIndex={open ? 0 : -1}
+            >
+              <IconNotes stroke={1.5} />
+              Changelog
+            </Link>
+            <Link
+              className={MenuOptionCss}
+              href="/settings"
+              onClick={handleCloseMenu}
+              tabIndex={open ? 0 : -1}
+            >
+              <IconSettings stroke={1.5} />
+              Settings
+            </Link>
+            <ul className={MenuSubOptionsCss}>
+              <Link
+                className={MenuSubOptionCss}
+                href="/settings"
+                onClick={handleCloseMenu}
+                tabIndex={open ? 0 : -1}
+              >
+                <IconPointFilled size={12} stroke={1.5} />
+                AI Horde Settings
+              </Link>
+              <Link
+                className={MenuSubOptionCss}
+                href="/settings?panel=workers"
+                onClick={handleCloseMenu}
+                tabIndex={open ? 0 : -1}
+              >
+                <IconPointFilled size={12} stroke={1.5} />
+                Manage Workers
+              </Link>
+              <Link
+                className={MenuSubOptionCss}
+                href="/settings?panel=prefs"
+                onClick={handleCloseMenu}
+                tabIndex={open ? 0 : -1}
+              >
+                <IconPointFilled size={12} stroke={1.5} />
+                ArtBot Prefs
+              </Link>
+              <Link
+                className={MenuSubOptionCss}
+                href="/settings?panel=import-export"
+                onClick={handleCloseMenu}
+                tabIndex={open ? 0 : -1}
+              >
+                <IconPointFilled size={12} stroke={1.5} />
+                Import / Export
+              </Link>
+            </ul>
+            <Link
+              className={MenuOptionCss}
+              href="/about"
+              onClick={handleCloseMenu}
+              tabIndex={open ? 0 : -1}
+            >
+              <IconHelp stroke={1.5} />
+              About
+            </Link>
+            <ul className={MenuSubOptionsCss}>
+              <Link
+                className={MenuSubOptionCss}
+                href="/contact"
+                onClick={handleCloseMenu}
+                tabIndex={open ? 0 : -1}
+              >
+                <IconPointFilled size={12} stroke={1.5} />
+                Contact
+              </Link>
+            </ul>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/app/_components/HeaderNav.tsx
+++ b/app/_components/HeaderNav.tsx
@@ -1,6 +1,7 @@
 'use client'
 import Image from 'next/image'
 import Link from 'next/link'
+import HamburgerNavButton from './HamburgerNavButton'
 
 export default function HeaderNav() {
   const LinkStyles =
@@ -12,6 +13,7 @@ export default function HeaderNav() {
       style={{ backgroundColor: `var(--background-color)` }}
     >
       <div className="row gap-1 pl-2">
+        <HamburgerNavButton />
         <Link href="/">
           <div className="row items-center p-2 text-white h-[42px]">
             <Image

--- a/app/_data-models/ClientHeader.ts
+++ b/app/_data-models/ClientHeader.ts
@@ -1,0 +1,3 @@
+export const clientHeader = () => {
+  return `ArtBot:v.2:(discord)rockbandit#4910`
+}

--- a/app/_hooks/useEffectOnce.tsx
+++ b/app/_hooks/useEffectOnce.tsx
@@ -1,0 +1,37 @@
+import { useEffect, useRef, useState } from 'react'
+
+export const useEffectOnce = (effect: () => void | (() => void)) => {
+  const effectFn = useRef<() => void | (() => void)>(effect)
+  const destroyFn = useRef<void | (() => void)>()
+  const effectCalled = useRef(false)
+  const rendered = useRef(false)
+  const [, setVal] = useState<number>(0)
+
+  if (effectCalled.current) {
+    rendered.current = true
+  }
+
+  useEffect(() => {
+    // only execute the effect first time around
+    if (!effectCalled.current) {
+      destroyFn.current = effectFn.current()
+      effectCalled.current = true
+    }
+
+    // this forces one render after the effect is run
+    setVal((val) => val + 1)
+
+    return () => {
+      // if the comp didn't render since the useEffect was called,
+      // we know it's the dummy React cycle
+      if (!rendered.current) {
+        return
+      }
+
+      // otherwise this is not a dummy destroy, so call the destroy func
+      if (destroyFn.current) {
+        destroyFn.current()
+      }
+    }
+  }, [])
+}

--- a/app/_hooks/useHordeApiKey.tsx
+++ b/app/_hooks/useHordeApiKey.tsx
@@ -1,0 +1,57 @@
+import { clientHeader } from '../_data-models/ClientHeader'
+import { AppSettings } from '../_data-models/AppSettings'
+import { HordeUser } from '../_types/HordeTypes'
+import { updateUser } from '../_stores/UserStore'
+
+interface ErrorResponse {
+  message: string
+}
+
+// type guard functions
+function isErrorResponse(response: ErrorResponse): response is ErrorResponse {
+  return (response as ErrorResponse).message !== undefined
+}
+
+function isUserResponse(response: HordeUser): response is HordeUser {
+  return (response as HordeUser).username !== undefined
+}
+
+export default function useHordeApiKey() {
+  // const { userDetails } = useStore(UserStore)
+
+  const handleLogin = async (apikey: string = '') => {
+    if (!apikey.trim()) {
+      return { success: false }
+    }
+
+    try {
+      const res = await fetch(`https://aihorde.net/api/v2/find_user`, {
+        headers: {
+          apikey: apikey,
+          'Client-Agent': clientHeader(),
+          'Content-Type': 'application/json'
+        }
+      })
+
+      const data = (await res.json()) || {}
+
+      if (isErrorResponse(data)) {
+        return { success: false, message: data.message }
+      } else if (isUserResponse(data)) {
+        console.log(`Successfully logged in as ${data.username}`)
+        AppSettings.set('apiKey', apikey)
+        updateUser(data)
+      } else {
+        console.warn('useHordeApiKey: Unknown data structure received', data)
+        return { success: false, message: 'Unknown data structure received' }
+      }
+
+      return data
+    } catch (err) {
+      console.warn(`useHordeApiKey: ${err}`)
+      return { success: false, message: (err as Error).message }
+    }
+  }
+
+  return [handleLogin]
+}

--- a/app/_hooks/useIsomorphicLayoutEffect.tsx
+++ b/app/_hooks/useIsomorphicLayoutEffect.tsx
@@ -1,0 +1,6 @@
+import { useEffect, useLayoutEffect } from 'react'
+
+const useIsomorphicLayoutEffect =
+  typeof window !== 'undefined' ? useLayoutEffect : useEffect
+
+export default useIsomorphicLayoutEffect

--- a/app/_hooks/useLockedBody.tsx
+++ b/app/_hooks/useLockedBody.tsx
@@ -1,0 +1,55 @@
+import { useEffect, useState } from 'react'
+
+import useIsomorphicLayoutEffect from './useIsomorphicLayoutEffect'
+
+type UseLockedBodyOutput = [boolean, (locked: boolean) => void]
+
+function useLockedBody(
+  initialLocked = false,
+  rootId = '__app'
+): UseLockedBodyOutput {
+  const [locked, setLocked] = useState(initialLocked)
+
+  // Do the side effect before render
+  useIsomorphicLayoutEffect(() => {
+    if (!locked) {
+      return
+    }
+
+    // Save initial body style
+    const originalOverflow = document.body.style.overflow
+    const originalPaddingRight = document.body.style.paddingRight
+
+    // Lock body scroll
+    document.body.style.overflow = 'hidden'
+
+    // Get the scrollBar width
+    const root = document.getElementById(rootId) // or root
+    const scrollBarWidth = root ? root.offsetWidth - root.scrollWidth : 0
+
+    // Avoid width reflow
+    if (scrollBarWidth) {
+      document.body.style.paddingRight = `${scrollBarWidth}px`
+    }
+
+    return () => {
+      document.body.style.overflow = originalOverflow
+
+      if (scrollBarWidth) {
+        document.body.style.paddingRight = originalPaddingRight
+      }
+    }
+  }, [locked])
+
+  // Update state if initialValue changes
+  useEffect(() => {
+    if (locked !== initialLocked) {
+      setLocked(initialLocked)
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [initialLocked])
+
+  return [locked, setLocked]
+}
+
+export default useLockedBody

--- a/app/_stores/UserStore.ts
+++ b/app/_stores/UserStore.ts
@@ -1,0 +1,14 @@
+import { makeStore } from 'statery'
+import { HordeUser } from '../_types/HordeTypes'
+
+interface UserStoreInterface {
+  userDetails: HordeUser
+}
+
+export const UserStore = makeStore<UserStoreInterface>({
+  userDetails: {} as HordeUser
+})
+
+export const updateUser = (user: HordeUser) => {
+  UserStore.set(() => ({ userDetails: user }))
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from 'next'
 import HeaderNav from './_components/HeaderNav'
 import './globals.css'
+import AppInit from './AppInit'
 
 export const metadata: Metadata = {
   title: 'ArtBot for Stable Diffusion',
@@ -16,6 +17,7 @@ export default function RootLayout({
   return (
     <html lang="en">
       <body className="flex flex-col justify-center min-h-screen" id="__app">
+        <AppInit />
         <div className="flex flex-col flex-1 pt-[42px] p-[8px]">
           <HeaderNav />
           <main className="flex flex-col gap-4 w-full flex-1 sm:p-1">

--- a/app/settings/_component/Apikey.tsx
+++ b/app/settings/_component/Apikey.tsx
@@ -22,7 +22,7 @@ export default function Apikey() {
 
   const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
     if (e.key === 'Enter') {
-      AppSettings.set('apiKey', apikey)
+      AppSettings.set('apiKey', apikey.trim())
     }
   }
 
@@ -38,18 +38,26 @@ export default function Apikey() {
       />
       <div className="row gap-1">
         <Button
+          disabled={!apikey}
           onClick={() => {
             setApikey('')
             AppSettings.set('apiKey', '')
           }}
           theme="danger"
+          title="Reset API key"
         >
           <IconArrowBarLeft />
         </Button>
-        <Button onClick={() => setShowKey(!showKey)}>
+        <Button
+          onClick={() => setShowKey(!showKey)}
+          title={!showKey ? 'Show API key' : 'Hide API key'}
+        >
           {showKey ? <IconEyeOff /> : <IconEye />}
         </Button>
-        <Button onClick={() => AppSettings.set('apiKey', apikey)}>
+        <Button
+          onClick={() => AppSettings.set('apiKey', apikey.trim())}
+          title="Save API key"
+        >
           <IconDeviceFloppy />
         </Button>
       </div>

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,8 @@
         "clsx": "2.1.1",
         "next": "14.2.3",
         "react": "18.3.1",
-        "react-dom": "18.3.1"
+        "react-dom": "18.3.1",
+        "statery": "0.7.1"
       },
       "devDependencies": {
         "@types/jest": "29.5.12",
@@ -8129,6 +8130,19 @@
       "dev": true,
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/statery": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/statery/-/statery-0.7.1.tgz",
+      "integrity": "sha512-lx51dik6NMZc5Sc5QSqdkN/yrSjog3S6DKyToyxlq2Gs2pt9FNbBLv5EoY49uH/vWCBp6qXKmHfsalE2QDuxfg==",
+      "peerDependencies": {
+        "react": ">=18.0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        }
       }
     },
     "node_modules/streamsearch": {

--- a/package.json
+++ b/package.json
@@ -31,7 +31,8 @@
     "clsx": "2.1.1",
     "next": "14.2.3",
     "react": "18.3.1",
-    "react-dom": "18.3.1"
+    "react-dom": "18.3.1",
+    "statery": "0.7.1"
   },
   "devDependencies": {
     "@types/jest": "29.5.12",


### PR DESCRIPTION
* Add global state management via `statery`
* Add a number of useful hooks: scroll lock (prevent page scroll when menu or modal is open), useEffectOnce (to get around a particular quirk related to NextJS dev mode) , custom hook to handle login functions
* Add `AppInit` component that will eventually handle a number of functions when web app first loads, such as... 
* Automatically fetch user details on page load (if API key exists in localStorage) and add to global store. Will later be used to reference various user details (number of kudos, active workers, etc)
* Add sliding sidebar menu nav