### PR TITLE
feat: prompt history

### DIFF
--- a/app/_components/Carousel/CarouselControls.tsx
+++ b/app/_components/Carousel/CarouselControls.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable @next/next/no-img-element */
-import React from 'react'
+import React, { useEffect } from 'react'
 import { PrevButton, NextButton } from './CarouselArrowButtons'
 import styles from './carousel.module.css'
 
@@ -20,6 +20,25 @@ const CarouselControls: React.FC<CarouselControlsProps> = ({
   onPrevButtonClick,
   onNextButtonClick
 }) => {
+  useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'ArrowLeft' || event.key === 'ArrowRight') {
+        event.preventDefault()
+        if (event.key === 'ArrowLeft') {
+          onPrevButtonClick()
+        } else if (event.key === 'ArrowRight') {
+          onNextButtonClick()
+        }
+      }
+    }
+
+    window.addEventListener('keydown', handleKeyDown)
+
+    return () => {
+      window.removeEventListener('keydown', handleKeyDown)
+    }
+  }, [onNextButtonClick, onPrevButtonClick])
+
   return (
     <div className={styles.embla__controls}>
       <div className={styles.embla__buttons}>

--- a/app/_components/HeaderNav_PendingJobs.tsx
+++ b/app/_components/HeaderNav_PendingJobs.tsx
@@ -1,5 +1,5 @@
 import { useStore } from 'statery'
-import { IconPhotoCheck } from '@tabler/icons-react'
+import { IconPhoto, IconPhotoCheck } from '@tabler/icons-react'
 import Link from 'next/link'
 import {
   PendingImagesStore,
@@ -9,11 +9,7 @@ import {
 export default function HeaderNavPendingJobs() {
   const { completedJobsNotViewed, pendingImages } = useStore(PendingImagesStore)
 
-  if (
-    pendingImages.length === 0 &&
-    completedJobsNotViewed === 0
-    // pendingJobCompletedTimestamp < pendingPageTimestamp
-  ) {
+  if (pendingImages.length === 0 && completedJobsNotViewed === 0) {
     return null
   }
 
@@ -26,7 +22,11 @@ export default function HeaderNavPendingJobs() {
         }}
       >
         <div className="relative">
-          <IconPhotoCheck stroke={1.5} />
+          {pendingImages.length === 0 ? (
+            <IconPhotoCheck stroke={1.5} />
+          ) : (
+            <IconPhoto stroke={1.5} />
+          )}
           {completedJobsNotViewed > 0 && (
             <span
               style={{

--- a/app/_components/HeaderNav_UserKudos.tsx
+++ b/app/_components/HeaderNav_UserKudos.tsx
@@ -28,7 +28,7 @@ export default function UserKudos() {
     if (!apikey || !apikey.trim() || apikey === '0000000000') return
     setClientApiKey(apikey)
     setIsClient(true)
-  }, [])
+  }, [userDetails])
 
   if (
     !isClient ||

--- a/app/_components/Modal_UserKudos.tsx
+++ b/app/_components/Modal_UserKudos.tsx
@@ -19,7 +19,7 @@ export default function UserKudosModal() {
           </div>
         </div>
       </div>
-      {records.request && (
+      {records && records.request && (
         <div className="stats bg-body-color">
           <div className="stat">
             <div className="font-bold p-1">Images requested</div>

--- a/app/_components/PromptLibrary/PromptHistoryCard.tsx
+++ b/app/_components/PromptLibrary/PromptHistoryCard.tsx
@@ -2,20 +2,32 @@ import {
   IconCopy,
   IconCornerDownRight,
   IconHeart,
+  IconHeartFilled,
   IconTrash
 } from '@tabler/icons-react'
 import Button from '../Button'
 import NiceModal from '@ebay/nice-modal-react'
 import { PromptsHistory } from '@/app/_types/ArtbotTypes'
 import { formatTimestamp } from '@/app/_utils/numberUtils'
+import { toastController } from '@/app/_controllers/toastController'
+import { useState } from 'react'
+import {
+  deletePromptFromDexie,
+  updateFavoritePrompt
+} from '@/app/_db/promptsHistory'
+import DeleteConfirmation from '../Modal_DeleteConfirmation'
 
 export default function PromptHistoryCard({
+  onDelete = () => {},
   prompt,
   setPrompt
 }: {
+  onDelete?: () => void
   prompt: PromptsHistory
   setPrompt: (prompt: string) => void
 }) {
+  const [isFavorite, setIsFavorite] = useState(prompt.favorited ? true : false)
+
   return (
     <div
       className="col gap-2"
@@ -37,12 +49,22 @@ export default function PromptHistoryCard({
           {formatTimestamp(prompt.timestamp)}
         </div>
         <div className="row">
-          <Button onClick={() => {}} outline>
-            <IconHeart />
+          <Button
+            onClick={() => {
+              const updatedStatus = !isFavorite
+              setIsFavorite(updatedStatus)
+              updateFavoritePrompt(prompt.id as number, updatedStatus)
+            }}
+            outline
+          >
+            {isFavorite ? <IconHeartFilled color={'red'} /> : <IconHeart />}
           </Button>
           <Button
             onClick={() => {
               navigator.clipboard.writeText(prompt.prompt)
+              toastController({
+                message: 'Prompt copied to clipboard!'
+              })
             }}
           >
             <IconCopy />
@@ -55,7 +77,37 @@ export default function PromptHistoryCard({
           >
             <IconCornerDownRight />
           </Button>
-          <Button onClick={() => {}} theme="danger">
+          <Button
+            onClick={() => {
+              NiceModal.show('delete', {
+                children: (
+                  <DeleteConfirmation
+                    deleteButtonTitle="Delete"
+                    title="Delete prompt?"
+                    message={
+                      <>
+                        <p>
+                          Are you sure you want to delete this prompt from your
+                          prompt library?
+                        </p>
+                        <p>This cannot be undone.</p>
+                        <p>NOTE: No images will be harmed in this process.</p>
+                      </>
+                    }
+                    onDelete={async () => {
+                      await deletePromptFromDexie(prompt.id as number)
+                      await onDelete()
+                      toastController({
+                        message: 'Prompt deleted!',
+                        type: 'success'
+                      })
+                    }}
+                  />
+                )
+              })
+            }}
+            theme="danger"
+          >
             <IconTrash />
           </Button>
         </div>

--- a/app/_components/PromptLibrary/index.tsx
+++ b/app/_components/PromptLibrary/index.tsx
@@ -1,7 +1,21 @@
-import { getPromptHistoryFromDexie } from '@/app/_db/promptsHistory'
+import {
+  getAllWords,
+  getPromptHistoryCountFromDexie,
+  getPromptHistoryFromDexie,
+  getPromptsByWordsWithPagination
+} from '@/app/_db/promptsHistory'
 import { PromptsHistory } from '@/app/_types/ArtbotTypes'
 import { useEffect, useState } from 'react'
 import PromptHistoryCard from './PromptHistoryCard'
+import ReactPaginate from 'react-paginate'
+import Button from '../Button'
+import {
+  IconArrowBarLeft,
+  IconHeart,
+  IconHeartFilled
+} from '@tabler/icons-react'
+
+const LIMIT_PER_PAGE = 5
 
 interface PromptLibraryProps {
   setPrompt?: (prompt: string) => void
@@ -11,16 +25,67 @@ export default function PromptLibrary({
   type = 'prompt',
   setPrompt = () => {}
 }: PromptLibraryProps) {
+  const [showFavorites, setShowFavorites] = useState(false)
+  const [searchInput, setSearchInput] = useState('')
+  const [currentPage, setCurrentPage] = useState(0)
+  const [initLoad, setInitLoad] = useState(true)
+  const [totalItems, setTotalItems] = useState(0)
   const [prompts, setPrompts] = useState<PromptsHistory[]>([])
 
-  useEffect(() => {
-    async function getPrompts() {
-      const data = await getPromptHistoryFromDexie(0, 20, 'prompt')
-      console.log(`data?`, data)
-      setPrompts(data)
+  const getPrompts = async (
+    {
+      page,
+      searchTerm,
+      favorites
+    }: {
+      page: number
+      searchTerm: string
+      favorites?: boolean
+    } = {
+      page: 0,
+      searchTerm: '',
+      favorites: false
+    }
+  ) => {
+    const offset = page * LIMIT_PER_PAGE
+
+    let count
+    let data
+
+    if (searchTerm.trim().length > 2) {
+      const array = getAllWords(searchTerm)
+      count = await getPromptsByWordsWithPagination(
+        array,
+        offset,
+        LIMIT_PER_PAGE,
+        type,
+        true
+      )
+      data = await getPromptsByWordsWithPagination(
+        array,
+        offset,
+        LIMIT_PER_PAGE,
+        type,
+        false
+      )
+    } else {
+      count = await getPromptHistoryCountFromDexie(type, favorites)
+      data = await getPromptHistoryFromDexie({
+        offset,
+        limit: LIMIT_PER_PAGE,
+        promptType: type,
+        showFavorites: favorites
+      })
     }
 
+    setPrompts(data as PromptsHistory[])
+    setTotalItems(count as number)
+    setInitLoad(false)
+  }
+
+  useEffect(() => {
     getPrompts()
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
 
   const title = type === 'prompt' ? 'Prompt Libary' : 'Negative Prompt Libary'
@@ -29,15 +94,87 @@ export default function PromptLibrary({
     <div className="col w-full h-full">
       <h2 className="row font-bold">{title}</h2>
       <div className="col gap-4">
+        <div className="row w-full">
+          <input
+            className="bg-gray-50 border border-gray-300 text-gray-900 text-[16px] rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-full p-2 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white dark:focus:ring-blue-500 dark:focus:border-blue-500"
+            placeholder={'Search your prompts'}
+            onChange={(e) => {
+              getPrompts({ page: 0, searchTerm: e.target.value })
+              setSearchInput(e.target.value)
+            }}
+            value={searchInput}
+          />
+          <Button
+            disabled={!searchInput.trim()}
+            theme="danger"
+            onClick={async () => {
+              setCurrentPage(0)
+              setSearchInput('')
+              await getPrompts({ page: 0, searchTerm: '' })
+            }}
+          >
+            <IconArrowBarLeft />
+          </Button>
+          <Button
+            outline={!showFavorites}
+            onClick={async () => {
+              const favStatus = !showFavorites
+              setShowFavorites(favStatus)
+              await getPrompts({
+                page: 0,
+                searchTerm: searchInput,
+                favorites: favStatus
+              })
+            }}
+          >
+            {showFavorites ? <IconHeartFilled /> : <IconHeart />}
+          </Button>
+        </div>
+        <div className="text-sm">
+          Page {currentPage + 1} of{' '}
+          {Math.ceil(totalItems / LIMIT_PER_PAGE) || 1} ({totalItems} prompts)
+        </div>
+        {!initLoad && totalItems === 0 && (
+          <p>No items found. Try creating an image, first!</p>
+        )}
         {prompts.map((prompt) => {
           return (
             <PromptHistoryCard
               key={prompt.artbot_id}
               prompt={prompt}
               setPrompt={setPrompt}
+              onDelete={async () => {
+                await getPrompts({
+                  page: currentPage,
+                  searchTerm: searchInput,
+                  favorites: showFavorites
+                })
+              }}
             />
           )
         })}
+      </div>
+      <div className="row justify-center my-2">
+        <ReactPaginate
+          breakLabel="..."
+          nextLabel="⇢"
+          onPageChange={async (val) => {
+            setCurrentPage(val.selected)
+            await getPrompts({ page: val.selected, searchTerm: searchInput })
+          }}
+          containerClassName="row gap-0"
+          activeClassName="bg-[#969696]"
+          activeLinkClassName="bg-[#969696]"
+          breakLinkClassName="border px-2 py-1 bg-[#8ac5d1] hover:bg-[#8ac5d1]"
+          pageLinkClassName="border px-2 py-1 bg-[#6AB7C6] hover:bg-[#8ac5d1]"
+          previousLinkClassName="rounded-l-md border px-2 py-1 bg-[#6AB7C6] hover:bg-[#8ac5d1]"
+          nextLinkClassName="rounded-r-md border px-2 py-1 bg-[#6AB7C6] hover:bg-[#8ac5d1]"
+          disabledLinkClassName="bg-[#969696] hover:bg-[#969696] cursor-default"
+          pageRangeDisplayed={5}
+          pageCount={Math.ceil(totalItems / LIMIT_PER_PAGE)}
+          previousLabel="⇠"
+          renderOnZeroPageCount={null}
+        />
       </div>
     </div>
   )

--- a/app/_controllers/toastController.ts
+++ b/app/_controllers/toastController.ts
@@ -1,0 +1,15 @@
+import toast from 'react-hot-toast'
+
+interface ToastController {
+  message: string
+  type?: 'success' | 'error'
+  timeout?: number
+}
+
+export const toastController = ({
+  message,
+  type = 'success',
+  timeout = 3000
+}: ToastController) => {
+  toast[type](message, { duration: timeout })
+}

--- a/app/_hooks/useHordeApiKey.tsx
+++ b/app/_hooks/useHordeApiKey.tsx
@@ -2,6 +2,7 @@ import { clientHeader } from '../_data-models/ClientHeader'
 import { AppSettings } from '../_data-models/AppSettings'
 import { HordeUser } from '../_types/HordeTypes'
 import { updateUser } from '../_stores/UserStore'
+import { isUuid } from '../_utils/stringUtils'
 
 interface ErrorResponse {
   message: string
@@ -24,8 +25,13 @@ export default function useHordeApiKey() {
       return { success: false }
     }
 
+    const isSharedKey = isUuid(apikey)
+    const userDetailsApi = isSharedKey
+      ? `https://aihorde.net/api/v2/sharedkeys/${apikey}`
+      : `https://aihorde.net/api/v2/find_user`
+
     try {
-      const res = await fetch(`https://aihorde.net/api/v2/find_user`, {
+      const res = await fetch(userDetailsApi, {
         headers: {
           apikey: apikey,
           'Client-Agent': clientHeader(),
@@ -46,7 +52,7 @@ export default function useHordeApiKey() {
         return { success: false, message: 'Unknown data structure received' }
       }
 
-      return data
+      return { success: true, data }
     } catch (err) {
       console.warn(`useHordeApiKey: ${err}`)
       return { success: false, message: (err as Error).message }

--- a/app/_types/ArtbotTypes.ts
+++ b/app/_types/ArtbotTypes.ts
@@ -88,10 +88,11 @@ export enum JobType {
 }
 
 export interface PromptsHistory {
+  id?: number
   artbot_id: string
   hash_id: string
   timestamp: number
-  favorited: boolean
+  favorited: number // true === 1, false === 0
   promptType: 'prompt' | 'negative' // indexed
   prompt: string
   promptWords: string[] // indexed

--- a/app/_utils/stringUtils.ts
+++ b/app/_utils/stringUtils.ts
@@ -1,0 +1,5 @@
+export function isUuid(str: string) {
+  const uuidRegex =
+    /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i
+  return uuidRegex.test(str)
+}

--- a/app/create/_component/PromptInputForm.tsx
+++ b/app/create/_component/PromptInputForm.tsx
@@ -123,7 +123,11 @@ export default function PromptInputForm() {
                         setInput({ prompt })
                       }}
                     />
-                  )
+                  ),
+                  modalStyle: {
+                    maxWidth: '1024px',
+                    width: 'calc(100% - 32px)'
+                  }
                 })
               }}
               title="Recently used prompts"

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,4 +1,6 @@
 import type { Metadata } from 'next'
+import { Toaster } from 'react-hot-toast'
+
 import HeaderNav from './_components/HeaderNav'
 import './globals.css'
 import AppInit from './AppInit'
@@ -21,6 +23,7 @@ export default function RootLayout({
     <html lang="en">
       <body className="flex flex-col justify-center min-h-screen" id="__app">
         <ModalProvider>
+          <Toaster />
           <AppInit />
           <div className="flex flex-col flex-1 pt-[42px] p-[8px]">
             <HeaderNav />

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,7 @@
         "react-detect-click-outside": "1.1.7",
         "react-dom": "18.3.1",
         "react-dropzone": "14.2.3",
+        "react-hot-toast": "2.4.1",
         "react-loader-spinner": "6.1.6",
         "react-paginate": "8.2.0",
         "react-photo-album": "2.4.0",
@@ -4884,6 +4885,14 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/goober": {
+      "version": "2.1.14",
+      "resolved": "https://registry.npmjs.org/goober/-/goober-2.1.14.tgz",
+      "integrity": "sha512-4UpC0NdGyAFqLNPnhCT2iHpza2q+RAY3GV85a/mRPdzyPQMsj0KmMMuetdIkzWRbJ+Hgau1EZztq8ImmiMGhsg==",
+      "peerDependencies": {
+        "csstype": "^3.0.10"
+      }
+    },
     "node_modules/gopd": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.0.1.tgz",
@@ -8246,6 +8255,21 @@
       },
       "peerDependencies": {
         "react": ">= 16.8 || 18.0.0"
+      }
+    },
+    "node_modules/react-hot-toast": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/react-hot-toast/-/react-hot-toast-2.4.1.tgz",
+      "integrity": "sha512-j8z+cQbWIM5LY37pR6uZR6D4LfseplqnuAO4co4u8917hBUvXlEqyP1ZzqVLcqoyUesZZv/ImreoCeHVDpE5pQ==",
+      "dependencies": {
+        "goober": "^2.1.10"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "react": ">=16",
+        "react-dom": ">=16"
       }
     },
     "node_modules/react-is": {

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "react-detect-click-outside": "1.1.7",
     "react-dom": "18.3.1",
     "react-dropzone": "14.2.3",
+    "react-hot-toast": "2.4.1",
     "react-loader-spinner": "6.1.6",
     "react-paginate": "8.2.0",
     "react-photo-album": "2.4.0",


### PR DESCRIPTION
* Completely rewrote ArtBot v1's Prompt Library from scratch. Fully implemented prompt history (indexed search, pagination, favorites, dupe prevention)
* Updated and improved table schema around prompts (speeds up searching for text, favorites)
* Misc improvements around API key log ins

TODOs

* Negative prompt library (75% done, as we can now easily extend Prompt Library components).