### PR TITLE
feat: lora keywords

### DIFF
--- a/app/_components/AdvancedOptions/LoRAs/LoraKeywords.tsx
+++ b/app/_components/AdvancedOptions/LoRAs/LoraKeywords.tsx
@@ -1,0 +1,136 @@
+import PromptInput from '@/app/_data-models/PromptInput'
+import { IconFileInfo, IconX } from '@tabler/icons-react'
+import clsx from 'clsx'
+import { useCallback, useState } from 'react'
+import Section from '../../Section'
+import LoraDetails from './LoraDetails'
+import NiceModal from '@ebay/nice-modal-react'
+
+interface LoraKeywordsProps {
+  input: PromptInput
+  setInput: React.Dispatch<Partial<PromptInput>>
+}
+
+export default function LoraKeywords({ input, setInput }: LoraKeywordsProps) {
+  const [prompt, setPrompt] = useState(input.prompt)
+  const [usedTags, setUsedTags] = useState<string[]>([])
+
+  const onTagClick = useCallback(
+    (tag: string) => {
+      if (!usedTags.includes(tag)) {
+        setUsedTags([...usedTags, tag])
+        setPrompt(prompt + ', ' + tag)
+        setInput({ prompt: prompt + ', ' + tag })
+      } else {
+        setUsedTags(usedTags.filter((t) => t !== tag))
+        setPrompt(prompt.replace(`, ${tag}`, ''))
+        setInput({ prompt: prompt.replace(`, ${tag}`, '') })
+      }
+    },
+    [prompt, setInput, usedTags]
+  )
+
+  const tags = input.loras.reduce(
+    (acc, embedding) => {
+      // Check if the embedding has any model versions and get the trainedWords from the first model version
+      if (embedding.modelVersions.length > 0) {
+        acc[embedding.name] = embedding.modelVersions[0].trainedWords
+      } else {
+        acc[embedding.name] = []
+      }
+      return acc
+    },
+    {} as { [loraName: string]: string[] }
+  )
+
+  const categories = Object.keys(tags)
+
+  return (
+    <div className="col w-full h-full">
+      <h2 className="row font-bold">Keywords</h2>
+      {usedTags.length > 0 && (
+        <Section className="w-full col mb-4">
+          <h3 className="font-[700] text-[16px]">Used tags</h3>
+          <div className="row w-full gap-2 flex-wrap">
+            {usedTags.map((tag) => {
+              const active = usedTags.includes(tag)
+              return (
+                <div
+                  key={`used_tag-${tag}`}
+                  className={clsx(
+                    'row gap-2 px-2 py-1 rounded hover:bg-[#14B8A6] cursor-pointer',
+                    active ? 'bg-[#14B8A6]' : 'bg-zinc-400 dark:bg-zinc-700'
+                  )}
+                  onClick={() => onTagClick(tag)}
+                >
+                  {active && (
+                    <div
+                      className="row gap-0 items-center"
+                      style={{
+                        borderRight: '1px solid white',
+                        paddingRight: '4px'
+                      }}
+                    >
+                      <IconX size={16} />
+                    </div>
+                  )}
+                  {tag}
+                </div>
+              )
+            })}
+          </div>
+        </Section>
+      )}
+      {categories.map((category) => (
+        <div key={category} className="w-full col mb-4">
+          <h3 className="font-[700] text-[16px] row gap-2">
+            {category}
+            <button
+              onClick={() => {
+                const obj = input.loras.filter(
+                  (lora) => lora.name === category
+                )[0]
+
+                NiceModal.show('embeddingDetails', {
+                  children: <LoraDetails details={obj} />
+                })
+              }}
+              title="More information"
+            >
+              <IconFileInfo className="primary-color" />
+            </button>
+          </h3>
+          <div className="row w-full gap-2 flex-wrap">
+            {tags[category] &&
+              tags[category].map((tag) => {
+                const active = usedTags.includes(tag)
+                return (
+                  <div
+                    key={`${category}-${tag}`}
+                    className={clsx(
+                      'row gap-2 px-2 py-1 rounded hover:bg-[#14B8A6] cursor-pointer',
+                      active ? 'bg-[#14B8A6]' : 'bg-zinc-400 dark:bg-zinc-700'
+                    )}
+                    onClick={() => onTagClick(tag)}
+                  >
+                    {active && (
+                      <div
+                        className="row gap-0 items-center"
+                        style={{
+                          borderRight: '1px solid white',
+                          paddingRight: '4px'
+                        }}
+                      >
+                        <IconX size={16} />
+                      </div>
+                    )}
+                    {tag}
+                  </div>
+                )
+              })}
+          </div>
+        </div>
+      ))}
+    </div>
+  )
+}

--- a/app/_components/AdvancedOptions/LoRAs/LoraKeywords.tsx
+++ b/app/_components/AdvancedOptions/LoRAs/LoraKeywords.tsx
@@ -36,7 +36,7 @@ export default function LoraKeywords({ input, setInput }: LoraKeywordsProps) {
       if (embedding.modelVersions.length > 0) {
         acc[embedding.name] = embedding.modelVersions[0].trainedWords
       } else {
-        acc[embedding.name] = []
+        acc[embedding.name] = [] // If no model versions, return an empty array
       }
       return acc
     },
@@ -81,7 +81,7 @@ export default function LoraKeywords({ input, setInput }: LoraKeywordsProps) {
           </div>
         </Section>
       )}
-      {categories.map((category) => (
+      {categories?.map((category) => (
         <div key={category} className="w-full col mb-4">
           <h3 className="font-[700] text-[16px] row gap-2">
             {category}
@@ -102,7 +102,7 @@ export default function LoraKeywords({ input, setInput }: LoraKeywordsProps) {
           </h3>
           <div className="row w-full gap-2 flex-wrap">
             {tags[category] &&
-              tags[category].map((tag) => {
+              tags[category]?.map((tag) => {
                 const active = usedTags.includes(tag)
                 return (
                   <div

--- a/app/_components/PromptWarning.tsx
+++ b/app/_components/PromptWarning.tsx
@@ -1,8 +1,4 @@
-import {
-  IconAlertTriangle,
-  IconExclamationCircle,
-  IconTriangle
-} from '@tabler/icons-react'
+import { IconAlertTriangle, IconExclamationCircle } from '@tabler/icons-react'
 import { PromptError } from '../_hooks/usePromptInputValidation'
 import Button from './Button'
 import NiceModal from '@ebay/nice-modal-react'

--- a/app/_components/PromptWarning.tsx
+++ b/app/_components/PromptWarning.tsx
@@ -1,0 +1,58 @@
+import {
+  IconAlertTriangle,
+  IconExclamationCircle,
+  IconTriangle
+} from '@tabler/icons-react'
+import { PromptError } from '../_hooks/usePromptInputValidation'
+import Button from './Button'
+import NiceModal from '@ebay/nice-modal-react'
+
+interface PromptWarningProps {
+  errors: PromptError[]
+}
+
+export default function PromptWarning({ errors }: PromptWarningProps) {
+  return (
+    <div className="col w-full h-full">
+      <h2 className="row font-bold">Warnings</h2>
+      <div className="col w-full gap-4 flex-wrap">
+        {errors.map((error) => (
+          <div
+            key={`error-${error.message}`}
+            className="col gap-2 px-2 py-1 rounded"
+            style={{
+              borderLeft: `4px solid ${error.type === 'critical' ? 'red' : 'orange'}`
+            }}
+          >
+            <div className="row gap-2">
+              {error.type === 'warning' && <IconExclamationCircle />}
+              {error.type === 'critical' && (
+                <IconAlertTriangle className="text-red-500" />
+              )}
+              {error.message}
+            </div>
+            {error.type === 'warning' && (
+              <div className="font-bold text-sm">
+                (Optional) You can still continue.
+              </div>
+            )}
+            {error.type === 'critical' && (
+              <div className="font-bold text-sm">
+                (Required) You must fix this error in order to continue.
+              </div>
+            )}
+          </div>
+        ))}
+      </div>
+      <div className="w-full row justify-end">
+        <Button
+          onClick={() => {
+            NiceModal.remove('modal')
+          }}
+        >
+          Close
+        </Button>
+      </div>
+    </div>
+  )
+}

--- a/app/_utils/arrayUtils.ts
+++ b/app/_utils/arrayUtils.ts
@@ -1,3 +1,5 @@
+import { SavedLora } from '../_types/ArtbotTypes'
+
 interface JsonData {
   [key: string]: string[]
 }
@@ -10,4 +12,14 @@ export const mergeArrays = (jsonData: JsonData): string[] => {
   })
 
   return mergedArray
+}
+
+export const flattenKeywords = (jsonData: SavedLora[] = []): string[] => {
+  return jsonData.reduce((acc: string[], embedding: SavedLora) => {
+    if (embedding.modelVersions.length > 0) {
+      // Flatten and concatenate the trainedWords of the first model version to the accumulator
+      acc = acc.concat(embedding.modelVersions[0].trainedWords)
+    }
+    return acc
+  }, [])
 }

--- a/app/create/_component/PromptActionPanel.tsx
+++ b/app/create/_component/PromptActionPanel.tsx
@@ -2,6 +2,7 @@
 
 import Button from '@/app/_components/Button'
 import DeleteConfirmation from '@/app/_components/Modal_DeleteConfirmation'
+import PromptWarning from '@/app/_components/PromptWarning'
 import PromptInput from '@/app/_data-models/PromptInput'
 import {
   deleteImageFileByArtbotIdTx,
@@ -136,7 +137,14 @@ export default function PromptActionPanel() {
         </span>
       </Button>
       {errors.length > 0 && (
-        <Button theme="warning" onClick={() => {}}>
+        <Button
+          theme="warning"
+          onClick={() => {
+            NiceModal.show('modal', {
+              children: <PromptWarning errors={errors} />
+            })
+          }}
+        >
           <span className="row gap-1">
             <IconInfoTriangle stroke={1.5} />
             {hasCriticalError ? 'Error' : 'Warning'}

--- a/app/create/_component/PromptInputForm.tsx
+++ b/app/create/_component/PromptInputForm.tsx
@@ -76,6 +76,14 @@ export default function PromptInputForm() {
     setOpenNegativePrompt(negOpen)
   }, [])
 
+  const hasTrainedWords = input.loras.some((embedding) => {
+    if (!embedding) return false
+
+    return embedding.modelVersions.some(
+      (modelVersion) => modelVersion.trainedWords.length > 0
+    )
+  })
+
   return (
     <div className="col bg-[#1d4d74] w-full rounded-md p-2">
       <div className="col gap-1">
@@ -103,22 +111,26 @@ export default function PromptInputForm() {
         </div>
         <div className="row w-full justify-between">
           <div className="row gap-2">
-            <Button
-              className="!h-[36px]"
-              onClick={() => {
-                NiceModal.show('modal', {
-                  children: (
-                    <div className="text-[20px]">LoRA / TI keywords....</div>
-                  )
-                })
-              }}
-              title="Suggested keywords from LoRA or TIs"
-              style={{
-                width: '36px'
-              }}
-            >
-              <IconCodePlus stroke={1.5} />
-            </Button>
+            {(input.loras.length > 0 ||
+              input.tis.length > 0 ||
+              hasTrainedWords) && (
+              <Button
+                className="!h-[36px]"
+                onClick={() => {
+                  NiceModal.show('modal', {
+                    children: (
+                      <div className="text-[20px]">LoRA / TI keywords....</div>
+                    )
+                  })
+                }}
+                title="Suggested keywords from LoRA or TIs"
+                style={{
+                  width: '36px'
+                }}
+              >
+                <IconCodePlus stroke={1.5} />
+              </Button>
+            )}
             <Button
               className="!h-[36px]"
               onClick={() => {

--- a/app/create/_component/PromptInputForm.tsx
+++ b/app/create/_component/PromptInputForm.tsx
@@ -23,6 +23,7 @@ import PromptLibrary from '@/app/_components/PromptLibrary'
 import { addPromptToDexie } from '@/app/_db/promptsHistory'
 import { toastController } from '@/app/_controllers/toastController'
 import StyleTags from '@/app/_components/StyleTags'
+import LoraKeywords from '@/app/_components/AdvancedOptions/LoRAs/LoraKeywords'
 
 const AccordionItem = ({
   children,
@@ -118,9 +119,7 @@ export default function PromptInputForm() {
                 className="!h-[36px]"
                 onClick={() => {
                   NiceModal.show('modal', {
-                    children: (
-                      <div className="text-[20px]">LoRA / TI keywords....</div>
-                    )
+                    children: <LoraKeywords input={input} setInput={setInput} />
                   })
                 }}
                 title="Suggested keywords from LoRA or TIs"


### PR DESCRIPTION
* Refactor lora keyword button and modal. Only shows up if a lora has `trainedWords`. We now show a warning if you've imported a LoRA but haven't used any of its keywords.
* Prompt validation modal with helpful error messages (e.g., "Remix can only be used with Stable Cascade")