### PR TITLE
Session 3 feedback improvements

### DIFF
--- a/app/_components/AdvancedOptions/AddWorkflow/index.tsx
+++ b/app/_components/AdvancedOptions/AddWorkflow/index.tsx
@@ -1,0 +1,180 @@
+'use client'
+
+import { useCallback, useEffect, useState } from 'react'
+import Section from '../../Section'
+import Select from '../../Select'
+import OptionLabel from '../OptionLabel'
+import { SelectOption } from '../../ComboBox'
+import { IconArrowBarLeft } from '@tabler/icons-react'
+import Button from '../../Button'
+import { useInput } from '@/app/_providers/PromptInputProvider'
+import { WorkflowPosition } from '@/app/_types/ArtbotTypes'
+
+export const QrCodeOptionsArray = [
+  { value: '', label: 'None' },
+  {
+    value: 'enabled',
+    label: 'Enabled'
+  }
+]
+
+export const QrCodePosition = [
+  { value: 'center', label: 'centered' },
+  { value: 'top left', label: 'top left' },
+  { value: 'top right', label: 'top right' },
+  { value: 'bottom left', label: 'bottom left' },
+  { value: 'bottom right', label: 'bottom right' }
+]
+
+export default function AddWorkflow() {
+  const { input, setInput } = useInput()
+  const [qrCodeOption, setQrCodeOption] = useState<SelectOption>({
+    value: '',
+    label: 'None'
+  })
+  const [qrCodeText, setQrCodeText] = useState<string>('')
+  const [qrCodePosition, setQrCodePosition] = useState<SelectOption>({
+    value: 'center',
+    label: 'Centered'
+  })
+
+  const handleEditWorkflow = useCallback(
+    (text: string, newPosition: WorkflowPosition) => {
+      const { workflows = [] } = input
+      let found = false
+
+      const updatedArray = workflows.map((workflow) => {
+        if (workflow.type === 'qr_code') {
+          found = true
+          return { ...workflow, text, position: newPosition }
+        }
+        return workflow
+      })
+
+      if (!found) {
+        updatedArray.push({
+          type: 'qr_code',
+          position: newPosition,
+          text
+        })
+      }
+
+      setInput({ workflows: updatedArray })
+    },
+    [input, setInput]
+  )
+
+  const handleWorkflowChange = (option: SelectOption) => {
+    const { workflows = [] } = input
+
+    if (!option.value) {
+      setInput({ workflows: workflows.filter((w) => w.type !== 'qr_code') })
+      setQrCodeOption({ value: '', label: 'None' })
+      setQrCodeText('')
+      setQrCodePosition({ value: 'center', label: 'centered' })
+      return
+    } else if (option.value === 'enabled') {
+      setQrCodeOption({ value: 'enabled', label: 'Enabled' })
+      setInput({
+        workflows: [
+          ...workflows,
+          { type: 'qr_code', position: 'center', text: '' }
+        ]
+      })
+      return
+    }
+  }
+
+  useEffect(() => {
+    if (input.workflows.length > 0) {
+      // Filter input.workflows to see if any workflows are of type 'qr_code'
+      const qrCodeWorkflow = input.workflows.find((w) => w.type === 'qr_code')
+      if (qrCodeWorkflow) {
+        setQrCodeOption({ value: 'enabled', label: 'Enabled' })
+        setQrCodeText(qrCodeWorkflow.text)
+        setQrCodePosition({
+          value: qrCodeWorkflow.position,
+          label: qrCodeWorkflow.position
+        })
+      }
+    }
+  }, [input.workflows])
+
+  return (
+    <Section anchor="workflows">
+      <div className="row justify-between">
+        <h2 className="row font-bold text-white">Workflows</h2>
+      </div>
+      <div className="w-full">
+        <OptionLabel
+          className="row md:row"
+          title={
+            <span className="row font-bold text-sm text-white gap-1">
+              QR Code
+            </span>
+          }
+        >
+          <Select
+            onChange={(option: SelectOption) => handleWorkflowChange(option)}
+            options={QrCodeOptionsArray}
+            value={{ ...qrCodeOption }}
+          />
+        </OptionLabel>
+        {qrCodeOption.value === 'enabled' && (
+          <div className="rounded bg-[#1d4d74] p-2 col mt-2">
+            <label
+              className={'col md:row justify-between gap-2 font-bold text-sm'}
+            >
+              QR Code Text
+            </label>
+            <div className="w-full row">
+              <input
+                className="bg-gray-50 border border-gray-300 text-gray-900 text-[16px] rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-full p-2 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white dark:focus:ring-blue-500 dark:focus:border-blue-500"
+                onChange={(e) => {
+                  setQrCodeText(e.target.value)
+                  handleEditWorkflow(
+                    e.target.value,
+                    qrCodePosition.value as WorkflowPosition
+                  )
+                }}
+                placeholder="Enter text or URL"
+                value={qrCodeText}
+              />
+              <div className="row gap-1">
+                <Button
+                  disabled={qrCodeText === ''}
+                  theme="danger"
+                  title="Clear text field"
+                  onClick={() => {
+                    setQrCodeText('')
+                    handleEditWorkflow(
+                      '',
+                      qrCodePosition.value as WorkflowPosition
+                    )
+                  }}
+                >
+                  <IconArrowBarLeft />
+                </Button>
+              </div>
+            </div>
+            <label
+              className={
+                'col md:row justify-between gap-2 font-bold text-sm mt-2'
+              }
+            >
+              QR Code Position
+            </label>
+            <Select
+              onChange={(option: SelectOption) => {
+                setQrCodePosition(option)
+                handleEditWorkflow(qrCodeText, option.value as WorkflowPosition)
+              }}
+              options={QrCodePosition}
+              value={{ ...qrCodePosition }}
+            />
+          </div>
+        )}
+      </div>
+    </Section>
+  )
+}

--- a/app/_components/AdvancedOptions/StylePresetModal.tsx
+++ b/app/_components/AdvancedOptions/StylePresetModal.tsx
@@ -8,7 +8,11 @@ import {
 import React, { useState } from 'react'
 import Button from '../Button'
 import NiceModal from '@ebay/nice-modal-react'
-import { CategoryPreset } from '@/app/_types/HordeTypes'
+import {
+  CategoryPreset,
+  StylePresetConfigurations,
+  StylePreviewConfigurations
+} from '@/app/_types/HordeTypes'
 import { Popover, PopoverButton, PopoverPanel } from '@headlessui/react'
 
 // Component to manage individual image loading and error handling
@@ -64,12 +68,14 @@ const ImageWithFallback = ({
   )
 }
 
-const FilterableCategories = ({
+const StylePresetModal = ({
   categories,
+  previews,
   handleOnClick = () => {}
 }: {
   categories: CategoryPreset
-  presets: unknown
+  presets: StylePresetConfigurations
+  previews: StylePreviewConfigurations
   handleOnClick?: (preset: string) => void
 }) => {
   const [searchInput, setSearchInput] = useState('')
@@ -171,74 +177,89 @@ const FilterableCategories = ({
           </PopoverPanel>
         </Popover>
       </div>
-      {Object.keys(filteredCategories).map((category: string) => (
-        <div key={category} className="w-full col mb-6">
-          <h3 className="font-[700] text-[18px] row gap-2">
-            {category}
-            <button
-              onClick={() => {
-                const filterStyles = filteredCategories[category]
-                const randomStyle =
-                  filterStyles[Math.floor(Math.random() * filterStyles.length)]
+      {Object.keys(filteredCategories).map((category: string) => {
+        if (
+          !filteredCategories[category] ||
+          filteredCategories[category].length === 0
+        )
+          return null
+        return (
+          <div key={category} className="w-full col mb-6">
+            <h3 className="font-[700] text-[18px] row gap-2">
+              {category}
+              <button
+                onClick={() => {
+                  const filterStyles = filteredCategories[category]
+                  const randomStyle =
+                    filterStyles[
+                      Math.floor(Math.random() * filterStyles.length)
+                    ]
 
-                if (!randomStyle) {
-                  return
-                }
+                  if (!randomStyle) {
+                    return
+                  }
 
-                handleOnClick(randomStyle)
-                NiceModal.remove('modal')
-              }}
-              title="Select random style"
-            >
-              <IconWand className="primary-color" />
-            </button>
-          </h3>
-          <div className="row w-full gap-2 flex-wrap">
+                  handleOnClick(randomStyle)
+                  NiceModal.remove('modal')
+                }}
+                title="Select random style"
+              >
+                <IconWand className="primary-color" />
+              </button>
+            </h3>
             <div className="row w-full gap-2 flex-wrap">
-              {filteredCategories[category].map((preset) => {
-                const formatPreset = preset.replace(' ', '_')
-                return (
-                  <div
-                    key={`${category}-${preset}`}
-                    style={{
-                      cursor: 'pointer',
-                      width: '200px',
-                      height: 'auto',
-                      border: '1px solid white',
-                      overflow: 'hidden',
-                      display: 'flex',
-                      flexDirection: 'column',
-                      alignItems: 'center'
-                    }}
-                    onClick={() => {
-                      handleOnClick(preset)
-                    }}
-                  >
-                    <ImageWithFallback
-                      src={`https://raw.githubusercontent.com/amiantos/AI-Horde-Styles-Previews/main/images/${formatPreset}_${subject}.webp`}
-                      alt={preset}
-                      fallbackColor="gray"
-                    />
+              <div className="row w-full gap-2 flex-wrap">
+                {filteredCategories[category].map((preset) => {
+                  if (!preset) return null
+                  return (
                     <div
+                      key={`${category}-${preset}`}
                       style={{
+                        cursor: 'pointer',
                         width: '200px',
-                        padding: '8px',
-                        textAlign: 'center',
-                        wordWrap: 'break-word',
-                        whiteSpace: 'normal'
+                        height: 'auto',
+                        border: '1px solid white',
+                        overflow: 'hidden',
+                        display: 'flex',
+                        flexDirection: 'column',
+                        alignItems: 'center'
+                      }}
+                      onClick={() => {
+                        handleOnClick(preset)
                       }}
                     >
-                      {preset}
+                      <ImageWithFallback
+                        src={
+                          previews[preset] && preset
+                            ? // @ts-expect-error TODO: Add type
+                              previews[preset][subject]
+                            : ''
+                        }
+                        alt={preset}
+                        fallbackColor="gray"
+                      />
+                      <div
+                        style={{
+                          width: '200px',
+                          padding: '4px',
+                          textAlign: 'center',
+                          wordWrap: 'break-word',
+                          whiteSpace: 'normal',
+                          fontSize: '12px'
+                        }}
+                      >
+                        {preset}
+                      </div>
                     </div>
-                  </div>
-                )
-              })}
+                  )
+                })}
+              </div>
             </div>
           </div>
-        </div>
-      ))}
+        )
+      })}
     </div>
   )
 }
 
-export default FilterableCategories
+export default StylePresetModal

--- a/app/_components/AdvancedOptions/StylePresetSelect/index.tsx
+++ b/app/_components/AdvancedOptions/StylePresetSelect/index.tsx
@@ -1,4 +1,7 @@
-import { CategoryPreset, StylePresetConfigurations } from '@/app/_types/HordeTypes'
+import {
+  CategoryPreset,
+  StylePresetConfigurations
+} from '@/app/_types/HordeTypes'
 import StylePresetSelectComponent from './stylePresetSelectComponent'
 
 export async function getData(): Promise<{
@@ -18,9 +21,18 @@ export async function getData(): Promise<{
     // @ts-expect-error TODO: Need to properly type this.
     const presets: never = (await presetsRes.json()) || {}
 
+    // Filter categories to include only those keys that exist in presets
+    // e.g., "Summer" category includes "Summer 2022" and "Summer 2023" categories
+    const filteredCategories = Object.keys(categories).reduce((acc, key) => {
+      acc[key] = categories[key].filter(
+        (category: string) => category in presets
+      )
+      return acc
+    }, {} as CategoryPreset)
+
     return {
       success: true,
-      categories,
+      categories: filteredCategories,
       presets
     }
   } catch (err) {

--- a/app/_components/AdvancedOptions/StylePresetSelect/stylePresetSelectComponent.tsx
+++ b/app/_components/AdvancedOptions/StylePresetSelect/stylePresetSelectComponent.tsx
@@ -60,7 +60,7 @@ export default function StylePresetSelectComponent({
               isArtbotManualEntry: true,
               name: lora.name,
               strength: lora.model || 1,
-              clip: lora.clip || 1
+              clip: lora.clip_skip || 1
             })
 
             // @ts-expect-error updateInput.loras is defined right above this.

--- a/app/_components/AdvancedOptions/StylePresetSelect/stylePresetSelectComponent.tsx
+++ b/app/_components/AdvancedOptions/StylePresetSelect/stylePresetSelectComponent.tsx
@@ -10,7 +10,8 @@ import Button from '../../Button'
 import {
   CategoryPreset,
   StylePresetConfig,
-  StylePresetConfigurations
+  StylePresetConfigurations,
+  StylePreviewConfigurations
 } from '@/app/_types/HordeTypes'
 import { useCallback } from 'react'
 import PromptInput from '@/app/_data-models/PromptInput'
@@ -21,10 +22,12 @@ import { ModelStore } from '@/app/_stores/ModelStore'
 export default function StylePresetSelectComponent({
   categories,
   presets,
+  previews,
   hasError = false
 }: {
   categories: CategoryPreset
   presets: StylePresetConfigurations
+  previews: StylePreviewConfigurations
   hasError: boolean
 }) {
   const { input, setInput } = useInput()
@@ -124,6 +127,7 @@ export default function StylePresetSelectComponent({
                 <StylePresetModal
                   categories={categories}
                   presets={presets}
+                  previews={previews}
                   handleOnClick={(option: string) => {
                     handleSelectPreset(option, presets[option])
                     NiceModal.remove('modal')

--- a/app/_components/AdvancedOptions/index.tsx
+++ b/app/_components/AdvancedOptions/index.tsx
@@ -16,6 +16,7 @@ import Steps from './Steps'
 import UploadImage from './UploadImage'
 import Upscalers from './Upscalers'
 import StylePresetSelect from './StylePresetSelect'
+import AddWorkflow from './AddWorkflow'
 
 export default function AdvancedOptions() {
   return (
@@ -38,6 +39,7 @@ export default function AdvancedOptions() {
       </Section>
       <AddLora />
       <AddEmbedding />
+      <AddWorkflow />
       <Section anchor="face-fixers">
         <FaceFixers />
       </Section>

--- a/app/_components/Gallery.tsx
+++ b/app/_components/Gallery.tsx
@@ -21,6 +21,7 @@ import Button from './Button'
 import ImageThumbnail from './ImageThumbnail'
 import GalleryImageCardOverlay from './GalleryImageCardOverlay'
 import { viewedPendingPage } from '../_stores/PendingImagesStore'
+import Section from './Section'
 
 export default function Gallery() {
   const [groupImages, setGroupImages] = useState(true)
@@ -73,60 +74,61 @@ export default function Gallery() {
 
   return (
     <div className="w-full">
-      <div className="row w-full justify-between my-2">
-        <div className="row">
-          <Button
-            onClick={() => {
-              if (showSearch) {
-                setSearchInput('')
-                setShowSearch(false)
-              } else {
-                setShowSearch(true)
-              }
-            }}
-            outline
-          >
-            <span className="row gap-1">
-              <IconSearch stroke={1.5} size={16} />
-              Search
-            </span>
-          </Button>
-          <Button
-            onClick={() => {
-              setCurrentPage(1)
-              setGroupImages(!groupImages)
-            }}
-            outline
-            title="Group or ungroup images by batched image request"
-          >
-            <span className="row gap-1 justify-center md:w-[5.75em]">
-              {groupImages ? (
-                <>
-                  <IconAffiliate />
-                  <span className="hidden sm:row">Ungroup</span>
-                </>
-              ) : (
-                <>
-                  <IconAffiliateFilled stroke={1.5} size={16} />
-                  <span className="hidden sm:row">Group</span>
-                </>
-              )}
-            </span>
-          </Button>
-          <Button
-            onClick={() => setSortBy(sortBy === 'desc' ? 'asc' : 'desc')}
-            outline
-          >
-            <span className="row gap-1">
-              {sortBy === 'desc' ? (
-                <IconSortDescending stroke={1.5} size={20} />
-              ) : (
-                <IconSortAscending stroke={1.5} size={20} />
-              )}
-              <span className="hidden sm:row">Sort</span>
-            </span>
-          </Button>
-          {/* <Menu
+      <Section className="w-full mb-2">
+        <div className="row w-full justify-between">
+          <div className="row">
+            <Button
+              onClick={() => {
+                if (showSearch) {
+                  setSearchInput('')
+                  setShowSearch(false)
+                } else {
+                  setShowSearch(true)
+                }
+              }}
+              outline
+            >
+              <span className="row gap-1">
+                <IconSearch stroke={1.5} size={16} />
+                Search
+              </span>
+            </Button>
+            <Button
+              onClick={() => {
+                setCurrentPage(0)
+                setGroupImages(!groupImages)
+              }}
+              outline
+              title="Group or ungroup images by batched image request"
+            >
+              <span className="row gap-1 justify-center md:w-[5.75em]">
+                {groupImages ? (
+                  <>
+                    <IconAffiliate />
+                    <span className="hidden sm:row">Ungroup</span>
+                  </>
+                ) : (
+                  <>
+                    <IconAffiliateFilled stroke={1.5} size={16} />
+                    <span className="hidden sm:row">Group</span>
+                  </>
+                )}
+              </span>
+            </Button>
+            <Button
+              onClick={() => setSortBy(sortBy === 'desc' ? 'asc' : 'desc')}
+              outline
+            >
+              <span className="row gap-1">
+                {sortBy === 'desc' ? (
+                  <IconSortDescending stroke={1.5} size={20} />
+                ) : (
+                  <IconSortAscending stroke={1.5} size={20} />
+                )}
+                <span className="hidden sm:row">Sort</span>
+              </span>
+            </Button>
+            {/* <Menu
             menuText={
               <span className="row">
                 <IconFilter stroke={1.5} size={20} />
@@ -138,27 +140,32 @@ export default function Gallery() {
             <MenuItem>Favorited</MenuItem>
             <MenuItem>Unfavorited</MenuItem>
           </Menu> */}
-          <Button onClick={() => {}} outline>
-            <span className="row gap-1">
-              <IconSettings stroke={1.5} size={20} />
-              <span className="hidden sm:row">
-                Settings
-                <IconChevronRight />
+            <Button onClick={() => {}} outline>
+              <span className="row gap-1">
+                <IconSettings stroke={1.5} size={20} />
+                <span className="hidden sm:row">
+                  Settings
+                  <IconChevronRight />
+                </span>
               </span>
-            </span>
-          </Button>
-        </div>
-        <div>
-          <Button onClick={() => {}} outline>
-            <span className="row gap-1">
-              <IconCircleCheck stroke={1.5} size={20} />
-              <span className="hidden sm:row">
-                Select
-                <IconChevronRight />
+            </Button>
+          </div>
+          <div>
+            <Button onClick={() => {}} outline>
+              <span className="row gap-1">
+                <IconCircleCheck stroke={1.5} size={20} />
+                <span className="hidden sm:row">
+                  Select
+                  <IconChevronRight />
+                </span>
               </span>
-            </span>
-          </Button>
+            </Button>
+          </div>
         </div>
+      </Section>
+      <div className="w-full font-mono text-xs mb-2">
+        Page {currentPage + 1} of {Math.ceil(totalImages / 20)} ({totalImages}{' '}
+        {groupImages ? 'image requests' : 'total images'})
       </div>
       {/* {showSearch && <ImageSearch setSearchInput={setSearchInput} />} */}
       {images.length > 0 && (

--- a/app/_components/ImageDetails.tsx
+++ b/app/_components/ImageDetails.tsx
@@ -2,7 +2,7 @@ import {
   HordeApiParams,
   ImageParamsForHordeApi
 } from '@/app/_data-models/ImageParamsForHordeApi'
-import { IconCodeDots, IconCopy } from '@tabler/icons-react'
+import { IconCaretRight, IconCodeDots, IconCopy } from '@tabler/icons-react'
 import { useEffect, useState } from 'react'
 import PromptInput from '../_data-models/PromptInput'
 import LoraDetails from './AdvancedOptions/LoRAs/LoraDetails'
@@ -10,6 +10,7 @@ import NiceModal from '@ebay/nice-modal-react'
 import { toastController } from '../_controllers/toastController'
 import { JobDetails } from '../_hooks/useImageDetails'
 import { ImageFileInterface } from '../_data-models/ImageFile_Dexie'
+import { JobStatus } from '../_types/ArtbotTypes'
 
 export default function ImageDetails({
   imageDetails
@@ -131,8 +132,9 @@ export default function ImageDetails({
               {imageRequest.width}px
             </div>
           </div>
-          {imageRequest.loras.length > 0 && (
+          {imageRequest?.loras?.length > 0 && (
             <div className="mt-4">
+              <div>[ LoRAs ]</div>
               {imageRequest.loras.map((lora) => {
                 return (
                   <div
@@ -182,6 +184,33 @@ export default function ImageDetails({
               })}
             </div>
           )}
+          {imageRequest?.workflows?.length > 0 && (
+            <div className="mt-4">
+              <div className="mb-1">[ Workflows ]</div>
+              {imageRequest.workflows.map((workflow, idx) => {
+                return (
+                  <div
+                    key={`${workflow.type}_${idx}`}
+                    style={{
+                      borderLeft: '2px solid #aabad4',
+                      marginLeft: '4px',
+                      paddingLeft: '8px'
+                    }}
+                  >
+                    <div className="row">
+                      <strong>Type: {workflow.type}</strong>
+                    </div>
+                    <div className="row">
+                      <strong>Text: {workflow.text}</strong>
+                    </div>
+                    <div className="row">
+                      <strong>Position: {workflow.position}</strong>
+                    </div>
+                  </div>
+                )
+              })}
+            </div>
+          )}
 
           <div className="mt-4">
             <strong>Karras: </strong>
@@ -199,24 +228,52 @@ export default function ImageDetails({
             <strong>Tiled: </strong>
             {imageRequest.tiling ? 'true' : 'false'}
           </div>
-          {imageFile.worker_id && (
+
+          {imageFile?.gen_metadata && imageFile?.gen_metadata?.length > 0 && (
             <div className="mt-4">
-              <strong>Worker ID: </strong>
-              {imageFile.worker_id}
+              <div className="mb-1">[ Generation Metadata ]</div>
+              {imageFile.gen_metadata.map((gen, idx) => {
+                return (
+                  <div
+                    key={`${gen}_${imageFile.image_id}_${idx}`}
+                    style={{
+                      borderLeft: '2px solid #aabad4',
+                      marginLeft: '4px',
+                      paddingLeft: '8px'
+                    }}
+                  >
+                    <div className="row">
+                      <strong>Type: {gen.type}</strong>
+                    </div>
+                    <div className="row">
+                      <strong>Ref: {gen.ref}</strong>
+                    </div>
+                  </div>
+                )
+              })}
             </div>
           )}
-          {imageFile.worker_name && (
-            <div>
-              <strong>Worker name: </strong>
-              {imageFile.worker_name}
-            </div>
-          )}
-          {jobDetails.horde_id && (
-            <div className="mt-4">
-              <strong>Horde Job ID: </strong>
-              {jobDetails.horde_id}
-            </div>
-          )}
+
+          <div className="col gap-1">
+            {imageFile.worker_name && (
+              <div className="mt-4">
+                <strong>Worker name: </strong>
+                <div>{imageFile.worker_name}</div>
+              </div>
+            )}
+            {imageFile.worker_id && (
+              <div>
+                <strong>Worker ID: </strong>
+                <div>{imageFile.worker_id}</div>
+              </div>
+            )}
+            {jobDetails.horde_id && (
+              <div>
+                <strong>Horde Job ID: </strong>
+                <div>{jobDetails.horde_id}</div>
+              </div>
+            )}
+          </div>
         </div>
       )}
       {display === 'request' && (
@@ -238,30 +295,47 @@ export default function ImageDetails({
           </pre>
         </div>
       )}
-      <button
-        className="cursor-pointer row text-[14px]"
-        tabIndex={0}
-        onClick={() => setDisplay('info')}
-      >
-        <IconCodeDots stroke={1.5} />
-        Image details
-      </button>
-      <button
-        className="cursor-pointer row text-[14px]"
-        tabIndex={0}
-        onClick={() => setDisplay('request')}
-      >
-        <IconCodeDots stroke={1.5} />
-        Request parameters
-      </button>
-      <button
-        className="cursor-pointer row text-[14px]"
-        tabIndex={0}
-        onClick={() => setDisplay('response')}
-      >
-        <IconCodeDots stroke={1.5} />
-        API response
-      </button>
+      <div className="col gap-1">
+        <div className="row gap-1 w-full">
+          <div className="w-[28px]">
+            {display === 'info' && <IconCaretRight />}
+          </div>
+          <button
+            className="cursor-pointer row text-[14px]"
+            tabIndex={0}
+            onClick={() => setDisplay('info')}
+          >
+            Image details
+          </button>
+        </div>
+
+        <div className="row gap-1 w-full">
+          <div className="w-[28px]">
+            {display === 'request' && <IconCaretRight />}
+          </div>
+          <button
+            className="cursor-pointer row text-[14px]"
+            tabIndex={0}
+            onClick={() => setDisplay('request')}
+          >
+            Request parameters
+          </button>
+        </div>
+        {jobDetails.status === JobStatus.Done && (
+          <div className="row gap-1 w-full">
+            <div className="w-[28px]">
+              {display === 'response' && <IconCaretRight />}
+            </div>
+            <button
+              className="cursor-pointer row text-[14px]"
+              tabIndex={0}
+              onClick={() => setDisplay('response')}
+            >
+              API response
+            </button>
+          </div>
+        )}
+      </div>
       <button
         className="cursor-pointer row text-[14px]"
         tabIndex={0}

--- a/app/_components/ImageDetails.tsx
+++ b/app/_components/ImageDetails.tsx
@@ -2,7 +2,7 @@ import {
   HordeApiParams,
   ImageParamsForHordeApi
 } from '@/app/_data-models/ImageParamsForHordeApi'
-import { IconCaretRight, IconCodeDots, IconCopy } from '@tabler/icons-react'
+import { IconCaretRight, IconCopy } from '@tabler/icons-react'
 import { useEffect, useState } from 'react'
 import PromptInput from '../_data-models/PromptInput'
 import LoraDetails from './AdvancedOptions/LoRAs/LoraDetails'

--- a/app/_components/StyleTags/index.tsx
+++ b/app/_components/StyleTags/index.tsx
@@ -106,7 +106,7 @@ export default function StyleTags({ input, setInput }: StyleTagsProps) {
   return (
     <>
       <div className="col w-full h-full">
-        <h2 className="row font-bold">Styles</h2>
+        <h2 className="row font-bold">Tags</h2>
         <div className="row w-full mb-2">
           <input
             className="bg-gray-50 border border-gray-300 text-gray-900 text-[16px] rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-full p-2 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white dark:focus:ring-blue-500 dark:focus:border-blue-500"

--- a/app/_data-models/ImageFile_Dexie.ts
+++ b/app/_data-models/ImageFile_Dexie.ts
@@ -26,7 +26,7 @@ export interface ImageFileInterface {
   sampler?: string
   model?: string
   imageBlob?: Blob | null
-  gen_metadata?: GenMetadata
+  gen_metadata?: GenMetadata[]
   strength?: number | null // Used when adding multiple images (e.g., remix)
   seed?: string
   worker_id?: string
@@ -46,7 +46,7 @@ class ImageFile implements ImageFileInterface {
 
   // Other fields
   imageBlob?: Blob | null = null
-  gen_metadata?: GenMetadata
+  gen_metadata?: GenMetadata[] = []
   seed: string = ''
   strength: number | null = null
   worker_id: string = ''

--- a/app/_data-models/ImageParamsForHordeApi.ts
+++ b/app/_data-models/ImageParamsForHordeApi.ts
@@ -343,7 +343,11 @@ class ImageParamsForHordeApi implements HordeApiParamsBuilderInterface {
   }
 
   setWorkflows(): ImageParamsForHordeApi {
-    if (this.imageDetails.workflows.length === 0) return this
+    if (
+      !this.imageDetails?.workflows ||
+      this.imageDetails?.workflows?.length === 0
+    )
+      return this
     const { workflows } = this.imageDetails
 
     // Filter through workflows array and find element that contains type === 'qr_code`

--- a/app/_data-models/ImageParamsForHordeApi.ts
+++ b/app/_data-models/ImageParamsForHordeApi.ts
@@ -342,6 +342,56 @@ class ImageParamsForHordeApi implements HordeApiParamsBuilderInterface {
     return this
   }
 
+  setWorkflows(): ImageParamsForHordeApi {
+    if (this.imageDetails.workflows.length === 0) return this
+    const { workflows } = this.imageDetails
+
+    // Filter through workflows array and find element that contains type === 'qr_code`
+    const qrCode = workflows.find((w) => w.type === 'qr_code')
+
+    if (qrCode) {
+      if (!this.apiParams.params.extra_texts) {
+        this.apiParams.params.extra_texts = []
+      }
+
+      this.apiParams.params.workflow = 'qr_code'
+      this.apiParams.params.extra_texts?.push({
+        text: qrCode.text,
+        reference: 'qr_code'
+      })
+
+      if (qrCode.position === 'center') {
+        return this
+      }
+
+      // Default setting for Top Left
+      let x_offset = 32
+      let y_offset = 32
+
+      if (qrCode.position === 'top right') {
+        x_offset = this.imageDetails.width - 32
+      } else if (qrCode.position === 'bottom left') {
+        x_offset = 32
+        y_offset = this.imageDetails.height - 32
+      } else if (qrCode.position === 'bottom right') {
+        x_offset = this.imageDetails.width - 32
+        y_offset = this.imageDetails.height - 32
+      }
+
+      this.apiParams.params.extra_texts?.push({
+        text: String(x_offset),
+        reference: 'x_offset'
+      })
+
+      this.apiParams.params.extra_texts?.push({
+        text: String(y_offset),
+        reference: 'y_offset'
+      })
+    }
+
+    return this
+  }
+
   setStylePresets(): ImageParamsForHordeApi {
     if (this.imageDetails.preset.length === 0) return this
 
@@ -392,6 +442,7 @@ class ImageParamsForHordeApi implements HordeApiParamsBuilderInterface {
     instance.setWorkerPreferences()
     await instance.setSourceProcessing()
     instance.setControlType()
+    instance.setWorkflows()
     instance.setStylePresets()
     instance.setErrorHandling(hasError)
     instance.validate()

--- a/app/_data-models/PromptInput.test.ts
+++ b/app/_data-models/PromptInput.test.ts
@@ -39,7 +39,7 @@ describe('PromptInput', () => {
     expect(defaultPromptInput.triggers).toEqual([])
     expect(defaultPromptInput.upscaled).toBe(false)
     expect(defaultPromptInput.width).toBe(1024)
-    expect(defaultPromptInput.workflow).toBe(undefined)
+    expect(defaultPromptInput.workflows).toEqual([])
   })
 
   it('should initialize with partial values', () => {

--- a/app/_data-models/PromptInput.ts
+++ b/app/_data-models/PromptInput.ts
@@ -1,7 +1,8 @@
 import {
   AiHordeEmbedding,
   ImageOrientations,
-  JobType
+  JobType,
+  Workflow
 } from '@/app/_types/ArtbotTypes'
 import {
   ControlTypes,
@@ -60,7 +61,7 @@ class PromptInput {
   triggers: Array<string> = []
   upscaled: boolean = false
   width: number = 1024
-  workflow?: 'qr_code' | ''
+  workflows: Workflow[] = []
 
   constructor(params: Partial<PromptInput> = {}) {
     Object.assign(this, params)

--- a/app/_types/ArtbotTypes.ts
+++ b/app/_types/ArtbotTypes.ts
@@ -112,3 +112,16 @@ export interface PromptsJobMap {
   artbot_id: string
   prompt_id: number
 }
+
+export interface Workflow {
+  type: 'qr_code' | ''
+  position: WorkflowPosition
+  text: string
+}
+
+export type WorkflowPosition =
+  | 'center'
+  | 'top left'
+  | 'top right'
+  | 'bottom left'
+  | 'bottom right'

--- a/app/_types/HordeTypes.ts
+++ b/app/_types/HordeTypes.ts
@@ -172,7 +172,7 @@ export interface TextualInversion {
 export interface LoraConfig {
   name: string
   model?: number
-  clip?: number
+  clip_skip?: number
   is_version: boolean
 }
 

--- a/app/_types/HordeTypes.ts
+++ b/app/_types/HordeTypes.ts
@@ -193,3 +193,13 @@ export interface StylePresetConfig {
 export interface StylePresetConfigurations {
   [key: string]: StylePresetConfig
 }
+
+export interface StylePreview {
+  person: string
+  place: string
+  thing: string
+}
+
+export interface StylePreviewConfigurations {
+  [key: string]: StylePreview
+}

--- a/app/create/_component/PromptInputForm.tsx
+++ b/app/create/_component/PromptInputForm.tsx
@@ -158,10 +158,7 @@ export default function PromptInputForm() {
               onClick={() => {
                 NiceModal.show('modal', {
                   children: <StyleTagsWrapper />,
-                  modalStyle: {
-                    maxWidth: '1600px',
-                    width: 'calc(100% - 32px)'
-                  }
+                  modalClassName: 'w-full md:min-w-[640px] max-w-[648px]'
                 })
               }}
               title="Suggested tags to help add additional styles to an image"
@@ -170,21 +167,6 @@ export default function PromptInputForm() {
                 <IconTags stroke={1.5} /> <span>Tags</span>
               </span>
             </Button>
-            {/*
-            // TODO: Move styles into advanced options area?
-            */}
-            {/* <ReactiveButton
-              idleText={
-                <span className="row gap-1">
-                  <IconCamera stroke={1.5} /> <span>Styles</span>
-                </span>
-              }
-              size="small"
-              style={{
-                borderRadius: '4px',
-                padding: '0 6px'
-              }}
-            /> */}
           </div>
           <div className="row">
             <Button


### PR DESCRIPTION
Fixes:

- Typo in title of tags modal
- `clip_skip` not applied correctly when using style preset
- Style presets had links to "categories" that ended up being unclickable (e.g., "Summer" included "Summer 2022" and "Summer 2023". I now check if a key exists in the "presets" payload. If not, filter it out.
- Pull correct style preview URLs from GitHub

Enhancements:

- Enables QR Code workflow on ArtBot v2
- Image gallery toolbar improvements
- Show gen_metadata in Image Info panel on image view modal
- Add setting to view raw API response data for an image