### PR TITLE
Initial work on model details page

### DIFF
--- a/app/_api/models/index.tsx
+++ b/app/_api/models/index.tsx
@@ -1,0 +1,59 @@
+import { clientHeader } from '@/app/_data-models/ClientHeader'
+import { AvailableImageModel } from '@/app/_types/HordeTypes'
+
+export async function getModelsData() {
+  try {
+    const availableUrl = `https://aihorde.net/api/v2/status/models`
+    const detailsUrl = `https://raw.githubusercontent.com/Haidra-Org/AI-Horde-image-model-reference/main/stable_diffusion.json`
+
+    const [availableRes, detailsRes] = await Promise.allSettled([
+      fetch(availableUrl, {
+        headers: {
+          'Client-Agent': clientHeader(),
+          'Content-Type': 'application/json'
+        },
+        next: { revalidate: 120 } // Revalidate every 120 seconds
+      }),
+      fetch(detailsUrl, {
+        cache: 'no-store',
+        headers: {
+          'Content-Type': 'application/json'
+        },
+        method: 'GET'
+      })
+    ])
+
+    const availableData =
+      availableRes.status === 'fulfilled' ? await availableRes.value.json() : []
+    const detailsData =
+      detailsRes.status === 'fulfilled' ? await detailsRes.value.json() : {}
+
+    const availableFiltered = availableData
+      .filter((model: AvailableImageModel) => model.type === 'image')
+      .sort(
+        (a: AvailableImageModel, b: AvailableImageModel) => b.count - a.count
+      )
+
+    // Parse json to ensure validity
+    const jsonString = JSON.stringify(detailsData)
+    const json = JSON.parse(jsonString)
+
+    // Optional: Additional checks to ensure the JSON structure is as expected
+    if (!json || typeof json !== 'object' || Object.keys(json).length === 0) {
+      return {
+        modelsAvailable: [],
+        modelDetails: {}
+      }
+    }
+
+    return {
+      modelsAvailable: availableFiltered,
+      modelDetails: detailsData
+    }
+  } catch (error) {
+    return {
+      modelsAvailable: [],
+      modelDetails: {}
+    }
+  }
+}

--- a/app/_components/AppInit/AppInitComponent.tsx
+++ b/app/_components/AppInit/AppInitComponent.tsx
@@ -13,13 +13,15 @@ import {
   initJobController,
   loadPendingImagesFromDexie
 } from '../../_controllers/pendingJobController'
-import { ImageModelDetails } from '@/app/_types/HordeTypes'
+import { AvailableImageModel, ImageModelDetails } from '@/app/_types/HordeTypes'
 import { useEffect } from 'react'
-import { setImageModels } from '@/app/_stores/ModelStore'
+import { setAvailableModels, setImageModels } from '@/app/_stores/ModelStore'
 
 export default function AppInitComponent({
+  modelsAvailable,
   modelDetails
 }: {
+  modelsAvailable: AvailableImageModel[]
   modelDetails: { [key: string]: ImageModelDetails }
 }) {
   const [handleLogin] = useHordeApiKey()
@@ -33,8 +35,9 @@ export default function AppInitComponent({
   }
 
   useEffect(() => {
+    setAvailableModels(modelsAvailable)
     setImageModels(modelDetails)
-  }, [modelDetails])
+  }, [modelDetails, modelsAvailable])
 
   useEffectOnce(() => {
     console.log(`ArtBot v2.0.0_beta is online: ${new Date().toLocaleString()}`)

--- a/app/_components/AppInit/index.tsx
+++ b/app/_components/AppInit/index.tsx
@@ -1,66 +1,8 @@
-import { clientHeader } from '@/app/_data-models/ClientHeader'
+import { getModelsData } from '@/app/_api/models'
 import AppInitComponent from './AppInitComponent'
-import { AvailableImageModel } from '@/app/_types/HordeTypes'
-
-export async function getData() {
-  try {
-    const availableUrl = `https://aihorde.net/api/v2/status/models`
-    const detailsUrl = `https://raw.githubusercontent.com/Haidra-Org/AI-Horde-image-model-reference/main/stable_diffusion.json`
-
-    const [availableRes, detailsRes] = await Promise.allSettled([
-      fetch(availableUrl, {
-        headers: {
-          'Client-Agent': clientHeader(),
-          'Content-Type': 'application/json'
-        },
-        next: { revalidate: 120 } // Revalidate every 120 seconds
-      }),
-      fetch(detailsUrl, {
-        cache: 'no-store',
-        headers: {
-          'Content-Type': 'application/json'
-        },
-        method: 'GET'
-      })
-    ])
-
-    const availableData =
-      availableRes.status === 'fulfilled' ? await availableRes.value.json() : []
-    const detailsData =
-      detailsRes.status === 'fulfilled' ? await detailsRes.value.json() : {}
-
-    const availableFiltered = availableData
-      .filter((model: AvailableImageModel) => model.type === 'image')
-      .sort(
-        (a: AvailableImageModel, b: AvailableImageModel) => b.count - a.count
-      )
-
-    // Parse json to ensure validity
-    const jsonString = JSON.stringify(detailsData)
-    const json = JSON.parse(jsonString)
-
-    // Optional: Additional checks to ensure the JSON structure is as expected
-    if (!json || typeof json !== 'object' || Object.keys(json).length === 0) {
-      return {
-        modelsAvailable: [],
-        modelDetails: {}
-      }
-    }
-
-    return {
-      modelsAvailable: availableFiltered,
-      modelDetails: detailsData
-    }
-  } catch (error) {
-    return {
-      modelsAvailable: [],
-      modelDetails: {}
-    }
-  }
-}
 
 export default async function AppInit() {
-  const { modelsAvailable, modelDetails } = await getData()
+  const { modelsAvailable, modelDetails } = await getModelsData()
   return (
     <AppInitComponent
       modelsAvailable={modelsAvailable}

--- a/app/_components/AppInit/index.tsx
+++ b/app/_components/AppInit/index.tsx
@@ -1,42 +1,70 @@
+import { clientHeader } from '@/app/_data-models/ClientHeader'
 import AppInitComponent from './AppInitComponent'
+import { AvailableImageModel } from '@/app/_types/HordeTypes'
 
 export async function getData() {
   try {
-    const res = await fetch(
-      `https://raw.githubusercontent.com/Haidra-Org/AI-Horde-image-model-reference/main/stable_diffusion.json`,
-      {
+    const availableUrl = `https://aihorde.net/api/v2/status/models`
+    const detailsUrl = `https://raw.githubusercontent.com/Haidra-Org/AI-Horde-image-model-reference/main/stable_diffusion.json`
+
+    const [availableRes, detailsRes] = await Promise.allSettled([
+      fetch(availableUrl, {
+        headers: {
+          'Client-Agent': clientHeader(),
+          'Content-Type': 'application/json'
+        },
+        next: { revalidate: 120 } // Revalidate every 120 seconds
+      }),
+      fetch(detailsUrl, {
         cache: 'no-store',
         headers: {
           'Content-Type': 'application/json'
         },
         method: 'GET'
-      }
-    )
+      })
+    ])
 
-    const data = await res.json()
+    const availableData =
+      availableRes.status === 'fulfilled' ? await availableRes.value.json() : []
+    const detailsData =
+      detailsRes.status === 'fulfilled' ? await detailsRes.value.json() : {}
+
+    const availableFiltered = availableData
+      .filter((model: AvailableImageModel) => model.type === 'image')
+      .sort(
+        (a: AvailableImageModel, b: AvailableImageModel) => b.count - a.count
+      )
 
     // Parse json to ensure validity
-    const jsonString = JSON.stringify(data)
+    const jsonString = JSON.stringify(detailsData)
     const json = JSON.parse(jsonString)
 
     // Optional: Additional checks to ensure the JSON structure is as expected
     if (!json || typeof json !== 'object' || Object.keys(json).length === 0) {
       return {
+        modelsAvailable: [],
         modelDetails: {}
       }
     }
 
     return {
-      modelDetails: data
+      modelsAvailable: availableFiltered,
+      modelDetails: detailsData
     }
   } catch (error) {
     return {
+      modelsAvailable: [],
       modelDetails: {}
     }
   }
 }
 
 export default async function AppInit() {
-  const { modelDetails } = await getData()
-  return <AppInitComponent modelDetails={modelDetails} />
+  const { modelsAvailable, modelDetails } = await getData()
+  return (
+    <AppInitComponent
+      modelsAvailable={modelsAvailable}
+      modelDetails={modelDetails}
+    />
+  )
 }

--- a/app/_components/PendingImagesPanel/index.tsx
+++ b/app/_components/PendingImagesPanel/index.tsx
@@ -49,6 +49,7 @@ export default function PendingImagesPanel({
   const topDivRef = useRef(null)
   const scrollableDivRef = useRef(null)
   const [topOffset, setTopOffset] = useState(178)
+  const [minHeight, setMinHeight] = useState('100vh')
 
   const { pendingImages } = useStore(PendingImagesStore)
   const [images, setImages] = useState<PhotoData[]>([])
@@ -122,6 +123,20 @@ export default function PendingImagesPanel({
     })
   }, [sortBy])
 
+  useEffect(() => {
+    const updateMinHeight = () => {
+      if (typeof window !== 'undefined') {
+        setMinHeight(`${window.innerHeight - 92}px`)
+      }
+    }
+
+    updateMinHeight()
+
+    window.addEventListener('resize', updateMinHeight)
+
+    return () => window.removeEventListener('resize', updateMinHeight)
+  }, [])
+
   const updateTopOffset = () => {
     if (topDivRef.current) {
       // @ts-expect-error Au contraire, it does!
@@ -164,10 +179,7 @@ export default function PendingImagesPanel({
       style={{
         border: showBorder ? '1px solid #7e5a6c' : 'none',
         padding: showBorder ? '0.5rem' : '0',
-        minHeight:
-          typeof window !== 'undefined'
-            ? `${window.innerHeight - 92}px`
-            : 'auto'
+        minHeight
       }}
     >
       {showTitle && (

--- a/app/_components/Section.tsx
+++ b/app/_components/Section.tsx
@@ -27,13 +27,16 @@ export default function Section({
             backgroundColor: 'gray',
             borderTopLeftRadius: '0.375rem',
             borderBottomLeftRadius: '0.375rem',
+            position: 'absolute',
+            top: 0,
+            bottom: 0,
             height: '100%',
             width: '8px'
           }}
           href={`#${anchor}`}
         ></a>
       )}
-      <div className="col px-2 py-2 gap-2 w-full">
+      <div className={clsx('col px-2 py-2 gap-2 w-full', anchor ? 'pl-5' : '')}>
         {title && <h2 className="row font-bold text-white">{title}</h2>}
         {children}
       </div>

--- a/app/_components/Section.tsx
+++ b/app/_components/Section.tsx
@@ -33,7 +33,7 @@ export default function Section({
           href={`#${anchor}`}
         ></a>
       )}
-      <div className="col px-2 py-3 gap-2 w-full">
+      <div className="col px-2 py-2 gap-2 w-full">
         {title && <h2 className="row font-bold text-white">{title}</h2>}
         {children}
       </div>

--- a/app/_providers/PromptInputProvider.tsx
+++ b/app/_providers/PromptInputProvider.tsx
@@ -170,6 +170,14 @@ export const PromptInputProvider: React.FC<PromptProviderProps> = ({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
 
+  useEffect(() => {
+    const params = new URLSearchParams(window.location.search)
+    const model = params.get('model')
+    if (model) {
+      setInput({ models: [model] })
+    }
+  }, [])
+
   return (
     <InputContext.Provider
       value={{

--- a/app/_providers/PromptInputProvider.tsx
+++ b/app/_providers/PromptInputProvider.tsx
@@ -115,8 +115,18 @@ export const PromptInputProvider: React.FC<PromptProviderProps> = ({
     const jsonString = JSON.stringify(updatedInputState)
     debouncedUpdate(jsonString)
 
-    // Call kudos API
-    debouncedFetchUpdatedKudos(updatedInputState)
+    // Only call kudos API if there are significant changes
+    // TODO: Handle weighted prompts or prompt matrix
+    // Other things like model, etc
+    if (
+      !(
+        Object.keys(newState).length === 1 &&
+        (newState.prompt || newState.negative)
+      )
+    ) {
+      // Call kudos API
+      debouncedFetchUpdatedKudos(updatedInputState)
+    }
 
     return updatedInputState
   }

--- a/app/_stores/ModelStore.ts
+++ b/app/_stores/ModelStore.ts
@@ -1,15 +1,21 @@
 import { makeStore } from 'statery'
-import { ImageModelDetails } from '../_types/HordeTypes'
+import { AvailableImageModel, ImageModelDetails } from '../_types/HordeTypes'
 
 interface ModelStoreInterface {
+  availableModels: AvailableImageModel[]
   modelDetails: {
     [key: string]: ImageModelDetails
   }
 }
 
 export const ModelStore = makeStore<ModelStoreInterface>({
+  availableModels: [],
   modelDetails: {}
 })
+
+export const setAvailableModels = (models: AvailableImageModel[]) => {
+  ModelStore.set(() => ({ availableModels: models }))
+}
 
 export const setImageModels = (modelDetails: {
   [key: string]: ImageModelDetails

--- a/app/_types/HordeTypes.ts
+++ b/app/_types/HordeTypes.ts
@@ -115,6 +115,7 @@ export interface ImageModelDetails {
   version: string
   style: string
   nsfw: boolean
+  homepage: string
   download_all: boolean
   config: {
     files: {

--- a/app/_utils/numberUtils.ts
+++ b/app/_utils/numberUtils.ts
@@ -48,6 +48,18 @@ export const calculateTimeDifference = ({
   }
 }
 
+export const formatSeconds = (seconds: number): string => {
+  const hours = Math.floor(seconds / 3600)
+  const minutes = Math.floor((seconds % 3600) / 60)
+  const secs = seconds % 60
+
+  const hoursStr = hours > 0 ? `${hours}h ` : ''
+  const minutesStr = minutes > 0 ? `${minutes}m ` : ''
+  const secondsStr = `${secs}s`
+
+  return `${hoursStr}${minutesStr}${secondsStr}`.trim()
+}
+
 export const formatTimestamp = (timestamp: number): string => {
   const date = new Date(timestamp)
 

--- a/app/info/models/_component/ModelsInfo.tsx
+++ b/app/info/models/_component/ModelsInfo.tsx
@@ -3,9 +3,11 @@
 import {
   IconArrowBarLeft,
   IconCube,
+  IconDownload,
   IconExternalLink,
   IconFilter,
   IconHeart,
+  IconPhotoSearch,
   IconSortDescending
 } from '@tabler/icons-react'
 import Link from 'next/link'
@@ -210,6 +212,16 @@ export default function ModelsInfo({
                 <div className="row justify-end">
                   <Button
                     onClick={() => {
+                      router.push(`/images?model=${key}`)
+                    }}
+                  >
+                    <div className="row gap-2">
+                      <IconPhotoSearch />
+                      Find images
+                    </div>
+                  </Button>
+                  <Button
+                    onClick={() => {
                       if (!onUseModel) {
                         router.push(`/create?model=${key}`)
                       }
@@ -219,7 +231,10 @@ export default function ModelsInfo({
                       }
                     }}
                   >
-                    Use Model
+                    <div className="row gap-2">
+                      <IconDownload />
+                      Use Model
+                    </div>
                   </Button>
                 </div>
               </div>

--- a/app/info/models/_component/ModelsInfo.tsx
+++ b/app/info/models/_component/ModelsInfo.tsx
@@ -1,0 +1,154 @@
+/* eslint-disable @next/next/no-img-element */
+'use client'
+import { IconCube, IconExternalLink, IconHeart } from '@tabler/icons-react'
+import Link from 'next/link'
+
+import Button from '@/app/_components/Button'
+import Section from '@/app/_components/Section'
+import { AvailableImageModel, ImageModelDetails } from '@/app/_types/HordeTypes'
+import { formatSeconds } from '@/app/_utils/numberUtils'
+
+export default function ModelsInfo({
+  modelsAvailable,
+  modelDetails
+}: {
+  modelsAvailable: AvailableImageModel[]
+  modelDetails: { [key: string]: ImageModelDetails }
+}) {
+  const availableModelsMap = modelsAvailable.reduce(
+    (acc, item) => {
+      acc[item.name] = item
+      return acc
+    },
+    {} as { [key: string]: AvailableImageModel }
+
+    // TODO: Handle sort
+  )
+  console.log(`availableModelsMap`, availableModelsMap)
+  console.log(`modelDetails`, modelDetails)
+
+  const getQueueTime = (s: number) => {
+    if (s === 0) {
+      return 'N/A'
+    }
+
+    if (s === 10000) {
+      return 'N/A'
+    }
+
+    return `~ ${formatSeconds(s)}`
+  }
+
+  return (
+    <div className="col">
+      <div className="col w-full gap-4">
+        {Object.keys(modelDetails).map((key) => (
+          <Section key={key} anchor={key} className="text-white">
+            <h2 className="row font-bold text-white gap-1 text-lg">{key}</h2>
+            <div className="row w-full gap-2">
+              <Button
+                style={{
+                  height: '36px',
+                  width: '36px'
+                }}
+              >
+                <IconHeart />
+              </Button>
+              <div className="row gap-1 bg-gray-600 px-2 h-[36px] rounded-md text-sm">
+                <IconCube /> {modelDetails[key].baseline}
+              </div>
+              <div>Version: {modelDetails[key].version}</div>
+            </div>
+            <div className="row w-full items-start gap-4">
+              <div
+                style={{
+                  backgroundColor: 'gray',
+                  borderRadius: '8px',
+                  height: '400px',
+                  width: '400px'
+                }}
+              >
+                {modelDetails[key]?.showcases &&
+                  modelDetails[key]?.showcases[0] && (
+                    <img
+                      src={modelDetails[key].showcases[0]}
+                      className="w-full h-full object-cover rounded-md"
+                      alt="Model showcase"
+                    />
+                  )}
+              </div>
+              <div
+                className="col justify-between h-full"
+                style={{
+                  minHeight: '400px',
+                  width: `calc(100% - 400px)`
+                }}
+              >
+                <div className="col">
+                  {modelDetails[key].description}
+                  <div className="col gap-0 text-sm">
+                    <div>
+                      <strong>NSFW:</strong>{' '}
+                      {modelDetails[key].nsfw ? 'true' : 'false'}
+                    </div>
+                    <div>
+                      <strong>Style:</strong> {modelDetails[key].style}
+                    </div>
+                  </div>
+                  {modelDetails[key].homepage && (
+                    <div>
+                      <Link
+                        href={modelDetails[key].homepage}
+                        target="_blank"
+                        className="text-[#1E293B] underline"
+                      >
+                        <div className="row gap-1 text-sm font-mono">
+                          View homepage <IconExternalLink size={18} />
+                        </div>
+                      </Link>
+                    </div>
+                  )}
+                  <div className="bg-[#1E293B] text-white font-mono p-2 w-full text-[14px] col gap-0">
+                    <strong>AI Horde Availability</strong>
+                    <div className="mt-2">
+                      <strong>GPU workers:</strong>{' '}
+                      {availableModelsMap[key].count}
+                    </div>
+                    <div>
+                      <strong>Queued jobs:</strong>{' '}
+                      {availableModelsMap[key].jobs}
+                    </div>
+                    <div className="mt-2">
+                      <strong>Queued work:</strong>{' '}
+                      {availableModelsMap[key].queued.toLocaleString()}{' '}
+                      megapixel-steps
+                    </div>
+                    <div>
+                      <strong>Performance:</strong>{' '}
+                      {availableModelsMap[key].performance.toLocaleString()}{' '}
+                      megapixel-steps / minute
+                    </div>
+
+                    <div className="mt-2">
+                      <strong>Wait time:</strong>{' '}
+                      {getQueueTime(availableModelsMap[key].eta)}
+                    </div>
+                  </div>
+                </div>
+                <div className="row justify-end">
+                  <Button
+                    onClick={() => {
+                      // handleOnUseModel(key)
+                    }}
+                  >
+                    Use Model
+                  </Button>
+                </div>
+              </div>
+            </div>
+          </Section>
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/app/info/models/_component/ModelsInfo.tsx
+++ b/app/info/models/_component/ModelsInfo.tsx
@@ -54,12 +54,18 @@ export default function ModelsInfo({
 
   const filteredModels = Object.keys(modelDetails).reduce(
     (acc, key) => {
-      const userInput = searchInput.toLocaleLowerCase()
       const nsfw = modelDetails[key].nsfw
+      const sdxl = modelDetails[key].baseline === 'stable_diffusion_xl'
+      const userInput = searchInput.toLocaleLowerCase()
 
-      if (userInput === 'nsfw' && nsfw) {
+      if (userInput === 'sdxl' && sdxl) {
         acc[key] = modelDetails[key]
-      } else if (key.toLocaleLowerCase().includes(userInput)) {
+      } else if (userInput === 'nsfw' && nsfw) {
+        acc[key] = modelDetails[key]
+      } else if (
+        key.toLocaleLowerCase().includes(userInput) ||
+        modelDetails[key].style.includes(userInput)
+      ) {
         acc[key] = modelDetails[key]
       }
       return acc
@@ -72,6 +78,9 @@ export default function ModelsInfo({
       <div className="col w-full gap-4">
         <div className="col gap-2">
           <div className="row w-full">
+            <Button onClick={() => {}}>
+              <IconHeart />
+            </Button>
             <input
               className="bg-gray-50 border border-gray-300 text-gray-900 text-[16px] rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-full p-2 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white dark:focus:ring-blue-500 dark:focus:border-blue-500"
               placeholder={'Search for image model'}
@@ -101,7 +110,7 @@ export default function ModelsInfo({
             </Button>
           </div>
           <div className="w-full font-mono text-xs mb-2">
-            Showing {Object.keys(filteredModels).length} model
+            Filter: showing {Object.keys(filteredModels).length} model
             {Object.keys(filteredModels).length !== 1 ? 's' : ''}
           </div>
         </div>

--- a/app/info/models/_component/ModelsInfo.tsx
+++ b/app/info/models/_component/ModelsInfo.tsx
@@ -1,6 +1,13 @@
 /* eslint-disable @next/next/no-img-element */
 'use client'
-import { IconCube, IconExternalLink, IconHeart } from '@tabler/icons-react'
+import {
+  IconArrowBarLeft,
+  IconCube,
+  IconExternalLink,
+  IconFilter,
+  IconHeart,
+  IconSortDescending
+} from '@tabler/icons-react'
 import Link from 'next/link'
 
 import Button from '@/app/_components/Button'
@@ -8,6 +15,7 @@ import Section from '@/app/_components/Section'
 import { AvailableImageModel, ImageModelDetails } from '@/app/_types/HordeTypes'
 import { formatSeconds } from '@/app/_utils/numberUtils'
 import { useRouter } from 'next/navigation'
+import { useState } from 'react'
 
 export default function ModelsInfo({
   modelsAvailable,
@@ -19,6 +27,7 @@ export default function ModelsInfo({
   onUseModel?: (model: string) => void
 }) {
   const router = useRouter()
+  const [searchInput, setSearchInput] = useState('')
   const availableModelsMap = modelsAvailable.reduce(
     (acc, item) => {
       acc[item.name] = item
@@ -43,10 +52,60 @@ export default function ModelsInfo({
     return `~ ${formatSeconds(s)}`
   }
 
+  const filteredModels = Object.keys(modelDetails).reduce(
+    (acc, key) => {
+      const userInput = searchInput.toLocaleLowerCase()
+      const nsfw = modelDetails[key].nsfw
+
+      if (userInput === 'nsfw' && nsfw) {
+        acc[key] = modelDetails[key]
+      } else if (key.toLocaleLowerCase().includes(userInput)) {
+        acc[key] = modelDetails[key]
+      }
+      return acc
+    },
+    {} as { [key: string]: ImageModelDetails }
+  )
+
   return (
     <div className="col">
       <div className="col w-full gap-4">
-        {Object.keys(modelDetails).map((key) => (
+        <div className="col gap-2">
+          <div className="row w-full">
+            <input
+              className="bg-gray-50 border border-gray-300 text-gray-900 text-[16px] rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-full p-2 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white dark:focus:ring-blue-500 dark:focus:border-blue-500"
+              placeholder={'Search for image model'}
+              onChange={(e) => {
+                setSearchInput(e.target.value)
+              }}
+              value={searchInput}
+            />
+            <Button
+              theme="danger"
+              onClick={() => {
+                setSearchInput('')
+              }}
+            >
+              <IconArrowBarLeft />
+            </Button>
+            <Button>
+              <IconSortDescending />
+            </Button>
+            <Button
+              // outline={!showFilter}
+              onClick={() => {
+                // setShowFilter(!showFilter)
+              }}
+            >
+              <IconFilter />
+            </Button>
+          </div>
+          <div className="w-full font-mono text-xs mb-2">
+            Showing {Object.keys(filteredModels).length} model
+            {Object.keys(filteredModels).length !== 1 ? 's' : ''}
+          </div>
+        </div>
+        {Object.keys(filteredModels).map((key) => (
           <Section key={key} anchor={key} className="text-white">
             <h2 className="row font-bold text-white gap-1 text-lg">{key}</h2>
             <div className="row w-full gap-2">

--- a/app/info/models/_component/ModelsInfo.tsx
+++ b/app/info/models/_component/ModelsInfo.tsx
@@ -7,14 +7,18 @@ import Button from '@/app/_components/Button'
 import Section from '@/app/_components/Section'
 import { AvailableImageModel, ImageModelDetails } from '@/app/_types/HordeTypes'
 import { formatSeconds } from '@/app/_utils/numberUtils'
+import { useRouter } from 'next/navigation'
 
 export default function ModelsInfo({
   modelsAvailable,
-  modelDetails
+  modelDetails,
+  onUseModel
 }: {
   modelsAvailable: AvailableImageModel[]
   modelDetails: { [key: string]: ImageModelDetails }
+  onUseModel?: (model: string) => void
 }) {
+  const router = useRouter()
   const availableModelsMap = modelsAvailable.reduce(
     (acc, item) => {
       acc[item.name] = item
@@ -138,7 +142,13 @@ export default function ModelsInfo({
                 <div className="row justify-end">
                   <Button
                     onClick={() => {
-                      // handleOnUseModel(key)
+                      if (!onUseModel) {
+                        router.push(`/create?model=${key}`)
+                      }
+
+                      if (onUseModel) {
+                        onUseModel(key)
+                      }
                     }}
                   >
                     Use Model

--- a/app/info/models/page.tsx
+++ b/app/info/models/page.tsx
@@ -1,0 +1,67 @@
+'use client'
+
+import Button from '@/app/_components/Button'
+import PageTitle from '@/app/_components/PageTitle'
+import { ModelStore } from '@/app/_stores/ModelStore'
+import { AvailableImageModel } from '@/app/_types/HordeTypes'
+import { IconCube, IconExternalLink, IconHeart } from '@tabler/icons-react'
+import Link from 'next/link'
+import { useStore } from 'statery'
+
+export default function ModelsPage() {
+  const { availableModels, modelDetails } = useStore(ModelStore)
+  const availableModelsMap = availableModels.reduce(
+    (acc, item) => {
+      acc[item.name] = item
+      return acc
+    },
+    {} as { [key: string]: AvailableImageModel }
+
+    // TODO: Handle sort
+  )
+  console.log(`availableModelsMap`, availableModelsMap)
+  console.log(`modelDetails`, modelDetails)
+
+  return (
+    <div className="col">
+      <PageTitle>Model Details</PageTitle>
+      <div className="col w-full">
+        {Object.keys(modelDetails).map((key) => (
+          <div
+            key={key}
+            className="col text-white p-2 flex gap-2 rounded-md bg-[#c1c1c1] dark:bg-zinc-700"
+          >
+            <h3 className="row font-bold text-white gap-1">{key}</h3>
+            <div className="row w-full gap-2">
+              <Button
+                style={{
+                  height: '36px',
+                  width: '36px'
+                }}
+              >
+                <IconHeart />
+              </Button>
+              <div className="row gap-1 bg-gray-600 px-2 h-[36px] rounded-md">
+                <IconCube /> {modelDetails[key].baseline}
+              </div>
+              <div>Version: {modelDetails[key].version}</div>
+            </div>
+            {modelDetails[key].homepage && (
+              <div>
+                <Link
+                  href={modelDetails[key].homepage}
+                  target="_blank"
+                  className="primary-color"
+                >
+                  <div className="row gap-1">
+                    Homepage <IconExternalLink />
+                  </div>
+                </Link>
+              </div>
+            )}
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/app/info/models/page.tsx
+++ b/app/info/models/page.tsx
@@ -2,6 +2,7 @@
 
 import Button from '@/app/_components/Button'
 import PageTitle from '@/app/_components/PageTitle'
+import Section from '@/app/_components/Section'
 import { ModelStore } from '@/app/_stores/ModelStore'
 import { AvailableImageModel } from '@/app/_types/HordeTypes'
 import { IconCube, IconExternalLink, IconHeart } from '@tabler/icons-react'
@@ -25,13 +26,10 @@ export default function ModelsPage() {
   return (
     <div className="col">
       <PageTitle>Model Details</PageTitle>
-      <div className="col w-full">
+      <div className="col w-full gap-4">
         {Object.keys(modelDetails).map((key) => (
-          <div
-            key={key}
-            className="col text-white p-2 flex gap-2 rounded-md bg-[#c1c1c1] dark:bg-zinc-700"
-          >
-            <h3 className="row font-bold text-white gap-1">{key}</h3>
+          <Section key={key} anchor={key}>
+            <h2 className="row font-bold text-white gap-1 text-lg">{key}</h2>
             <div className="row w-full gap-2">
               <Button
                 style={{
@@ -59,7 +57,18 @@ export default function ModelsPage() {
                 </Link>
               </div>
             )}
-          </div>
+            <div className="row w-full items-start gap-4">
+              <div
+                style={{
+                  backgroundColor: 'gray',
+                  borderRadius: '8px',
+                  height: '400px',
+                  width: '400px'
+                }}
+              ></div>
+              <div className="w-full">{modelDetails[key].description}</div>
+            </div>
+          </Section>
         ))}
       </div>
     </div>

--- a/app/info/models/page.tsx
+++ b/app/info/models/page.tsx
@@ -1,76 +1,17 @@
-'use client'
-
-import Button from '@/app/_components/Button'
 import PageTitle from '@/app/_components/PageTitle'
-import Section from '@/app/_components/Section'
-import { ModelStore } from '@/app/_stores/ModelStore'
-import { AvailableImageModel } from '@/app/_types/HordeTypes'
-import { IconCube, IconExternalLink, IconHeart } from '@tabler/icons-react'
-import Link from 'next/link'
-import { useStore } from 'statery'
+import ModelsInfo from './_component/ModelsInfo'
+import { getModelsData } from '@/app/_api/models'
 
-export default function ModelsPage() {
-  const { availableModels, modelDetails } = useStore(ModelStore)
-  const availableModelsMap = availableModels.reduce(
-    (acc, item) => {
-      acc[item.name] = item
-      return acc
-    },
-    {} as { [key: string]: AvailableImageModel }
-
-    // TODO: Handle sort
-  )
-  console.log(`availableModelsMap`, availableModelsMap)
-  console.log(`modelDetails`, modelDetails)
+export default async function ModelsPage() {
+  const { modelsAvailable, modelDetails } = await getModelsData()
 
   return (
     <div className="col">
       <PageTitle>Model Details</PageTitle>
-      <div className="col w-full gap-4">
-        {Object.keys(modelDetails).map((key) => (
-          <Section key={key} anchor={key}>
-            <h2 className="row font-bold text-white gap-1 text-lg">{key}</h2>
-            <div className="row w-full gap-2">
-              <Button
-                style={{
-                  height: '36px',
-                  width: '36px'
-                }}
-              >
-                <IconHeart />
-              </Button>
-              <div className="row gap-1 bg-gray-600 px-2 h-[36px] rounded-md">
-                <IconCube /> {modelDetails[key].baseline}
-              </div>
-              <div>Version: {modelDetails[key].version}</div>
-            </div>
-            {modelDetails[key].homepage && (
-              <div>
-                <Link
-                  href={modelDetails[key].homepage}
-                  target="_blank"
-                  className="primary-color"
-                >
-                  <div className="row gap-1">
-                    Homepage <IconExternalLink />
-                  </div>
-                </Link>
-              </div>
-            )}
-            <div className="row w-full items-start gap-4">
-              <div
-                style={{
-                  backgroundColor: 'gray',
-                  borderRadius: '8px',
-                  height: '400px',
-                  width: '400px'
-                }}
-              ></div>
-              <div className="w-full">{modelDetails[key].description}</div>
-            </div>
-          </Section>
-        ))}
-      </div>
+      <ModelsInfo
+        modelsAvailable={modelsAvailable}
+        modelDetails={modelDetails}
+      />
     </div>
   )
 }


### PR DESCRIPTION
Fix:

- Don't re-call kudos endpoint on prompt changes
- Fetch model availability and model details on initial page load

Enhancements:

- Split API calls for model details so that it can be used in multiple places
- Implements a new and improved model details page.
- Initial work on filtering models
- Scaffold out some features for reusing components for SelectModal dropdown