### PR TITLE
Additional feedback fixes from round 3

### DIFF
--- a/app/_components/AdvancedOptions/AdditionalOptions.tsx
+++ b/app/_components/AdvancedOptions/AdditionalOptions.tsx
@@ -54,6 +54,15 @@ export default function AdditionalOptions() {
         />
         Tiling
       </label>
+      <label className="row gap-2 text-white">
+        <Switch
+          checked={input.transparent}
+          onChange={() => {
+            setInput({ transparent: !input.transparent })
+          }}
+        />
+        Transparent background
+      </label>
     </Section>
   )
 }

--- a/app/_components/Gallery.tsx
+++ b/app/_components/Gallery.tsx
@@ -2,14 +2,14 @@
 
 import NiceModal from '@ebay/nice-modal-react'
 import PhotoAlbum from 'react-photo-album'
-import React, { useCallback, useEffect, useState } from 'react'
+import React, { useCallback, useEffect } from 'react'
 import ReactPaginate from 'react-paginate'
 import {
   IconAffiliate,
   IconAffiliateFilled,
   IconChevronRight,
   IconCircleCheck,
-  IconSearch,
+  // IconSearch,
   IconSettings,
   IconSortAscending,
   IconSortDescending
@@ -24,7 +24,7 @@ import { viewedPendingPage } from '../_stores/PendingImagesStore'
 import Section from './Section'
 
 export default function Gallery() {
-  const [showSearch, setShowSearch] = useState(false)
+  // const [showSearch, setShowSearch] = useState(false)
 
   const {
     currentPage,
@@ -34,7 +34,7 @@ export default function Gallery() {
     initLoad,
     setCurrentPage,
     setGroupImages,
-    setSearchInput,
+    // setSearchInput,
     setSortBy,
     sortBy,
     totalImages
@@ -81,7 +81,7 @@ export default function Gallery() {
       <Section className="w-full mb-2">
         <div className="row w-full justify-between">
           <div className="row">
-            <Button
+            {/* <Button
               onClick={() => {
                 if (showSearch) {
                   setSearchInput('')
@@ -95,7 +95,7 @@ export default function Gallery() {
                 <IconSearch stroke={1.5} size={16} />
                 Search
               </span>
-            </Button>
+            </Button> */}
             <Button
               onClick={() => {
                 setCurrentPage(0)

--- a/app/_components/Gallery.tsx
+++ b/app/_components/Gallery.tsx
@@ -242,21 +242,22 @@ export default function Gallery() {
             }}
           />
           {!initLoad && (
-            <div className="row justify-center my-2">
+            <div className="row justify-center my-2 mt-4">
               <ReactPaginate
                 breakLabel="..."
                 nextLabel="⇢"
+                forcePage={currentPage}
                 onPageChange={(val) => {
-                  setCurrentPage(val.selected)
+                  setCurrentPage(Number(val.selected))
                   window.scrollTo(0, 0)
                 }}
                 containerClassName="row gap-0"
-                breakLinkClassName="border px-2 py-1 bg-[#8ac5d1] hover:bg-[#8ac5d1]"
-                pageLinkClassName="border px-2 py-1 bg-[#6AB7C6] hover:bg-[#8ac5d1]"
-                previousLinkClassName="rounded-l-md border px-2 py-1 bg-[#6AB7C6] hover:bg-[#8ac5d1]"
-                nextLinkClassName="rounded-r-md border px-2 py-1 bg-[#6AB7C6] hover:bg-[#8ac5d1]"
-                disabledLinkClassName="bg-[#969696] hover:bg-[#969696] cursor-default"
-                pageRangeDisplayed={5}
+                breakLinkClassName="border px-3 py-2 bg-[#8ac5d1] hover:bg-[#8ac5d1] text-white"
+                pageLinkClassName="border px-3 py-2 bg-[#6AB7C6] hover:bg-[#8ac5d1] text-white"
+                previousLinkClassName="rounded-l-md border px-3 py-2 bg-[#6AB7C6] hover:bg-[#8ac5d1] text-white"
+                nextLinkClassName="rounded-r-md border px-3 py-2 bg-[#6AB7C6] hover:bg-[#8ac5d1] text-white"
+                disabledLinkClassName="bg-[#969696] hover:bg-[#969696] cursor-default text-white"
+                pageRangeDisplayed={3}
                 pageCount={Math.ceil(totalImages / 20)}
                 previousLabel="⇠"
                 renderOnZeroPageCount={null}

--- a/app/_components/Gallery.tsx
+++ b/app/_components/Gallery.tsx
@@ -24,17 +24,21 @@ import { viewedPendingPage } from '../_stores/PendingImagesStore'
 import Section from './Section'
 
 export default function Gallery() {
-  const [groupImages, setGroupImages] = useState(true)
-  const [sortBy, setSortBy] = useState<'asc' | 'desc'>('desc')
-  const [currentPage, setCurrentPage] = useState(0)
   const [showSearch, setShowSearch] = useState(false)
 
-  const { images, totalImages, fetchImages, setSearchInput, initLoad } =
-    useFetchImages({
-      groupImages,
-      sortBy,
-      currentPage
-    })
+  const {
+    currentPage,
+    fetchImages,
+    groupImages,
+    images,
+    initLoad,
+    setCurrentPage,
+    setGroupImages,
+    setSearchInput,
+    setSortBy,
+    sortBy,
+    totalImages
+  } = useFetchImages()
 
   const handleImageOpen = useCallback(
     (artbot_id: string, image_id?: string) => {

--- a/app/_components/Gallery.tsx
+++ b/app/_components/Gallery.tsx
@@ -29,7 +29,7 @@ export default function Gallery() {
   const [currentPage, setCurrentPage] = useState(0)
   const [showSearch, setShowSearch] = useState(false)
 
-  const [images, totalImages, fetchImages, setSearchInput, initLoad] =
+  const { images, totalImages, fetchImages, setSearchInput, initLoad } =
     useFetchImages({
       groupImages,
       sortBy,

--- a/app/_components/ImageDetails.tsx
+++ b/app/_components/ImageDetails.tsx
@@ -228,6 +228,12 @@ export default function ImageDetails({
             <strong>Tiled: </strong>
             {imageRequest.tiling ? 'true' : 'false'}
           </div>
+          {imageRequest.transparent && (
+            <div>
+              <strong>Transparent background: </strong>
+              {imageRequest.transparent ? 'true' : 'false'}
+            </div>
+          )}
 
           {imageFile?.gen_metadata && imageFile?.gen_metadata?.length > 0 && (
             <div className="mt-4">

--- a/app/_components/ImageView/imageViewActions.tsx
+++ b/app/_components/ImageView/imageViewActions.tsx
@@ -25,6 +25,7 @@ import useImageBlobUrl from '@/app/_hooks/useImageBlobUrl'
 import { FullScreen, useFullScreenHandle } from 'react-full-screen'
 import { compressAndEncode, getBaseUrl } from '@/app/_utils/urlUtils'
 import { toastController } from '@/app/_controllers/toastController'
+import { blobToClipboard } from '@/app/_utils/imageUtils'
 
 export default function ImageViewActions({
   onDelete
@@ -111,7 +112,18 @@ export default function ImageViewActions({
             <MenuItem>Use all settings</MenuItem>
             <MenuDivider />
             <MenuItem>Copy JSON parameters</MenuItem>
-            <MenuItem>Copy image to clipboard</MenuItem>
+            <MenuItem
+              onClick={async () => {
+                const success = await blobToClipboard(imageBlob as Blob)
+                if (success) {
+                  toastController({
+                    message: 'Image copied to clipboard!'
+                  })
+                }
+              }}
+            >
+              Copy image to clipboard
+            </MenuItem>
           </DropdownMenu>
           <DropdownMenu
             menuButton={

--- a/app/_components/PendingImageOverlay/index.tsx
+++ b/app/_components/PendingImageOverlay/index.tsx
@@ -5,15 +5,8 @@ import {
   IconAlertTriangle,
   IconLibraryPhoto,
   IconPhotoUp,
-  IconTrash,
   IconX
 } from '@tabler/icons-react'
-// import { deletePendingImageFromAppState } from '@/app/_store/PendingImagesStore'
-// import { JobStatus } from '@/app/_types/artbot'
-// import ParticleAnimation from '@/app/_components/ui/ParticleLoader'
-// import { deleteJobFromDexie } from '@/app/_db/transactions'
-// import { usePendingJob } from '../../_hooks/usePendingJob'
-// import NiceModal from '@ebay/nice-modal-react'
 import { JobStatus } from '../../_types/ArtbotTypes'
 import { usePendingJob } from '../../_hooks/usePendingJob'
 import { deletePendingImageFromAppState } from '../../_stores/PendingImagesStore'
@@ -21,7 +14,6 @@ import { deleteJobFromDexie } from '../../_db/jobTransactions'
 import ParticleAnimation from '../ParticleAnimation'
 import styles from './pendingImageOverlay.module.css'
 import { formatPendingPercentage } from '@/app/_utils/numberUtils'
-// import DeleteConfirmation from '@/app/_components/modals/DeleteConfirmation'
 
 function PendingImageOverlay({
   artbot_id,
@@ -83,10 +75,10 @@ function PendingImageOverlay({
         }}
         title="Remove pending job from queue"
       >
-        <IconX />
+        <IconX stroke={'#000'} strokeWidth={2} />
       </div>
 
-      {(status === JobStatus.Done || status === JobStatus.Error) && (
+      {/* {(status === JobStatus.Done || status === JobStatus.Error) && (
         <div
           className={styles.TrashIcon}
           onClick={async (e) => {
@@ -137,7 +129,7 @@ function PendingImageOverlay({
         >
           <IconTrash stroke={1} />
         </div>
-      )}
+      )} */}
 
       {status === JobStatus.Waiting && (
         <>

--- a/app/_data-models/ImageParamsForHordeApi.ts
+++ b/app/_data-models/ImageParamsForHordeApi.ts
@@ -43,6 +43,7 @@ export interface ImageParams {
   n: number
   loras?: Lora[]
   tis?: TextualInversion[]
+  transparent?: boolean
   workflow?: 'qr_code' | ''
   extra_texts?: Array<{
     text: string
@@ -112,6 +113,7 @@ class ImageParamsForHordeApi implements HordeApiParamsBuilderInterface {
       seed = '',
       steps,
       tiling = false,
+      transparent = false,
       width
     } = imageDetails
 
@@ -150,6 +152,10 @@ class ImageParamsForHordeApi implements HordeApiParamsBuilderInterface {
       ) {
         this.apiParams.params.facefixer_strength = facefixer_strength
       }
+    }
+
+    if (transparent) {
+      this.apiParams.params.transparent = true
     }
 
     // Set the base parameters of apiParams here based on imageDetails and options

--- a/app/_data-models/PromptInput.ts
+++ b/app/_data-models/PromptInput.ts
@@ -58,6 +58,7 @@ class PromptInput {
   steps: number = 20
   tiling: boolean = false
   tis: AiHordeEmbedding[] = []
+  transparent: boolean = false
   triggers: Array<string> = []
   upscaled: boolean = false
   width: number = 1024

--- a/app/_hooks/useFetchImages.tsx
+++ b/app/_hooks/useFetchImages.tsx
@@ -32,20 +32,22 @@ export interface FetchImagesResult {
   fetchImages: () => void
   setSearchInput: Dispatch<SetStateAction<string>>
   initLoad: boolean
+  currentPage: number
+  setCurrentPage: Dispatch<SetStateAction<number>>
+  groupImages: boolean
+  setGroupImages: Dispatch<SetStateAction<boolean>>
+  sortBy: 'asc' | 'desc'
+  setSortBy: Dispatch<SetStateAction<'asc' | 'desc'>>
 }
 
-export default function useFetchImages({
-  currentPage,
-  groupImages,
-  sortBy = 'desc'
-}: {
-  currentPage: number
-  groupImages: boolean
-  sortBy: 'asc' | 'desc'
-}): FetchImagesResult {
+export default function useFetchImages(): FetchImagesResult {
   // Handle initial load of page
   // so we don't flash "No Images Found" if images actually exist.
   const [initLoad, setInitLoad] = useState(true)
+
+  const [currentPage, setCurrentPage] = useState(0)
+  const [groupImages, setGroupImages] = useState(false)
+  const [sortBy, setSortBy] = useState<'asc' | 'desc'>('desc')
 
   // Track internal state of groupImages so we can reset offset and currentPage to 0 if groupImages changes
   const [groupImagesState, setGroupImagesState] = useState(groupImages)
@@ -136,6 +138,12 @@ export default function useFetchImages({
     totalImages,
     fetchImages,
     setSearchInput: debounceSearchInput,
-    initLoad
+    initLoad,
+    currentPage,
+    setCurrentPage,
+    groupImages,
+    setGroupImages,
+    sortBy,
+    setSortBy
   }
 }

--- a/app/_hooks/useFetchImages.tsx
+++ b/app/_hooks/useFetchImages.tsx
@@ -161,6 +161,7 @@ export default function useFetchImages(): FetchImagesResult {
     if (currentPage !== page) setCurrentPage(page)
     if (groupImages !== group) setGroupImages(group)
     if (sortBy !== sort) setSortBy(sort)
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [searchParams])
 
   return {

--- a/app/_hooks/useFetchImages.tsx
+++ b/app/_hooks/useFetchImages.tsx
@@ -46,6 +46,7 @@ export default function useFetchImages(): FetchImagesResult {
   const pathname = usePathname()
   const searchParams = useSearchParams()
 
+  // Initialize state with query parameters or defaults
   const [initLoad, setInitLoad] = useState(true)
   const [currentPage, setCurrentPage] = useState(
     Number(searchParams.get('page') || 1) - 1
@@ -56,19 +57,18 @@ export default function useFetchImages(): FetchImagesResult {
   const [sortBy, setSortBy] = useState<'asc' | 'desc'>(
     (searchParams.get('sortBy') as 'asc' | 'desc') || 'desc'
   )
-
   const [groupImagesState, setGroupImagesState] = useState(groupImages)
   const [offset, setOffset] = useState(0)
   const [totalImages, setTotalImages] = useState(0)
   const [images, setImages] = useState<PhotoData[]>([])
   const [searchInput, setSearchInput] = useState('')
 
+  // Update the URL with current state values
   const updateUrl = useCallback(() => {
     const query = new URLSearchParams()
     query.set('page', (currentPage + 1).toString()) // Set page as currentPage + 1
     query.set('sortBy', sortBy)
     query.set('group', groupImages.toString())
-
     router.push(`${pathname}?${query.toString()}`)
   }, [currentPage, sortBy, groupImages, router, pathname])
 
@@ -78,28 +78,28 @@ export default function useFetchImages(): FetchImagesResult {
     }
   }, [currentPage, groupImages, sortBy, updateUrl, initLoad])
 
+  // Fetch search results from Dexie based on search input and sorting
   const fetchSearchResults = useCallback(async () => {
     const data = await searchPromptsFromDexie({
       searchInput,
       sortDirection: sortBy
     })
 
-    const imagesArray = data.map((image) => {
-      return {
-        artbot_id: image.artbot_id,
-        image_id: image.image_id,
-        key: `image-${image.image_id}`,
-        src: '',
-        image_count: image.image_count || 1,
-        width: image.width,
-        height: image.height
-      }
-    }) as unknown as PhotoData[]
+    const imagesArray = data.map((image) => ({
+      artbot_id: image.artbot_id,
+      image_id: image.image_id,
+      key: `image-${image.image_id}`,
+      src: '',
+      image_count: image.image_count || 1,
+      width: image.width,
+      height: image.height
+    })) as PhotoData[]
 
     setTotalImages(imagesArray.length)
     setImages(imagesArray)
   }, [searchInput, sortBy])
 
+  // Fetch images based on current state values
   const fetchImages = useCallback(async () => {
     let data = []
     let count = 0
@@ -123,17 +123,15 @@ export default function useFetchImages(): FetchImagesResult {
       )
     }
 
-    const imagesArray = data.map((image) => {
-      return {
-        artbot_id: image.artbot_id,
-        image_id: image.image_id,
-        key: `image-${image.image_id}`,
-        src: '',
-        image_count: image.image_count || 1,
-        width: image.width,
-        height: image.height
-      }
-    }) as unknown as PhotoData[]
+    const imagesArray = data.map((image) => ({
+      artbot_id: image.artbot_id,
+      image_id: image.image_id,
+      key: `image-${image.image_id}`,
+      src: '',
+      image_count: image.image_count || 1,
+      width: image.width,
+      height: image.height
+    })) as PhotoData[]
 
     setTotalImages(count)
     setImages(imagesArray)

--- a/app/_utils/browserUtils.ts
+++ b/app/_utils/browserUtils.ts
@@ -1,0 +1,27 @@
+export const isiOS = () => {
+  return (
+    [
+      'iPad Simulator',
+      'iPhone Simulator',
+      'iPod Simulator',
+      'iPad',
+      'iPhone',
+      'iPod'
+    ].includes(navigator?.platform) ||
+    // iPad on iOS 13 detection
+    (navigator.userAgent.includes('Mac') && 'ontouchend' in document)
+  )
+}
+
+export const isSafariBrowser = () => {
+  const is_chrome = navigator.userAgent.indexOf('Chrome') > -1
+  const is_safari = navigator.userAgent.indexOf('Safari') > -1
+
+  if (is_safari) {
+    if (is_chrome)
+      // Chrome seems to have both Chrome and Safari userAgents
+      return false
+    else return true
+  }
+  return false
+}

--- a/app/_utils/imageUtils.ts
+++ b/app/_utils/imageUtils.ts
@@ -1,6 +1,108 @@
-export const base64toBlob = async (
-  base64Data: string
-): Promise<Blob | boolean> => {
+import { isSafariBrowser, isiOS } from './browserUtils'
+
+function URI2Blob(dataURI: string, mimeType: string): Blob {
+  const imageBytes = atob(dataURI.split(',')[1])
+
+  const arrayBuf = new ArrayBuffer(imageBytes.length)
+  const intArr = new Uint8Array(arrayBuf)
+  for (let i = 0; i < imageBytes.length; i++) {
+    intArr[i] = imageBytes.charCodeAt(i)
+  }
+
+  return new Blob([intArr], { type: mimeType })
+}
+
+function loadImage(src: string) {
+  return new Promise((resolve, reject) => {
+    const image = new Image()
+    image.onload = () => {
+      resolve(image)
+    }
+    image.onerror = (error) => {
+      reject(error)
+    }
+    image.src = src
+  })
+}
+
+function createTempCanvas() {
+  const canvas = document.createElement('CANVAS')
+  canvas.style.display = 'none'
+  return canvas
+}
+
+async function convertBlob(
+  blob: Blob,
+  mimeType: string,
+  callback: (arg0: Blob) => void
+  // exif: object = {}
+) {
+  let convertedBlob: Blob
+  if (blob.type !== mimeType) {
+    const image = (await loadImage(
+      URL.createObjectURL(blob)
+    )) as HTMLImageElement
+    const canvas = <HTMLCanvasElement>createTempCanvas()
+    const ctx = canvas.getContext('2d')
+
+    canvas.width = image.width
+    canvas.height = image.height
+
+    if (ctx) {
+      ctx.drawImage(image, 0, 0)
+    }
+
+    convertedBlob = URI2Blob(canvas.toDataURL(mimeType, 1), mimeType)
+  } else {
+    convertedBlob = blob
+  }
+
+  const result = convertedBlob
+  // const result = await writeMetadata(convertedBlob, exif)
+
+  if (callback) {
+    callback(result)
+  } else {
+    return result
+  }
+}
+
+export const initBlob = () => {
+  if (!Blob.prototype.toPNG) {
+    Blob.prototype.toPNG = async function (callback: () => void) {
+      // Converting through canvas will remove exif data
+      // So extract exif first, and then add it back when creating new blob
+      // const exif = await getExifFromBlob(this)
+      return await convertBlob(this, 'image/png', callback)
+    }
+  }
+
+  if (!Blob.prototype.toWebP) {
+    Blob.prototype.toWebP = async function (callback: () => void) {
+      // const exif = await getExifFromBlob(this)
+      return await convertBlob(this, 'image/webp', callback)
+    }
+  }
+
+  if (!Blob.prototype.toJPEG) {
+    Blob.prototype.toJPEG = async function (callback: () => void) {
+      // const exif = await getExifFromBlob(this)
+      return await convertBlob(this, 'image/jpeg', callback)
+    }
+  }
+
+  if (!Blob.prototype.addOrUpdateExifData) {
+    Blob.prototype.addOrUpdateExifData = async function () {
+      return this
+    }
+
+    // Blob.prototype.addOrUpdateExifData = async function (userComment: string) {
+    //   return await writeMetadata(this, mergeExifData({}, userComment))
+    // }
+  }
+}
+
+export const base64toBlob = async (base64Data: string) => {
   try {
     const base64str = `data:${inferMimeTypeFromBase64(
       base64Data
@@ -177,4 +279,38 @@ export const nearestWholeMultiple = (input: number, X = 64) => {
   output *= X
 
   return output
+}
+
+export const blobToClipboard = async (imageBlob: Blob) => {
+  initBlob()
+
+  const makeImagePromiseForSafari = async () => {
+    return await imageBlob.toPNG()
+  }
+
+  if (isiOS() || isSafariBrowser()) {
+    try {
+      const imagePromise = await makeImagePromiseForSafari()
+
+      if (imagePromise) {
+        navigator.clipboard.write([
+          new ClipboardItem({
+            'image/png': imagePromise
+          })
+        ])
+
+        return true
+      }
+    } catch (err) {
+      return false
+    }
+  } else {
+    // Only PNGs can be copied to the clipboard
+    const newBlob = await imageBlob.toPNG()
+
+    if (newBlob) {
+      navigator.clipboard.write([new ClipboardItem({ 'image/png': newBlob })])
+      return true
+    }
+  }
 }

--- a/global.d.ts
+++ b/global.d.ts
@@ -1,0 +1,8 @@
+interface Blob {
+  toPNG(callback?: () => void): Promise<Blob | undefined>
+  toWebP(callback?: () => void): Promise<Blob | undefined>
+  toJPEG(callback?: () => void): Promise<Blob | undefined>
+  addOrUpdateExifData(userComment: string): Promise<Blob>
+}
+
+declare global {}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,10 +1,6 @@
 {
   "compilerOptions": {
-    "lib": [
-      "dom",
-      "dom.iterable",
-      "esnext"
-    ],
+    "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,
     "skipLibCheck": true,
     "strict": true,
@@ -21,9 +17,7 @@
       }
     ],
     "paths": {
-      "@/*": [
-        "./*"
-      ]
+      "@/*": ["./*"]
     },
     "resolveJsonModule": true
   },
@@ -33,9 +27,8 @@
     "**/*.ts",
     "**/*.tsx",
     ".next/types/**/*.ts",
-    "jest.config.js"
+    "jest.config.js",
+    "global.d.ts"
   ],
-  "exclude": [
-    "node_modules"
-  ]
+  "exclude": ["node_modules"]
 }


### PR DESCRIPTION
Fixes:

- Ungrouping images from image gallery page could get you into a weird state. Now, grouping or ungrouping images sends you back to page 1.
- Image requests weren't respecting 2 per 1 seconds limit and would result in API timeouts.
- Refactor some functions within the image gallery hook

Enhancements:

- Add query params to image gallery (can now click back / forward buttons in browser).
- Add support for transparency 
- Re-implement "copy image to clipboard"

TODOs:

- Need to re-implement existing EXIF logic from ArtBot v1.