### PR TITLE
feat: Implement favorites and recents modals for embeddings

### DIFF
--- a/app/_components/AdvancedOptions/AddEmbedding.tsx
+++ b/app/_components/AdvancedOptions/AddEmbedding.tsx
@@ -5,7 +5,7 @@ import Button from '../Button'
 import Section from '../Section'
 import NiceModal from '@ebay/nice-modal-react'
 import LoraSearch from './LoRAs/LoraSearch'
-import { useCallback } from 'react'
+import { Suspense, useCallback } from 'react'
 import { SavedEmbedding, SavedLora } from '@/app/_data-models/Civitai'
 import { useInput } from '@/app/_providers/PromptInputProvider'
 import EmbeddingSettingsCard from './LoRAs/EmbeddingSettingsCard'
@@ -50,10 +50,12 @@ export default function AddEmbedding() {
             onClick={() => {
               NiceModal.show('modal', {
                 children: (
-                  <LoraSearch
-                    onUseLoraClick={handleUseLoraClick}
-                    civitAiType="TextualInversion"
-                  />
+                  <Suspense>
+                    <LoraSearch
+                      onUseLoraClick={handleUseLoraClick}
+                      civitAiType="TextualInversion"
+                    />
+                  </Suspense>
                 ),
                 modalStyle: {
                   maxWidth: '1600px',
@@ -69,11 +71,13 @@ export default function AddEmbedding() {
             onClick={() => {
               NiceModal.show('modal', {
                 children: (
-                  <LoraSearch
-                    onUseLoraClick={handleUseLoraClick}
-                    civitAiType="TextualInversion"
-                    searchType="favorite"
-                  />
+                  <Suspense>
+                    <LoraSearch
+                      onUseLoraClick={handleUseLoraClick}
+                      civitAiType="TextualInversion"
+                      searchType="favorite"
+                    />
+                  </Suspense>
                 ),
                 modalStyle: {
                   maxWidth: '1600px',
@@ -89,11 +93,13 @@ export default function AddEmbedding() {
             onClick={() => {
               NiceModal.show('modal', {
                 children: (
-                  <LoraSearch
-                    onUseLoraClick={handleUseLoraClick}
-                    civitAiType="TextualInversion"
-                    searchType="recent"
-                  />
+                  <Suspense>
+                    <LoraSearch
+                      onUseLoraClick={handleUseLoraClick}
+                      civitAiType="TextualInversion"
+                      searchType="recent"
+                    />
+                  </Suspense>
                 ),
                 modalStyle: {
                   maxWidth: '1600px',

--- a/app/_components/AdvancedOptions/AddEmbedding.tsx
+++ b/app/_components/AdvancedOptions/AddEmbedding.tsx
@@ -68,7 +68,18 @@ export default function AddEmbedding() {
           <Button
             onClick={() => {
               NiceModal.show('modal', {
-                children: <div>Favorite TIs - hello!</div>
+                children: (
+                  <LoraSearch
+                    onUseLoraClick={handleUseLoraClick}
+                    civitAiType="TextualInversion"
+                    searchType="favorite"
+                  />
+                ),
+                modalStyle: {
+                  maxWidth: '1600px',
+                  minHeight: `calc(100vh - 32px)`,
+                  width: 'calc(100% - 32px)'
+                }
               })
             }}
           >
@@ -77,7 +88,18 @@ export default function AddEmbedding() {
           <Button
             onClick={() => {
               NiceModal.show('modal', {
-                children: <div>Recently used TIs- hello!</div>
+                children: (
+                  <LoraSearch
+                    onUseLoraClick={handleUseLoraClick}
+                    civitAiType="TextualInversion"
+                    searchType="recent"
+                  />
+                ),
+                modalStyle: {
+                  maxWidth: '1600px',
+                  minHeight: `calc(100vh - 32px)`,
+                  width: 'calc(100% - 32px)'
+                }
               })
             }}
           >

--- a/app/_components/AdvancedOptions/LoRAs/AddLora.tsx
+++ b/app/_components/AdvancedOptions/LoRAs/AddLora.tsx
@@ -7,7 +7,7 @@ import NiceModal from '@ebay/nice-modal-react'
 import LoraSearch from './LoraSearch'
 import { useInput } from '@/app/_providers/PromptInputProvider'
 import LoraSettingsCard from './LoraSettingsCard'
-import { useCallback } from 'react'
+import { Suspense, useCallback } from 'react'
 import { SavedEmbedding, SavedLora } from '@/app/_data-models/Civitai'
 
 const MAX_LORAS = 5
@@ -55,7 +55,11 @@ export default function AddLora() {
             disabled={input.loras.length >= MAX_LORAS}
             onClick={() => {
               NiceModal.show('modal', {
-                children: <LoraSearch onUseLoraClick={handleUseLoraClick} />,
+                children: (
+                  <Suspense>
+                    <LoraSearch onUseLoraClick={handleUseLoraClick} />,
+                  </Suspense>
+                ),
                 modalStyle: {
                   maxWidth: '1600px',
                   minHeight: `calc(100vh - 32px)`,
@@ -70,10 +74,12 @@ export default function AddLora() {
             onClick={() => {
               NiceModal.show('modal', {
                 children: (
-                  <LoraSearch
-                    onUseLoraClick={handleUseLoraClick}
-                    searchType="favorite"
-                  />
+                  <Suspense>
+                    <LoraSearch
+                      onUseLoraClick={handleUseLoraClick}
+                      searchType="favorite"
+                    />
+                  </Suspense>
                 ),
                 modalStyle: {
                   maxWidth: '1600px',
@@ -89,10 +95,12 @@ export default function AddLora() {
             onClick={() => {
               NiceModal.show('modal', {
                 children: (
-                  <LoraSearch
-                    onUseLoraClick={handleUseLoraClick}
-                    searchType="recent"
-                  />
+                  <Suspense>
+                    <LoraSearch
+                      onUseLoraClick={handleUseLoraClick}
+                      searchType="recent"
+                    />
+                  </Suspense>
                 ),
                 modalStyle: {
                   maxWidth: '1600px',

--- a/app/_components/AdvancedOptions/LoRAs/EmbeddingSettingsCard.tsx
+++ b/app/_components/AdvancedOptions/LoRAs/EmbeddingSettingsCard.tsx
@@ -164,7 +164,7 @@ export default function EmbeddingSettingsCard({ ti }: { ti: SavedEmbedding }) {
           options={[
             { value: 'prompt', label: 'Prompt' },
             { value: 'negprompt', label: 'Negative Prompt' },
-            { value: 'manual', label: 'None' }
+            { value: 'none', label: 'None' }
           ]}
           value={{
             value: ti.inject_ti as string,

--- a/app/_components/AdvancedOptions/LoRAs/LoraDetails.tsx
+++ b/app/_components/AdvancedOptions/LoRAs/LoraDetails.tsx
@@ -69,7 +69,7 @@ export default function LoraDetails({
       model: {
         ...details
       },
-      type: 'lora',
+      type: civitAiType === 'LORA' ? 'lora' : 'ti',
       model_id: model_id as string
     })
   }

--- a/app/_components/AdvancedOptions/LoRAs/_Embeddings.json
+++ b/app/_components/AdvancedOptions/LoRAs/_Embeddings.json
@@ -1,0 +1,10839 @@
+{
+  "items": [
+    {
+      "id": 7808,
+      "name": "EasyNegative",
+      "description": "<p><a target=\"_blank\" rel=\"ugc\" href=\"https://huggingface.co/datasets/gsdf/EasyNegative\"><strong>Original Hugging Face Repository</strong></a><strong><br />Simply uploaded by me, all credit goes to </strong><a target=\"_blank\" rel=\"ugc\" href=\"https://huggingface.co/gsdf\"><strong>https://huggingface.co/gsdf</strong></a><strong>.</strong><br /><strong>Counterfeit-V3 (which has 2.5 and 2.5 as well) on Civitai - </strong><a target=\"_blank\" rel=\"ugc\" href=\"https://civitai.com/models/4468/counterfeit-v25\"><strong>https://civitai.com/models/4468/counterfeit-v25</strong></a><br /><strong>If you like this embedding, please consider taking the time to give the repository a like and browsing their other work on HuggingFace.</strong><br /></p><p><strong>This embedding should be used in your NEGATIVE prompt. Adjust the strength as desired (seems to scale well without any distortions), the strength required may vary based on positive and negative prompts. Use the EasyNegative_pt (PickleTensors) version if you are unable to use SafeTensors embeddings.</strong><br /><br /><strong>Samples are, in order:</strong></p><ol><li><p><strong>sample01 - Counterfeit-V2.0.safetensors</strong></p></li><li><p><strong>sample02 - AbyssOrangeMix2_sfw.safetensors</strong></p></li><li><p><strong>sample03 - anything-v4.0-pruned.safetensors</strong></p></li><li><p><strong>Strength comparison using AbyssOrangeMix2_sfw.</strong></p></li></ol><p><br /><strong>From Author</strong><br />\"This is a Negative Embedding trained with Counterfeit. Please use it in the \"\\stable-diffusion-webui\\embeddings\" folder. It can be used with other models, but the effectiveness is not certain.\"</p>",
+      "allowNoCredit": true,
+      "allowCommercialUse": ["Image", "RentCivit", "Rent", "Sell"],
+      "allowDerivatives": true,
+      "allowDifferentLicense": false,
+      "type": "TextualInversion",
+      "minor": false,
+      "poi": false,
+      "nsfw": false,
+      "nsfwLevel": 1,
+      "cosmetic": null,
+      "stats": {
+        "downloadCount": 487523,
+        "favoriteCount": 0,
+        "thumbsUpCount": 29772,
+        "thumbsDownCount": 23,
+        "commentCount": 95,
+        "ratingCount": 0,
+        "rating": 0,
+        "tippedAmountCount": 640
+      },
+      "creator": {
+        "username": "Havoc",
+        "image": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/2da02a6c-ff45-4469-d64e-a2d8a4e75900/width=96/Havoc.jpeg"
+      },
+      "tags": [
+        "anime",
+        "negative",
+        "negative embedding",
+        "textual inversion",
+        "embedding",
+        "tool"
+      ],
+      "modelVersions": [
+        {
+          "id": 9208,
+          "index": 0,
+          "name": "EasyNegative",
+          "baseModel": "SD 1.5",
+          "baseModelType": "Standard",
+          "publishedAt": "2023-02-10T12:56:41.356Z",
+          "availability": "Public",
+          "nsfwLevel": 1,
+          "description": "<p><strong>This embedding should be used in your NEGATIVE prompt. Adjust the strength as desired (seems to scale well without any distortions), the strength required may vary based on positive and negative prompts.</strong><br /><br /><strong>Samples are, in order:</strong></p><ol><li><p><strong>sample01 - Counterfeit-V2.0.safetensors</strong></p></li><li><p><strong>sample02 - AbyssOrangeMix2_sfw.safetensors</strong></p></li><li><p><strong>sample03 - anything-v4.0-pruned.safetensors</strong></p></li><li><p><strong>Strength comparison using AbyssOrangeMix2_sfw.</strong></p></li></ol><p><br /><strong>From Author</strong><br />\"This is a Negative Embedding trained with Counterfeit. Please use it in the \"\\stable-diffusion-webui\\embeddings\" folder. It can be used with other models, but the effectiveness is not certain.\"</p>",
+          "trainedWords": ["easynegative"],
+          "stats": {
+            "downloadCount": 448628,
+            "ratingCount": 1743,
+            "rating": 4.85,
+            "thumbsUpCount": 6990,
+            "thumbsDownCount": 23
+          },
+          "files": [
+            {
+              "id": 8955,
+              "sizeKB": 24.0771484375,
+              "name": "easynegative.safetensors",
+              "type": "Model",
+              "pickleScanResult": "Success",
+              "pickleScanMessage": "No Pickle imports",
+              "virusScanResult": "Success",
+              "virusScanMessage": null,
+              "scannedAt": "2023-02-10T13:01:00.347Z",
+              "metadata": {
+                "format": "SafeTensor",
+                "size": "full",
+                "fp": "fp16"
+              },
+              "hashes": {
+                "AutoV2": "C74B4E810B",
+                "SHA256": "C74B4E810B030F6B75FDE959E2DB678C268D07115B85356D3C0138BA5EB42340",
+                "CRC32": "9B6C6647",
+                "BLAKE3": "EDC4D4CA619F612417FC4B463B3B2864E42E8CC5F291835E1312F2A6C8923507"
+              },
+              "downloadUrl": "https://civitai.com/api/download/models/9208",
+              "primary": true
+            }
+          ],
+          "images": [
+            {
+              "id": 88246,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/a2505a48-8eed-4b12-b6a0-6a8ec7e0c600/width=450/88246.jpeg",
+              "nsfwLevel": 1,
+              "width": 3387,
+              "height": 1930,
+              "hash": "UnLNiM~q?v?axtafaybGofWVfkn%%2afj[f+",
+              "type": "image"
+            },
+            {
+              "id": 88248,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/945f1968-7fda-4512-0676-d41787befd00/width=450/88248.jpeg",
+              "nsfwLevel": 1,
+              "width": 3387,
+              "height": 1930,
+              "hash": "UjLz,I~q_4-;xaWCayj[oeayfjWVt6j]ofof",
+              "type": "image"
+            },
+            {
+              "id": 88273,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/027053dc-60f2-42c5-6373-64db78fbc100/width=450/88273.jpeg",
+              "nsfwLevel": 1,
+              "width": 3387,
+              "height": 1930,
+              "hash": "UkL;Nw_N?u?b%2WCWUofoLa}ayfQxat7a#j]",
+              "type": "image"
+            },
+            {
+              "id": 88725,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/8c1de243-daf4-413e-386e-d5b8a33e7e00/width=450/88725.jpeg",
+              "nsfwLevel": 1,
+              "width": 6656,
+              "height": 872,
+              "hash": "UcL4W,S$S6sA_MozkCjF%Nk9ozWX~XWUkCNb",
+              "type": "image"
+            }
+          ],
+          "downloadUrl": "https://civitai.com/api/download/models/9208"
+        },
+        {
+          "id": 9536,
+          "index": 1,
+          "name": "EasyNegative_pt",
+          "baseModel": "SD 1.5",
+          "baseModelType": "Standard",
+          "publishedAt": "2023-02-11T20:17:16.421Z",
+          "availability": "Public",
+          "nsfwLevel": 1,
+          "description": "<p><strong>PickleTensor (pt) version for those who can't use SafeTensors.</strong><br /><br /><strong>This embedding should be used in your NEGATIVE prompt. Adjust the strength as desired (seems to scale well without any distortions), the strength required may vary based on positive and negative prompts.</strong><br /><br /><strong>Samples are, in order:</strong></p><ol><li><p><strong>sample01 - Counterfeit-V2.0.safetensors</strong></p></li><li><p><strong>sample02 - AbyssOrangeMix2_sfw.safetensors</strong></p></li><li><p><strong>sample03 - anything-v4.0-pruned.safetensors</strong></p></li><li><p><strong>Strength comparison using AbyssOrangeMix2_sfw.</strong></p></li></ol><p><br /><strong>From Author</strong><br />\"This is a Negative Embedding trained with Counterfeit. Please use it in the \"\\stable-diffusion-webui\\embeddings\" folder. It can be used with other models, but the effectiveness is not certain.\"</p>",
+          "trainedWords": ["easynegative"],
+          "stats": {
+            "downloadCount": 38895,
+            "ratingCount": 16250,
+            "rating": 5,
+            "thumbsUpCount": 23687,
+            "thumbsDownCount": 0
+          },
+          "files": [
+            {
+              "id": 9235,
+              "sizeKB": 24.7294921875,
+              "name": "easynegative.pt",
+              "type": "Model",
+              "pickleScanResult": "Success",
+              "pickleScanMessage": "No Pickle imports",
+              "virusScanResult": "Success",
+              "virusScanMessage": null,
+              "scannedAt": "2023-02-11T20:21:02.465Z",
+              "metadata": {
+                "format": "PickleTensor",
+                "size": "full",
+                "fp": "fp16"
+              },
+              "hashes": {
+                "AutoV2": "66A7279A88",
+                "SHA256": "66A7279A88DD0CB17AFBC88560540C638336D5783FD6B191C53C0D654E25B9DB",
+                "CRC32": "B6D1BAE9",
+                "BLAKE3": "AF0C6780949960AFABF44E1339CB515B9BE94FC091382DA8F90EF7F59E8AA6FA"
+              },
+              "downloadUrl": "https://civitai.com/api/download/models/9536",
+              "primary": true
+            }
+          ],
+          "images": [
+            {
+              "id": 91997,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/bf650aea-0db1-4b0c-9191-9a48be35d700/width=450/91997.jpeg",
+              "nsfwLevel": 1,
+              "width": 3387,
+              "height": 1930,
+              "hash": "UnLNiM~q?v?axtafaybHofWVfkn%%2afj[f+",
+              "type": "image"
+            },
+            {
+              "id": 91996,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/794e9cc4-aa49-400e-9be8-12f1ae40c200/width=450/91996.jpeg",
+              "nsfwLevel": 1,
+              "width": 3387,
+              "height": 1930,
+              "hash": "UjLz,I~q_4-;xaWCayj[ofayfkayt6j]ofof",
+              "type": "image"
+            },
+            {
+              "id": 91995,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/1ee773e9-a7d2-4b98-6e03-7c5418dbb800/width=450/91995.jpeg",
+              "nsfwLevel": 1,
+              "width": 3387,
+              "height": 1930,
+              "hash": "UkL;Nw_N?u?b%2WCWUofoLa}ayfQxat7a#j]",
+              "type": "image"
+            },
+            {
+              "id": 92496,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/72b1aeeb-c608-40bb-f6e5-10b32eea9e00/width=450/92496.jpeg",
+              "nsfwLevel": 1,
+              "width": 6656,
+              "height": 872,
+              "hash": "UcL4W,S$S6sA_MozkCjF%Nk9ozWX_4WUkDNb",
+              "type": "image"
+            }
+          ],
+          "downloadUrl": "https://civitai.com/api/download/models/9536"
+        }
+      ]
+    },
+    {
+      "id": 4629,
+      "name": "Deep Negative V1.x",
+      "description": "<p>This embedding will tell you what is <strong>REALLY DISGUSTING</strong>🤢🤮</p><p>So please put it in <strong><u>negative prompt</u></strong>😜</p><p></p><p><u>⚠This model is not trained for SDXL and may bring undesired results when used in SDXL.</u></p><p><u>If you use </u><strong><u>SDXL</u></strong><u>, recommended this 👉 </u><a target=\"_blank\" rel=\"ugc\" href=\"https://civitai.com/models/407448/deepnegativexl\"><u>DeepNegative for SDXL version</u></a></p><p></p><h3 id=\"heading-53\">TOP Q&amp;A</h3><ul><li><p>how to use TI model?</p></li></ul><p><a target=\"_blank\" rel=\"ugc\" href=\"https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Textual-Inversion\">https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Textual-Inversion</a></p><ul><li><p>what is negative prompt?</p></li></ul><p><a target=\"_blank\" rel=\"ugc\" href=\"https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Negative-prompt\">https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Negative-prompt</a></p><p></p><p><strong>[Special Reminder]</strong> If your webui reports the following errors:</p><p>- <code>CUDA: CUDA error: device-side assert triggered</code></p><p>- <code>Assertion -sizes[i] &lt;= index &amp;&amp; index &lt; sizes[i] &amp;&amp; \"index out of bounds\" failed</code></p><p>- <code>XXX object has no attribute 'text_cond'</code></p><p>Please try using a model version other than 75T. </p><p>&gt; The reason is that many scripts do not handle overly long negative prompt words (greater than 75 tokens) properly, so choosing a smaller token version can improve this situation.</p><p></p><h3 id=\"heading-73\">[Update:230120] What does it do?</h3><p>These embedding learn what disgusting compositions and color patterns are, including faulty human anatomy, offensive color schemes, upside-down spatial structures, and more. Placing it in the negative can go a long way to avoiding these things.</p><p>-</p><p><img src=\"https://imagecache.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/00f10479-531c-4dc8-8021-f2af1c697700/width=525\" /></p><p></p><p></p><h3 id=\"heading-74\">What is 2T 4T 16T 32T?</h3><p>Number of vectors per token</p><p></p><h3 id=\"heading-75\">[Update:230120] What is 64T 75T？</h3><p><strong>64T</strong>: Train over <u>30,000</u> steps on mixed datasets.</p><p><strong>75T</strong>: embedding limit maximum size, training 10,000 steps on a <u>special dataset</u> (generated by many different sd models and special reverse processing)</p><p></p><h3 id=\"heading-76\">Which one should choose?</h3><ul><li><p><strong>75T</strong>: The most ”easy to use“ embedding, which is trained from its accurate dataset created in a special way with almost <strong>no side effects</strong>. And it contains enough information to cover various usage scenarios. But for some <u>\"good-trained-model\"</u> may hard to effect</p><p>and, change about may be subtle and not drastic enough.</p></li><li><p><strong>64T</strong>: It works for all models, but has side effect. so, some tuning is required to find the best weight. <u>recommend</u>: [( NG_DeepNegative_V1_64T :0.9) :0.1]</p></li><li><p><strong>32T</strong>: Useful, but too more</p></li><li><p><strong>16T</strong>: Reduces the chance of drawing bad anatomy, but may draw ugly faces. Suitable for raising <strong>architecture</strong> level.</p></li><li><p><strong>4T</strong>: Reduces the chance of drawing bad anatomy, but has a little effect on light and shadow</p></li><li><p><strong>2T</strong>: ”easy to use“ like T75, but just a little effect</p></li></ul><p></p><h3 id=\"heading-77\">Suggestion</h3><p>Because this embedding is learning how to create <strong>disgusting concepts</strong>, it cannot improve the picture quality accurately, so it is best used with <u>(worst quality, low quality, logo, text, watermark, username)</u> these negative prompts.</p><p>Of course, it is completely fine to use with other similar negative embeddings.</p><p></p><h3 id=\"heading-78\">More examples and tests</h3><ul><li><p>draw building: <a target=\"_blank\" rel=\"ugc\" href=\"https://imgur.com/5aX9yrP\">https://imgur.com/5aX9yrP</a></p></li><li><p>hand fix: <a target=\"_blank\" rel=\"ugc\" href=\"https://imgur.com/rDlsrgS\">https://imgur.com/rDlsrgS</a></p></li><li><p>portrait (with <a target=\"_blank\" rel=\"ugc\" href=\"https://civitai.com/models/4514/pure-eros-face\">PureErosFace</a>): <a target=\"_blank\" rel=\"ugc\" href=\"https://imgur.com/1Lqq595\">https://imgur.com/1Lqq595</a> <a target=\"_blank\" rel=\"ugc\" href=\"https://imgur.com/V5kXBXz\">https://imgur.com/V5kXBXz</a></p></li><li><p>fusion body fix:</p><p><img src=\"https://imagecache.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/ac167975-eadc-4c28-e87e-0d8ed2bec000/width=525\" /><img src=\"https://imagecache.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/61bd2d45-b21e-47dd-a9c4-cbad326dc200/width=525\" /></p><p></p></li></ul><p></p><h3 id=\"heading-79\">How is it work?</h3><p>I tried to make SD learn what is really disgusting with deepdream algorithm, the dataset is imagenet-mini (1000 images chosen randomly from the dataset again)</p><p>deepdream is <strong>REALLLLLLLLLLLLLLLLLLLLLY</strong> disgusting 🤮 and process of training this model really made me experience physical discomfort 😂</p><p></p><h3 id=\"heading-80\">Backup</h3><p><a target=\"_blank\" rel=\"ugc\" href=\"https://huggingface.co/lenML/DeepNegative/tree/main\">https://huggingface.co/lenML/DeepNegative/tree/main</a></p>",
+      "allowNoCredit": false,
+      "allowCommercialUse": ["Image", "RentCivit", "Rent"],
+      "allowDerivatives": true,
+      "allowDifferentLicense": false,
+      "type": "TextualInversion",
+      "minor": false,
+      "poi": false,
+      "nsfw": false,
+      "nsfwLevel": 7,
+      "cosmetic": null,
+      "stats": {
+        "downloadCount": 398161,
+        "favoriteCount": 0,
+        "thumbsUpCount": 23319,
+        "thumbsDownCount": 12,
+        "commentCount": 74,
+        "ratingCount": 0,
+        "rating": 0,
+        "tippedAmountCount": 6243
+      },
+      "creator": {
+        "username": "lenML",
+        "image": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/625d4b36-c648-4a5d-5282-f35fe7cdd100/width=96/lenML.jpeg"
+      },
+      "tags": ["concept", "negative", "negative embedding"],
+      "modelVersions": [
+        {
+          "id": 5637,
+          "index": 0,
+          "name": "V1 75T",
+          "baseModel": "SD 1.5",
+          "baseModelType": "Standard",
+          "publishedAt": "2023-01-20T14:18:30.815Z",
+          "availability": "Public",
+          "nsfwLevel": 5,
+          "description": "<p>put it in <strong>negative</strong> prompts</p>",
+          "trainedWords": ["ng_deepnegative_v1_75t"],
+          "stats": {
+            "downloadCount": 375659,
+            "ratingCount": 8218,
+            "rating": 4.98,
+            "thumbsUpCount": 13434,
+            "thumbsDownCount": 12
+          },
+          "files": [
+            {
+              "id": 5845,
+              "sizeKB": 225.9169921875,
+              "name": "ng_deepnegative_v1_75t.pt",
+              "type": "Model",
+              "pickleScanResult": "Success",
+              "pickleScanMessage": "**Detected Pickle imports (3)**\n```\ncollections.OrderedDict\ntorch._utils._rebuild_tensor_v2\ntorch.FloatStorage\n```",
+              "virusScanResult": "Success",
+              "virusScanMessage": null,
+              "scannedAt": "2023-01-20T14:32:14.256Z",
+              "metadata": {
+                "format": "PickleTensor",
+                "size": "full",
+                "fp": "fp16"
+              },
+              "hashes": {
+                "AutoV2": "54E7E4826D",
+                "SHA256": "54E7E4826D53949A3D0DDE40AEA023B1E456A618C608A7630E3999FD38F93245",
+                "CRC32": "0C1E6878",
+                "BLAKE3": "CD204591E66D17AFB31359C6EFEE88AAA20B5B257F06F284BB57CF4BB939914E"
+              },
+              "downloadUrl": "https://civitai.com/api/download/models/5637",
+              "primary": true
+            }
+          ],
+          "images": [
+            {
+              "id": 45555,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/f7fe0b31-86a6-48ff-4fc2-906227af9300/width=450/45555.jpeg",
+              "nsfwLevel": 4,
+              "width": 2048,
+              "height": 1784,
+              "hash": "UfKdSjbHjZbH_NayWUf8_3ayjZt7.8WBWVWB",
+              "type": "image"
+            },
+            {
+              "id": 45554,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/117e30bd-c869-4735-3d02-512881a98e00/width=450/45554.jpeg",
+              "nsfwLevel": 1,
+              "width": 2048,
+              "height": 904,
+              "hash": "UbK^]GsoS2rs_NWEn$t7_3WVWqWB?cWBoMNG",
+              "type": "image"
+            },
+            {
+              "id": 45553,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/310c34a0-8b9f-4bc8-7c2d-0ab5112d6100/width=450/45553.jpeg",
+              "nsfwLevel": 1,
+              "width": 2048,
+              "height": 1784,
+              "hash": "UhIWsBaeWBjZ?^WUaybb?vaybGof_3a#jZn*",
+              "type": "image"
+            },
+            {
+              "id": 45559,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/ee7cfb2f-f3f7-4d5e-7d07-7d5c20855e00/width=450/45559.jpeg",
+              "nsfwLevel": 1,
+              "width": 2048,
+              "height": 1180,
+              "hash": "UiIh$^sokCxb~pe.j]oc?bWBWoWY~VbHaykW",
+              "type": "image"
+            }
+          ],
+          "downloadUrl": "https://civitai.com/api/download/models/5637"
+        },
+        {
+          "id": 5638,
+          "index": 1,
+          "name": "V1 64T",
+          "baseModel": "SD 1.5",
+          "baseModelType": "Standard",
+          "publishedAt": "2023-01-20T14:18:30.815Z",
+          "availability": "Public",
+          "nsfwLevel": 5,
+          "description": "<p>put it in <strong>negative</strong> prompts</p>",
+          "trainedWords": ["ng_deepnegative_v1_64t"],
+          "stats": {
+            "downloadCount": 6838,
+            "ratingCount": 7679,
+            "rating": 5,
+            "thumbsUpCount": 10174,
+            "thumbsDownCount": 0
+          },
+          "files": [
+            {
+              "id": 5846,
+              "sizeKB": 192.9169921875,
+              "name": "ng_deepnegative_v1_64t.pt",
+              "type": "Model",
+              "pickleScanResult": "Success",
+              "pickleScanMessage": "**Detected Pickle imports (3)**\n```\ncollections.OrderedDict\ntorch.FloatStorage\ntorch._utils._rebuild_tensor_v2\n```",
+              "virusScanResult": "Success",
+              "virusScanMessage": null,
+              "scannedAt": "2023-01-20T14:34:59.456Z",
+              "metadata": {
+                "format": "PickleTensor",
+                "size": "full",
+                "fp": "fp16"
+              },
+              "hashes": {
+                "AutoV2": "3F2693E926",
+                "SHA256": "3F2693E92692B4CC01E9C3166986DB52C215AB4DF68BE8C8424E41F9BBD4C070",
+                "CRC32": "18BC0D5C",
+                "BLAKE3": "706A60B05ABD23B973269FB51B684E92DBF41B37F623337F958AECF5CF3CEDA0"
+              },
+              "downloadUrl": "https://civitai.com/api/download/models/5638",
+              "primary": true
+            }
+          ],
+          "images": [
+            {
+              "id": 45558,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/4343f12a-d8a6-422b-92ab-c945359bdc00/width=450/45558.jpeg",
+              "nsfwLevel": 4,
+              "width": 1536,
+              "height": 893,
+              "hash": "UcKB8oocjYt7%gflj[WB_3aej[of~qWVj[j]",
+              "type": "image"
+            },
+            {
+              "id": 45557,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/aeee4c92-4793-44d2-efe4-1489cdc11000/width=450/45557.jpeg",
+              "nsfwLevel": 1,
+              "width": 1536,
+              "height": 893,
+              "hash": "UbH.7;s:kCWV?bRjj[of?bayjtj[~qWBoLof",
+              "type": "image"
+            },
+            {
+              "id": 45556,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/47eb8462-329c-49c6-a946-67b370b30500/width=450/45556.jpeg",
+              "nsfwLevel": 1,
+              "width": 3072,
+              "height": 904,
+              "hash": "UhF65:W=ozoz?co0jZoe-qWBayWV~qR*ofax",
+              "type": "image"
+            },
+            {
+              "id": 45560,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/bb374752-ef42-4052-5d15-7ae852f5ab00/width=450/45560.jpeg",
+              "nsfwLevel": 1,
+              "width": 2048,
+              "height": 1784,
+              "hash": "UgH2.ktSWUt6_4RjWBjr^,RjaejY?baxoeWB",
+              "type": "image"
+            }
+          ],
+          "downloadUrl": "https://civitai.com/api/download/models/5638"
+        },
+        {
+          "id": 5287,
+          "index": 2,
+          "name": "V1 2T",
+          "baseModel": "SD 1.5",
+          "baseModelType": "Standard",
+          "publishedAt": "2023-01-16T12:50:42.292Z",
+          "availability": "Public",
+          "nsfwLevel": 3,
+          "description": "<p>put it in <strong>negative</strong> prompts</p>",
+          "trainedWords": ["ng_deepnegative_v1_2t"],
+          "stats": {
+            "downloadCount": 4198,
+            "ratingCount": 83,
+            "rating": 5,
+            "thumbsUpCount": 92,
+            "thumbsDownCount": 0
+          },
+          "files": [
+            {
+              "id": 5432,
+              "sizeKB": 6.9169921875,
+              "name": "ng_deepnegative_v1_2t.pt",
+              "type": "Model",
+              "pickleScanResult": "Success",
+              "pickleScanMessage": "**Detected Pickle imports (3)**\n```\ntorch.FloatStorage\ncollections.OrderedDict\ntorch._utils._rebuild_tensor_v2\n```",
+              "virusScanResult": "Success",
+              "virusScanMessage": null,
+              "scannedAt": "2023-01-16T13:13:14.775Z",
+              "metadata": {
+                "format": "PickleTensor",
+                "size": "full",
+                "fp": "fp16"
+              },
+              "hashes": {
+                "AutoV2": "43483653FD",
+                "SHA256": "43483653FD2ABC807AFF08F95D31CE62B3A3CF9C2A2FE43D0C6760DEE55ED8E6",
+                "CRC32": "AA3376C6",
+                "BLAKE3": "AE3646135D6D5AB9DDF7C7F4982D4416DC7CE76A04BFC10B67774642BE1D4697"
+              },
+              "downloadUrl": "https://civitai.com/api/download/models/5287",
+              "primary": true
+            }
+          ],
+          "images": [
+            {
+              "id": 40960,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/b474ecd6-170b-4842-b494-0007423ab800/width=450/40960.jpeg",
+              "nsfwLevel": 1,
+              "width": 2432,
+              "height": 3161,
+              "hash": "UdK^~f~q_3?ut7j[a|jst7ayWBayt7ayjsj[",
+              "type": "image"
+            },
+            {
+              "id": 40844,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/b6b56c5a-6415-4daa-2510-b00fa5c64b00/width=450/40844.jpeg",
+              "nsfwLevel": 1,
+              "width": 2432,
+              "height": 4733,
+              "hash": "UdIh?S~p_3_3xZj]aya}t7aeayayxua|ayfQ",
+              "type": "image"
+            },
+            {
+              "id": 40843,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/c237a176-8cbf-426a-5b94-58db2a1bf200/width=450/40843.jpeg",
+              "nsfwLevel": 1,
+              "width": 2944,
+              "height": 2125,
+              "hash": "UZIhW}_4_2?vWAoJkDoIt6WUa#fRkXj[oLj?",
+              "type": "image"
+            },
+            {
+              "id": 40848,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/c65a8ae2-fcfe-42be-f6d0-e5f6dd8c5600/width=450/40848.jpeg",
+              "nsfwLevel": 1,
+              "width": 3456,
+              "height": 3161,
+              "hash": "USKKA@_3?^_3%haxaxf5%MWBafaxyEjEayjY",
+              "type": "image"
+            },
+            {
+              "id": 40936,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/29c215b8-654f-4738-2175-b7764aabb800/width=450/40936.jpeg",
+              "nsfwLevel": 2,
+              "width": 3456,
+              "height": 3161,
+              "hash": "ULM7ZB_N~q_N%gWBjZax%MWVayWB%gayjZWB",
+              "type": "image"
+            }
+          ],
+          "downloadUrl": "https://civitai.com/api/download/models/5287"
+        },
+        {
+          "id": 5279,
+          "index": 3,
+          "name": "V1 4T",
+          "baseModel": "SD 1.5",
+          "baseModelType": "Standard",
+          "publishedAt": "2023-01-16T12:36:33.858Z",
+          "availability": "Public",
+          "nsfwLevel": 1,
+          "description": "<p>put it in <strong>negative</strong> prompts</p>",
+          "trainedWords": ["ng_deepnegative_v1_4t"],
+          "stats": {
+            "downloadCount": 4154,
+            "ratingCount": 7,
+            "rating": 4.86,
+            "thumbsUpCount": 96,
+            "thumbsDownCount": 0
+          },
+          "files": [
+            {
+              "id": 5424,
+              "sizeKB": 12.9169921875,
+              "name": "ng_deepnegative_v1_4t.pt",
+              "type": "Model",
+              "pickleScanResult": "Success",
+              "pickleScanMessage": "**Detected Pickle imports (3)**\n```\ncollections.OrderedDict\ntorch._utils._rebuild_tensor_v2\ntorch.FloatStorage\n```",
+              "virusScanResult": "Success",
+              "virusScanMessage": null,
+              "scannedAt": "2023-01-16T12:43:15.504Z",
+              "metadata": {
+                "format": "PickleTensor",
+                "size": "full",
+                "fp": "fp16"
+              },
+              "hashes": {
+                "AutoV2": "6FD7D5F1C2",
+                "SHA256": "6FD7D5F1C28C38DB1074EA99904653AD1F1A9C67E9594C3B03321423818FA60B",
+                "CRC32": "794F72D6",
+                "BLAKE3": "98BC2D5ED3E01DB2C906416C7FFF221785FEFC813C31DF4B1B749F78B1ED1CDB"
+              },
+              "downloadUrl": "https://civitai.com/api/download/models/5279",
+              "primary": true
+            }
+          ],
+          "images": [
+            {
+              "id": 40808,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/21b5f746-aa9c-4512-73dc-c5d3c086be00/width=450/40808.jpeg",
+              "nsfwLevel": 1,
+              "width": 2944,
+              "height": 2629,
+              "hash": "UYF=]r~q~q_3xubHj[ayxuWBayax%Mayf6ay",
+              "type": "image"
+            },
+            {
+              "id": 40809,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/a21109c4-d82c-4755-88b1-a171415a3b00/width=450/40809.jpeg",
+              "nsfwLevel": 1,
+              "width": 2944,
+              "height": 2629,
+              "hash": "UcI;;M_3_4?ct7kCjabHtRWBjZayxtj@a#j@",
+              "type": "image"
+            }
+          ],
+          "downloadUrl": "https://civitai.com/api/download/models/5279"
+        },
+        {
+          "id": 5280,
+          "index": 4,
+          "name": "V1 16T",
+          "baseModel": "SD 1.5",
+          "baseModelType": "Standard",
+          "publishedAt": "2023-01-16T12:36:33.858Z",
+          "availability": "Public",
+          "nsfwLevel": 1,
+          "description": "<p>put it in <strong>negative</strong> prompts</p>",
+          "trainedWords": ["ng_deepnegative_v1_16t"],
+          "stats": {
+            "downloadCount": 3508,
+            "ratingCount": 2,
+            "rating": 5,
+            "thumbsUpCount": 4,
+            "thumbsDownCount": 0
+          },
+          "files": [
+            {
+              "id": 5425,
+              "sizeKB": 48.9169921875,
+              "name": "ng_deepnegative_v1_16t.pt",
+              "type": "Model",
+              "pickleScanResult": "Success",
+              "pickleScanMessage": "**Detected Pickle imports (3)**\n```\ntorch.FloatStorage\ntorch._utils._rebuild_tensor_v2\ncollections.OrderedDict\n```",
+              "virusScanResult": "Success",
+              "virusScanMessage": null,
+              "scannedAt": "2023-01-16T12:46:05.804Z",
+              "metadata": {
+                "format": "PickleTensor",
+                "size": "full",
+                "fp": "fp16"
+              },
+              "hashes": {
+                "AutoV2": "85B119497E",
+                "SHA256": "85B119497E9671F648A95E327847D17248817EDB0AF0AC2BC5DD34CEEB2345F8",
+                "CRC32": "A5CFA5BF",
+                "BLAKE3": "179B7208B8A31B07D951DC84681210A500C8CA1795F7CBFD3C2857E937E11284"
+              },
+              "downloadUrl": "https://civitai.com/api/download/models/5280",
+              "primary": true
+            }
+          ],
+          "images": [
+            {
+              "id": 40845,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/d4f6f440-c53a-4d51-744b-4a5304f4c500/width=450/40845.jpeg",
+              "nsfwLevel": 1,
+              "width": 2944,
+              "height": 2629,
+              "hash": "UZFkdZ^%~C^*v|kDj]bbxZayaya}w]a#bbbH",
+              "type": "image"
+            },
+            {
+              "id": 40811,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/a8eb392e-4a1c-460d-16eb-ba2d88e91900/width=450/40811.jpeg",
+              "nsfwLevel": 1,
+              "width": 2944,
+              "height": 2629,
+              "hash": "UUJ[9k~q_3_3x^jsjYjZtRWBayaxx^axf5f5",
+              "type": "image"
+            },
+            {
+              "id": 40810,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/e6c54d00-4700-4cae-b944-5d801bbd4c00/width=450/40810.jpeg",
+              "nsfwLevel": 1,
+              "width": 2944,
+              "height": 2629,
+              "hash": "UaJkM{^+_4?bxtj[j]fit7ayayayxuaza{fQ",
+              "type": "image"
+            }
+          ],
+          "downloadUrl": "https://civitai.com/api/download/models/5280"
+        },
+        {
+          "id": 5281,
+          "index": 5,
+          "name": "V1 32T",
+          "baseModel": "SD 1.5",
+          "baseModelType": "Standard",
+          "publishedAt": "2023-01-16T12:36:33.858Z",
+          "availability": "Public",
+          "nsfwLevel": 1,
+          "description": "<p>put it in <strong>negative</strong> prompts</p>",
+          "trainedWords": ["ng_deepnegative_v1_32t"],
+          "stats": {
+            "downloadCount": 3804,
+            "ratingCount": 1,
+            "rating": 5,
+            "thumbsUpCount": 9,
+            "thumbsDownCount": 0
+          },
+          "files": [
+            {
+              "id": 5426,
+              "sizeKB": 96.9169921875,
+              "name": "ng_deepnegative_v1_32t.pt",
+              "type": "Model",
+              "pickleScanResult": "Success",
+              "pickleScanMessage": "**Detected Pickle imports (3)**\n```\ntorch._utils._rebuild_tensor_v2\ntorch.FloatStorage\ncollections.OrderedDict\n```",
+              "virusScanResult": "Success",
+              "virusScanMessage": null,
+              "scannedAt": "2023-01-16T12:48:43.934Z",
+              "metadata": {
+                "format": "PickleTensor",
+                "size": "full",
+                "fp": "fp16"
+              },
+              "hashes": {
+                "AutoV2": "4B1A22A155",
+                "SHA256": "4B1A22A155E90866E27C4F928575F53DBBD8E9FB9250F8C5E073B428BB9E338F",
+                "CRC32": "9BF2EEC3",
+                "BLAKE3": "3190F070D1D91311BFD79C60DA7D36CB518F02B47D34EF7E2DBCEAAF73271464"
+              },
+              "downloadUrl": "https://civitai.com/api/download/models/5281",
+              "primary": true
+            }
+          ],
+          "images": [
+            {
+              "id": 40812,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/593a02b9-1c84-4d64-ea71-4ad220112300/width=450/40812.jpeg",
+              "nsfwLevel": 1,
+              "width": 2944,
+              "height": 3929,
+              "hash": "UWH.sZ~W_3_3xaflj]fjt7ayayayxuj?ayjs",
+              "type": "image"
+            }
+          ],
+          "downloadUrl": "https://civitai.com/api/download/models/5281"
+        }
+      ]
+    },
+    {
+      "id": 16993,
+      "name": "badhandv4",
+      "description": "<h1 id=\"heading-1238\"><strong>介绍（Chinese Version）</strong></h1><h2 id=\"heading-1239\"><strong>简介</strong></h2><p>此文本嵌入（text embedding）为 <strong><span style=\"color:#fa5252\">负面文本嵌入</span></strong>。它能够在对画风影响较小的前提下改善AI生成图片的手部细节。如果它让你的模型表现得比以前更糟，请勿使用它。您可与其他负面文本嵌入一同使用。虽然它是为 AnimeIllustDiffusion 模型设计的，但您也可以在其他模型上使用。</p><p>它<strong>似乎</strong>在较高的 CFG Scale 下（&gt;=11）表现得更好。</p><p></p><h2 id=\"heading-1240\"><strong>如何使用</strong></h2><p><strong>对于 AUTOMATIC1111 WebUI 用户</strong></p><ol><li><p>下载模型文件 <a target=\"_blank\" rel=\"ugc\" href=\"http://badhandv4.pt\">badhandv4.pt</a>；</p></li><li><p>将模型文件放置于您 Stable Diffusion WebUI 目录下的 \"embeddings\" 文件夹内；</p></li><li><p>打开 WebUI，在负面提示词框内填入 “badhandv4” 以触发效果。</p></li></ol><p></p><p><strong>对于 ComfuUI 用户</strong></p><ol><li><p>下载模型文件 <a target=\"_blank\" rel=\"ugc\" href=\"http://badhandv4.pt\">badhandv4.pt</a>；</p></li><li><p>将模型文件放置于您 ComfyUI 目录下的 \"models/embeddings\" 文件夹内；</p></li><li><p>打开 ComfyUI，在 <strong>负面提示词框内 </strong>填入 “embedding:badhandv4” 以触发效果。</p></li></ol><p></p><h2 id=\"heading-1241\"><strong>SDXL 版本</strong></h2><p>我将 badhandv4 移植到了 SDXL 格式的 embedding 上。下载地址参见：</p><p><a target=\"_blank\" rel=\"ugc\" href=\"https://civitai.com/models/144327/negative-embeddings-aidxl-series-models\">Negative Embeddings - AIDXL Series Models - v0.4 | Stable Diffusion Embedding | Civitai</a></p><p></p><h1 id=\"heading-1242\"><strong>Introduction</strong> (英文版本)</h1><h2 id=\"heading-13\"><strong>Introduction</strong></h2><p>This text embedding is a <strong><span style=\"color:#fa5252\">negative text embedding</span></strong>. It can improve the hand details of AI-generated images with less impact on the style of painting. If it makes your model behave worse than before, please do not use it. You can use it with other negative text embeddings.</p><p>Although it was designed for AnimeIllustDiffusion model, you can use it on other models as well.</p><p>It performs better with higher CFG scale (&gt;=11).</p><p></p><h2 id=\"heading-1244\"><strong>Quick Start</strong></h2><p><strong>For AUTOMATIC1111 WebUI User</strong></p><ol><li><p>Download model file <a target=\"_blank\" rel=\"ugc\" href=\"http://badhandv4.pt\">badhandv4.pt</a>;</p></li><li><p>Move the model file to the \"embeddings\" folder in your Stable Diffusion WebUI directory;</p></li><li><p>Lanuch WebUI. Enter \"badhandv4\" into the <strong>negative prompt</strong> box to trigger its effect.</p></li></ol><p></p><p><strong>For ComfyUI User</strong></p><ol><li><p>Download model file <a target=\"_blank\" rel=\"ugc\" href=\"http://badhandv4.pt\">badhandv4.pt</a>;</p></li><li><p>Move the model file to the \"models/embeddings\" folder in your ComfyUI directory;</p></li><li><p>Lanuch ComfyUI. Enter \"embedding:badhandv4\" into the negative prompt box to trigger its effect.</p></li></ol><p></p><h2 id=\"heading-1245\"><strong>SDXL version</strong></h2><p>I converted badhandv4 to SDXL format embedding.<span style=\"color:rgb(60, 64, 67)\"> </span>For downloading, see:</p><p><a target=\"_blank\" rel=\"ugc\" href=\"https://civitai.com/models/144327/negative-embeddings-aidxl-series-models\">Negative Embeddings - AIDXL Series Models - v0.4 | Stable Diffusion Embedding | Civitai</a></p>",
+      "allowNoCredit": true,
+      "allowCommercialUse": ["Image", "RentCivit", "Rent"],
+      "allowDerivatives": true,
+      "allowDifferentLicense": true,
+      "type": "TextualInversion",
+      "minor": false,
+      "poi": false,
+      "nsfw": false,
+      "nsfwLevel": 3,
+      "cosmetic": null,
+      "stats": {
+        "downloadCount": 275090,
+        "favoriteCount": 0,
+        "thumbsUpCount": 16986,
+        "thumbsDownCount": 10,
+        "commentCount": 40,
+        "ratingCount": 0,
+        "rating": 0,
+        "tippedAmountCount": 60
+      },
+      "creator": {
+        "username": "Euge_",
+        "image": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/f59d1991-04ab-4cce-387e-2e90e7603700/width=96/Euge_.jpeg"
+      },
+      "tags": ["anime", "textual inversion", "style"],
+      "modelVersions": [
+        {
+          "id": 20068,
+          "index": 0,
+          "name": "badhandv4",
+          "baseModel": "Other",
+          "baseModelType": "Standard",
+          "publishedAt": "2023-03-08T03:43:03.750Z",
+          "availability": "Public",
+          "nsfwLevel": 3,
+          "description": null,
+          "trainedWords": ["badhandv4"],
+          "stats": {
+            "downloadCount": 275090,
+            "ratingCount": 12108,
+            "rating": 4.99,
+            "thumbsUpCount": 16986,
+            "thumbsDownCount": 10
+          },
+          "files": [
+            {
+              "id": 16755,
+              "sizeKB": 18.9169921875,
+              "name": "badhandv4.pt",
+              "type": "Model",
+              "pickleScanResult": "Success",
+              "pickleScanMessage": "No Pickle imports",
+              "virusScanResult": "Success",
+              "virusScanMessage": null,
+              "scannedAt": "2023-03-08T03:46:27.344Z",
+              "metadata": {
+                "format": "PickleTensor",
+                "size": "full",
+                "fp": "fp16"
+              },
+              "hashes": {
+                "AutoV2": "5E40D722FC",
+                "SHA256": "5E40D722FC3D0C2DECB62DEBFAF8058DB30CCDAE9AB00FF64B183907B435708E",
+                "CRC32": "0BB5F649",
+                "BLAKE3": "AA841F9EF2C4E444FD4D52DAED713DF61BE9EADD9794C1A4607FF119EEDAB9CB"
+              },
+              "downloadUrl": "https://civitai.com/api/download/models/20068",
+              "primary": true
+            }
+          ],
+          "images": [
+            {
+              "id": 212048,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/45318cc7-231d-4d8a-044d-a081d0a40700/width=450/212048.jpeg",
+              "nsfwLevel": 1,
+              "width": 1280,
+              "height": 1074,
+              "hash": "UbLD=WE2bE9v~oahWBW?.9ognjtRyFs+j[s:",
+              "type": "image"
+            },
+            {
+              "id": 212050,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/6b099945-aac7-4eab-7a19-19e5bc064e00/width=450/212050.jpeg",
+              "nsfwLevel": 1,
+              "width": 1280,
+              "height": 1074,
+              "hash": "UaJRddj]fRxt_Nayayj]-;kCfkoz-;WCj[ay",
+              "type": "image"
+            },
+            {
+              "id": 212049,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/af56f40a-9fb6-498e-81ef-50cab1bf5200/width=450/212049.jpeg",
+              "nsfwLevel": 2,
+              "width": 1280,
+              "height": 1074,
+              "hash": "UrKeAzngWBt6~qo0WWoe%MbIf6kCxua}ofa#",
+              "type": "image"
+            }
+          ],
+          "downloadUrl": "https://civitai.com/api/download/models/20068"
+        }
+      ]
+    },
+    {
+      "id": 56519,
+      "name": "negative_hand Negative Embedding ",
+      "description": "<h2>negative_hand Negative Embedding</h2><h3>Problem with Negative Embedding's</h3><p>Currently, there are more and more negative embedding, while many are also very good and easy to use. However, almost all of them currently have a big problem... They change the main or initial artstyle of the used model. Best example would be my bad_prompt_version2 Negative Embedding. It helps enormously with the quality of an image, but drastically changes the artstyle of the model. That's not the point of it. For this reason, I have now trained my new Negative Embedding negative_hand!</p><p>An example of the issue:</p><p><a target=\"_blank\" rel=\"ugc\" href=\"https://civitai.com/images/667829?modelVersionId=60938&amp;prioritizedUserIds=162020&amp;period=AllTime&amp;sort=Most%20Reactions&amp;limit=20\">Image Link</a></p><p></p><h3>So what is negative_hand?</h3><p>negative_hand is supposed to fix the said issue. That means it should improve the quality of the image, but without changing the initial artstyle of the model.</p><p>Pro:</p><ul><li><p>The artstyle of the model can be used without any problems and without possible artstyle changes.</p></li><li><p>The quality of the image and incorrect anatomy like hands are improved.</p></li></ul><p>Con:</p><ul><li><p>Since this embedding cannot drastically change the artstyle and composition of the image, not one hundred percent of any faulty anatomy can be improved.</p></li></ul><p></p><h3>Usage</h3><p>To use this embedding you have to download the file aswell as drop it into the \"\\stable-diffusion-webui\\embeddings\" folder.</p><p><strong>Please put the embedding in the negative prompt to get the right results!</strong></p><p>For special negative tags such as \"malformed sword\", you still need to add them yourself. The negative embedding is trained on a basic skeleton for the negative prompt, which should provide a high-resolution image as a result.</p>",
+      "allowNoCredit": false,
+      "allowCommercialUse": ["Image", "RentCivit", "Rent"],
+      "allowDerivatives": true,
+      "allowDifferentLicense": true,
+      "type": "TextualInversion",
+      "minor": false,
+      "poi": false,
+      "nsfw": false,
+      "nsfwLevel": 1,
+      "cosmetic": null,
+      "stats": {
+        "downloadCount": 271623,
+        "favoriteCount": 0,
+        "thumbsUpCount": 14370,
+        "thumbsDownCount": 12,
+        "commentCount": 59,
+        "ratingCount": 0,
+        "rating": 0,
+        "tippedAmountCount": 100
+      },
+      "creator": {
+        "username": "Nerfgun3",
+        "image": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/6d89b406-336b-44f6-ea07-c4e1c2db8800/width=96/Nerfgun3.jpeg"
+      },
+      "tags": ["concept", "negative embedding", "bad prompt"],
+      "modelVersions": [
+        {
+          "id": 60938,
+          "index": 0,
+          "name": "negative_hand",
+          "baseModel": "SD 1.5",
+          "baseModelType": "Standard",
+          "publishedAt": "2023-05-02T23:14:02.252Z",
+          "availability": "Public",
+          "nsfwLevel": 1,
+          "description": "<p>~initial upload~</p>",
+          "trainedWords": ["negative_hand"],
+          "stats": {
+            "downloadCount": 271623,
+            "ratingCount": 8744,
+            "rating": 4.98,
+            "thumbsUpCount": 14370,
+            "thumbsDownCount": 12
+          },
+          "files": [
+            {
+              "id": 43127,
+              "sizeKB": 24.9345703125,
+              "name": "negative_hand-neg.pt",
+              "type": "Negative",
+              "pickleScanResult": "Success",
+              "pickleScanMessage": "No Pickle imports",
+              "virusScanResult": "Success",
+              "virusScanMessage": null,
+              "scannedAt": "2023-05-02T23:16:21.914Z",
+              "metadata": {
+                "format": "Other",
+                "size": null,
+                "fp": null
+              },
+              "hashes": {
+                "AutoV2": "73B524A2DA",
+                "SHA256": "73B524A2DA121EB1B7AD04DEA11DA286277813120700FF8F1D8522516F7B30AB",
+                "CRC32": "9A87199B",
+                "BLAKE3": "0924C878FD868BFB103C55EA9BFAE51D265BB31D4095F1CA252F14B88FE93F2B"
+              },
+              "downloadUrl": "https://civitai.com/api/download/models/60938",
+              "primary": true
+            }
+          ],
+          "images": [
+            {
+              "id": 667878,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/1de1b4da-e9eb-43bf-9e9c-050e51cbbb25/width=450/667878.jpeg",
+              "nsfwLevel": 1,
+              "width": 2304,
+              "height": 1450,
+              "hash": "U{N0*lofkCt6~qofj[j[kWayj[WVayWBj[ay",
+              "type": "image"
+            },
+            {
+              "id": 667876,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/1879056f-9bc8-4914-b1bd-6a9495dbd037/width=450/667876.jpeg",
+              "nsfwLevel": 1,
+              "width": 2304,
+              "height": 1450,
+              "hash": "UePi^%bvoys:_NoLofkD_NaKoJWBIAozozof",
+              "type": "image"
+            },
+            {
+              "id": 667879,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/342ad8dc-0677-4585-9da8-482de1b107c5/width=450/667879.jpeg",
+              "nsfwLevel": 1,
+              "width": 2304,
+              "height": 1450,
+              "hash": "UkOpuzx[oz%M~pV@ofWBtRafj]fP%Mj[ofjZ",
+              "type": "image"
+            },
+            {
+              "id": 667877,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/7226994c-10c2-4270-b145-79c6fb888811/width=450/667877.jpeg",
+              "nsfwLevel": 1,
+              "width": 2304,
+              "height": 1450,
+              "hash": "UuNS]PoboJs:_NbIkCa#x]a#oMbH?bjsofof",
+              "type": "image"
+            },
+            {
+              "id": 667880,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/b3ef345e-01a8-4f0f-af20-3a6d4811bcad/width=450/667880.jpeg",
+              "nsfwLevel": 1,
+              "width": 2304,
+              "height": 1450,
+              "hash": "UwOWKco}bvt7_NadjFj[x]bHj[ayxtfkofae",
+              "type": "image"
+            },
+            {
+              "id": 671892,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/22b0d6e3-a955-42fb-8e96-a1e295152bb3/width=450/671892.jpeg",
+              "nsfwLevel": 1,
+              "width": 2304,
+              "height": 1450,
+              "hash": "UbOWgAxuoMxu~qWCt7fkx]WAt7Rj_3oMflt7",
+              "type": "image"
+            }
+          ],
+          "downloadUrl": "https://civitai.com/api/download/models/60938"
+        }
+      ]
+    },
+    {
+      "id": 3036,
+      "name": "CharTurner - Character Turnaround helper for 1.5 AND 2.1!",
+      "description": "<h1>CharTurner</h1><p>Edit: <strong>controlNet</strong> works <strong>great </strong>with this. Charturner keeps the outfit consistent, controlNet openPose keeps the turns under control. </p><p><strong>Three versions,</strong> scroll down to pick the right one for you.</p><p>If you're unsure of what version you are running, it's <em>probably</em> 1.5, as it is more popular, but 2.1 is newer and gaining ground fast.</p><p><strong>Version 2, for 2.0 and 2.1 models<br />Version 2, for 1.5 models<br />Version 1, for 1.5 models</strong></p><p>BONUS: <a target=\"_blank\" rel=\"ugc\" href=\"https://civitai.com/models/7252/charturnerbeta-lora-experimental\">Experimental </a>LORA released<br />used at your own risk. :D (mixes well tho)</p><p>Hey there! I'm a working artist, and I loathe doing character turnarounds, I find it the least fun part of character design. I've been working on an embedding that helps with this process, and, though it's not where I want it to be, I was encouraged to release it under the <a target=\"_blank\" rel=\"ugc\" href=\"https://en.wikipedia.org/wiki/Minimum_viable_product\"><u>MVP</u></a> principle.</p><p>I'm also working on a few more character embeddings, including a head turn around and an expression sheet. They're still way too raw to release tho.</p><p>Is there some type of embedding that would be useful for you? Let me know, i'm having fun making tools to fix all the stuff I hate doing by hand.</p><p>v1 is still a little bit... fiddly.</p><ul><li><p>Sampler: I use DPM++ 2m Karras or DDIM most often.</p></li><li><p>Highres. fix ON for best results</p></li><li><p>landscape orientation will get you more 'turns'; square images tend toward just front and back.</p></li><li><p>I like <a target=\"_blank\" rel=\"ugc\" href=\"https://civitai.com/models/2540/elldreths-stolendreams-mix\"><u>https://civitai.com/models/2540/elldreths-stolendreams-mix</u></a> to make characters in.</p></li><li><p>I use an embedding trained on my own art (smoose) that I will release if people want it? But it's an aesthetic thing, just my own vibe.</p></li><li><p>I didn't really test this in any of the waifu/NAI type models, as I don't usually use them. Looks like it works but it probably has its own special dance.</p></li></ul><p>Things I'm working on for v2: EDIT: <strong>V2 out, see below! (also v2 2.1)</strong></p><ul><li><p>It fights you on style sometimes. I'm adding more various types of art styles to the dataset to combat this. -<strong> V2 has much better styles</strong></p></li><li><p>Open front coats and such tend to be open 'back' on the back view. Adding more types of clothing to the dataset to combat this. - <strong>Still has this problem</strong></p></li><li><p>Tends toward white and 'fit' characters, which isn't useful. Adding more diversity in body and skin tone to the dataset to combat this. - <strong>v2 Much more body and racial diversity added to the set, easier to get different results.</strong></p></li></ul><p>Helps create multiple full body views of a character. The intention is to get at least a front and back, and ideally, a front, 3/4, profile, 1/4 and back versions, in the same outfit.</p><p></p>",
+      "allowNoCredit": true,
+      "allowCommercialUse": ["Image", "RentCivit", "Rent"],
+      "allowDerivatives": true,
+      "allowDifferentLicense": true,
+      "type": "TextualInversion",
+      "minor": false,
+      "poi": false,
+      "nsfw": false,
+      "nsfwLevel": 7,
+      "cosmetic": null,
+      "stats": {
+        "downloadCount": 114534,
+        "favoriteCount": 0,
+        "thumbsUpCount": 14053,
+        "thumbsDownCount": 7,
+        "commentCount": 107,
+        "ratingCount": 0,
+        "rating": 0,
+        "tippedAmountCount": 240
+      },
+      "creator": {
+        "username": "mousewrites",
+        "image": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/bdfe115f-4430-4ee7-31bc-eff38f86c500/width=96/mousewrites.jpeg"
+      },
+      "tags": ["consistent character", "turnaround", "model sheet", "tool"],
+      "modelVersions": [
+        {
+          "id": 8387,
+          "index": 1,
+          "name": "CharTurner V2 - For 1.5",
+          "baseModel": "SD 1.5",
+          "baseModelType": "Standard",
+          "publishedAt": "2023-02-07T03:46:57.500Z",
+          "availability": "Public",
+          "nsfwLevel": 7,
+          "description": "<p>2.1 and LoRa versions coming soon.</p><p><strong>Prompt hints</strong>: format something like this: \"A character turnaround of a (X) wearing (Y). \" In some of the prompts the token is spelled differently: due to some technical issues with xformers, I trained this badboy about 40 times, and some of the examples are from those trainings. All the same dataset, I promise.  Just change any weird token names to CharTurnerV2 if you use them.</p><p><strong>Token - \"CharTurnerV2\"</strong> place at the front for stronger effect, place at the end for a weaker effect. Token weighting works too</p><p><strong>Add</strong>:</p><ul><li><p>\"Multiple views of the same character in the same outfit\"</p></li><li><p>Add original CharTurner to mix back in some anime/turns</p></li><li><p>Add charTurner Lora (uploading soon) on top (at very low strength, like .3) to really force the turn. Will affect style.</p></li></ul><p>Next Version: (after the v2 lora and 2.1 versions): Looking for more variety for the data set! Post a review or comment with your best turn around (especially if it was a hard one to get it to do!) and I will use it in the V3 dataset.  </p>",
+          "trainedWords": ["charturnerv2"],
+          "stats": {
+            "downloadCount": 67066,
+            "ratingCount": 757,
+            "rating": 4.97,
+            "thumbsUpCount": 1430,
+            "thumbsDownCount": 6
+          },
+          "files": [
+            {
+              "id": 8384,
+              "sizeKB": 45.92578125,
+              "name": "charturnerv2.pt",
+              "type": "Model",
+              "pickleScanResult": "Success",
+              "pickleScanMessage": "No Pickle imports",
+              "virusScanResult": "Success",
+              "virusScanMessage": null,
+              "scannedAt": "2023-02-07T17:05:48.272Z",
+              "metadata": {
+                "format": "PickleTensor",
+                "size": "full",
+                "fp": "fp16"
+              },
+              "hashes": {
+                "AutoV2": "A91B570185",
+                "SHA256": "A91B570185766FF71F242F83D5BEB6D658348900EDB706A2092BA23D6E1E2CF8",
+                "CRC32": "F874123A",
+                "BLAKE3": "29322FB6F5E7C19E49F8C1CFEFE0C638BD47CF6BCE0778A7202F175816B4D26C"
+              },
+              "downloadUrl": "https://civitai.com/api/download/models/8387",
+              "primary": true
+            }
+          ],
+          "images": [
+            {
+              "id": 79565,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/6b404ab7-c1f1-4c56-8df6-3a5871faa100/width=450/79565.jpeg",
+              "nsfwLevel": 2,
+              "width": 2026,
+              "height": 2714,
+              "hash": "U9D+h~I;R+oeOUEMxa-V00~VNHE200IAkCoz",
+              "type": "image"
+            },
+            {
+              "id": 79564,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/b1a654d8-0ece-4488-1689-1dbf33b3b200/width=450/79564.jpeg",
+              "nsfwLevel": 1,
+              "width": 2178,
+              "height": 2506,
+              "hash": "U797Lo~VM{WX004:t7oe^+%MWBWCWBaxayj]",
+              "type": "image"
+            },
+            {
+              "id": 79563,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/f21f7b7e-7431-484e-5079-4f1c6501f000/width=450/79563.jpeg",
+              "nsfwLevel": 4,
+              "width": 2472,
+              "height": 2711,
+              "hash": "U6CF#COsK5Sd01w]M|jF00xY-Sso~pEht5bH",
+              "type": "image"
+            },
+            {
+              "id": 79562,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/ad240caa-1c18-40d9-de17-2569775d8b00/width=450/79562.jpeg",
+              "nsfwLevel": 1,
+              "width": 2201,
+              "height": 2047,
+              "hash": "U4DIg?hyTKy?00TJVsvf00.8ofEL%fnit7kC",
+              "type": "image"
+            },
+            {
+              "id": 79561,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/035cbefd-7770-424a-4a63-0ffb18dae200/width=450/79561.jpeg",
+              "nsfwLevel": 1,
+              "width": 1772,
+              "height": 2047,
+              "hash": "U7Bf;FxaIo%M00ayt7M{xuRjofof~qt8NGof",
+              "type": "image"
+            },
+            {
+              "id": 79560,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/1a9a83c6-faba-472e-77bf-c6d2f81da700/width=450/79560.jpeg",
+              "nsfwLevel": 1,
+              "width": 768,
+              "height": 536,
+              "hash": "U5H-_a~pE1WW00%LofR*kXD*t7t700D%bHof",
+              "type": "image"
+            },
+            {
+              "id": 79559,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/0b0550e6-1034-4b5b-63c7-e545545cfb00/width=450/79559.jpeg",
+              "nsfwLevel": 1,
+              "width": 816,
+              "height": 816,
+              "hash": "U5F;TjT1s.}q19bvoejF^QxDR*I=ZLenaeNw",
+              "type": "image"
+            },
+            {
+              "id": 79558,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/d102e6a2-3f44-49ea-33ab-47633f090c00/width=450/79558.jpeg",
+              "nsfwLevel": 2,
+              "width": 816,
+              "height": 608,
+              "hash": "ULI50xs.%MIU~qt7ofWCMxofR*t7D%WCaxof",
+              "type": "image"
+            },
+            {
+              "id": 79557,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/aff87e58-f731-42dc-7838-cc811e7e4700/width=450/79557.jpeg",
+              "nsfwLevel": 1,
+              "width": 944,
+              "height": 824,
+              "hash": "U9Kw|Mae4n4o4no0t7Rj~qjt%M-;?bNGt7xu",
+              "type": "image"
+            },
+            {
+              "id": 79556,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/f8ff5342-06a4-4a72-aa5f-11762c417a00/width=450/79556.jpeg",
+              "nsfwLevel": 1,
+              "width": 944,
+              "height": 944,
+              "hash": "UEG[+o$*aet6D%RkjsoL~pxut7R*Rjayayj[",
+              "type": "image"
+            },
+            {
+              "id": 79555,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/1c17c565-159c-46fc-0b5c-88fabdd5f400/width=450/79555.jpeg",
+              "nsfwLevel": 1,
+              "width": 1152,
+              "height": 768,
+              "hash": "U4FYos~W4--;=E%L%gM{00RjbHRk.9RPIUoz",
+              "type": "image"
+            },
+            {
+              "id": 79554,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/18958787-c944-4a1c-bc56-7030af946400/width=450/79554.jpeg",
+              "nsfwLevel": 1,
+              "width": 1056,
+              "height": 768,
+              "hash": "U3Bo{r~UnjM{sV%2xaE1XnIoof%L00D*of%M",
+              "type": "image"
+            },
+            {
+              "id": 79553,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/29e43c8c-b422-4a3c-46df-4f60b374cd00/width=450/79553.jpeg",
+              "nsfwLevel": 1,
+              "width": 1056,
+              "height": 768,
+              "hash": "U29jQ0baEKbF00NHIpM|~qI:NHR+00%1-U%1",
+              "type": "image"
+            },
+            {
+              "id": 79552,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/cb7ae492-cdd2-4e5c-12f0-7eb6acae5d00/width=450/79552.jpeg",
+              "nsfwLevel": 1,
+              "width": 816,
+              "height": 608,
+              "hash": "UBGbYTxaD%xtspjFxtjZ00ozx[V@~ptRIVRk",
+              "type": "image"
+            },
+            {
+              "id": 79551,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/14e626c1-9f57-40c0-fe7e-3196f5cd0100/width=450/79551.jpeg",
+              "nsfwLevel": 1,
+              "width": 688,
+              "height": 536,
+              "hash": "UGKKNE-o%2DjEgWBkCof?^M|WCt7jFs:j[WV",
+              "type": "image"
+            },
+            {
+              "id": 79550,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/322f9057-5c14-4b94-426e-95bcfd594400/width=450/79550.jpeg",
+              "nsfwLevel": 1,
+              "width": 816,
+              "height": 816,
+              "hash": "U7Ci{.?Hwdw^?Ht7aeoL_Nt7kCbb%gR*W;kD",
+              "type": "image"
+            }
+          ],
+          "downloadUrl": "https://civitai.com/api/download/models/8387"
+        },
+        {
+          "id": 9857,
+          "index": 2,
+          "name": "CharTurner V2 - For 2.1",
+          "baseModel": "SD 2.1",
+          "baseModelType": "Standard",
+          "publishedAt": "2023-02-12T22:44:01.442Z",
+          "availability": "Public",
+          "nsfwLevel": 7,
+          "description": "<p>I'm not great at prompting for 2.1 yet, so I\"m sure your prompts will work better with it. Works fantastic with negative embeds. (still collecting links)</p><p><a target=\"_blank\" rel=\"ugc\" href=\"https://civitai.com/models/7728/negativemutation\">https://civitai.com/models/7728/negativemutation</a></p>",
+          "trainedWords": ["21charturnerv2"],
+          "stats": {
+            "downloadCount": 37154,
+            "ratingCount": 9895,
+            "rating": 5,
+            "thumbsUpCount": 11669,
+            "thumbsDownCount": 1
+          },
+          "files": [
+            {
+              "id": 9500,
+              "sizeKB": 17.017578125,
+              "name": "21charturnerv2.pt",
+              "type": "Model",
+              "pickleScanResult": "Success",
+              "pickleScanMessage": "No Pickle imports",
+              "virusScanResult": "Success",
+              "virusScanMessage": null,
+              "scannedAt": "2023-02-12T22:45:53.210Z",
+              "metadata": {
+                "format": "PickleTensor",
+                "size": "full",
+                "fp": "fp16"
+              },
+              "hashes": {
+                "AutoV2": "F253ABB016",
+                "SHA256": "F253ABB016C22DD426D6E482F4F8C3960766DE6E4C02F151478BFB98F6985383",
+                "CRC32": "F500AADD",
+                "BLAKE3": "E7163C1A3F6B135A3E473CDD749BC1E6F4ED2D1AB43FEB1ACC4BEB1E5C205260"
+              },
+              "downloadUrl": "https://civitai.com/api/download/models/9857",
+              "primary": true
+            }
+          ],
+          "images": [
+            {
+              "id": 96744,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/d197481b-1c21-4c14-c7fd-708f838a1000/width=450/96744.jpeg",
+              "nsfwLevel": 2,
+              "width": 1238,
+              "height": 1293,
+              "hash": "UAEVA;?]JoR6+^OaNxxC^jXSWXjF?G$~s.WY",
+              "type": "image"
+            },
+            {
+              "id": 95916,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/e1fe96b4-c2e0-4e8b-094f-051a7e69e700/width=450/95916.jpeg",
+              "nsfwLevel": 4,
+              "width": 1398,
+              "height": 1259,
+              "hash": "U4FrbC^ljH_MFV00IUx[00McbvoM03o}t7xG",
+              "type": "image"
+            },
+            {
+              "id": 95915,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/613ec8af-7010-4b24-38b3-aa4488b9b000/width=450/95915.jpeg",
+              "nsfwLevel": 1,
+              "width": 992,
+              "height": 792,
+              "hash": "U7Du;[xZRj~A-pt7a#Rj0hR+ofNH01WBoJbI",
+              "type": "image"
+            },
+            {
+              "id": 95914,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/478efb4a-d63c-4b0d-8f19-bd60d52fc700/width=450/95914.jpeg",
+              "nsfwLevel": 1,
+              "width": 1184,
+              "height": 792,
+              "hash": "USIEU--:xut6tmofWWoL~UV@ayay-pbHjZbH",
+              "type": "image"
+            },
+            {
+              "id": 95913,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/04e55b16-e671-463a-bde9-3898f053e600/width=450/95913.jpeg",
+              "nsfwLevel": 1,
+              "width": 792,
+              "height": 792,
+              "hash": "UFG+R6NLs+D*02xujGRkH?S$V?kV?^RjkVtR",
+              "type": "image"
+            },
+            {
+              "id": 95912,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/a70413cb-e2bf-4a92-25e5-ed4786452a00/width=450/95912.jpeg",
+              "nsfwLevel": 1,
+              "width": 792,
+              "height": 792,
+              "hash": "UIHLI%E3D*02~TbcaKEM0M%1$$^%9^WWsm-n",
+              "type": "image"
+            },
+            {
+              "id": 95911,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/dd2d972b-42d4-45d2-9be5-ce4baf407700/width=450/95911.jpeg",
+              "nsfwLevel": 1,
+              "width": 792,
+              "height": 792,
+              "hash": "U7DI:yoe~V%L^*jsRkof9Zay9ZWC-oofM{WB",
+              "type": "image"
+            },
+            {
+              "id": 95910,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/04bab185-a5f6-447a-870c-2fd1b1fc9c00/width=450/95910.jpeg",
+              "nsfwLevel": 1,
+              "width": 792,
+              "height": 792,
+              "hash": "UAG8.ZoL00E1%0oMV@M|8{xt?axt~pj[xtxu",
+              "type": "image"
+            },
+            {
+              "id": 95909,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/c8ae65bb-2616-4774-ce6b-4527f20b1b00/width=450/95909.jpeg",
+              "nsfwLevel": 1,
+              "width": 1184,
+              "height": 792,
+              "hash": "UNIE@Nt7%MoftSofofay~pogM{oz_3kCRjof",
+              "type": "image"
+            },
+            {
+              "id": 95908,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/d91b46e7-7d69-43db-239d-412bdd8ed400/width=450/95908.jpeg",
+              "nsfwLevel": 1,
+              "width": 792,
+              "height": 792,
+              "hash": "UGF6CBnNI9xB~WxDs:RPVtaJofRQ00bwj@ad",
+              "type": "image"
+            },
+            {
+              "id": 95907,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/26f3a5f2-fcd4-493c-3944-1477b5b6c400/width=450/95907.jpeg",
+              "nsfwLevel": 1,
+              "width": 792,
+              "height": 792,
+              "hash": "UAF~jot7~q%M%1oetRWV_2t800M{adayt7t7",
+              "type": "image"
+            },
+            {
+              "id": 95906,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/fe1b2062-00d6-4a69-9087-d0ae4ffbba00/width=450/95906.jpeg",
+              "nsfwLevel": 1,
+              "width": 664,
+              "height": 664,
+              "hash": "U4DS:y~q_2?b00s.oJIU-?RjxuWCrCD%t7Mx",
+              "type": "image"
+            },
+            {
+              "id": 95905,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/5dce96bc-c613-4de1-16fb-d5e762803a00/width=450/95905.jpeg",
+              "nsfwLevel": 1,
+              "width": 664,
+              "height": 664,
+              "hash": "UAD9n[n$E1?a_NWBaeX80KayofNG$et7kCn$",
+              "type": "image"
+            },
+            {
+              "id": 95904,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/cb985636-9a04-4049-0236-a616fcd9d300/width=450/95904.jpeg",
+              "nsfwLevel": 1,
+              "width": 920,
+              "height": 920,
+              "hash": "U8EoMj^+^Q}[.Rxtt7NH00RkI:9tMeV[RjsC",
+              "type": "image"
+            },
+            {
+              "id": 95903,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/db4beb76-3beb-4920-45ff-df953dfe1f00/width=450/95903.jpeg",
+              "nsfwLevel": 1,
+              "width": 920,
+              "height": 920,
+              "hash": "U3EfKD_M4:Mf00%LxtRk00Dj%LyDOt9GRjWU",
+              "type": "image"
+            },
+            {
+              "id": 95902,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/d06a39bf-bba7-45c6-8667-63a0dd1b9400/width=450/95902.jpeg",
+              "nsfwLevel": 1,
+              "width": 664,
+              "height": 664,
+              "hash": "UDD9-g%2RPx]_NogV@oz9FR*kCRjR5s.ofRj",
+              "type": "image"
+            },
+            {
+              "id": 95901,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/528b3338-946c-4c38-c6b2-3f977cf3e100/width=450/95901.jpeg",
+              "nsfwLevel": 1,
+              "width": 664,
+              "height": 664,
+              "hash": "ULI=MX4:XSNI_2WBayxu~pn%-;o2_2xtRjt6",
+              "type": "image"
+            },
+            {
+              "id": 95900,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/1f7efa70-19b2-4061-0bab-145fd2e92900/width=450/95900.jpeg",
+              "nsfwLevel": 2,
+              "width": 1184,
+              "height": 792,
+              "hash": "UQF$@b-pV@jJPEbcWVR*8_jYaxjrMxs-oIt6",
+              "type": "image"
+            }
+          ],
+          "downloadUrl": "https://civitai.com/api/download/models/9857"
+        },
+        {
+          "id": 3334,
+          "index": 3,
+          "name": "CharTurner V1 - For 1.5",
+          "baseModel": "SD 1.5",
+          "baseModelType": "Standard",
+          "publishedAt": "2022-12-28T23:21:25.362Z",
+          "availability": "Public",
+          "nsfwLevel": 1,
+          "description": "<p>First version. Still has things I'm working on fixing. Adding \"multiple views of the same character\" can help if your character is being stubborn. </p>",
+          "trainedWords": ["charturner"],
+          "stats": {
+            "downloadCount": 10314,
+            "ratingCount": 1059,
+            "rating": 4.99,
+            "thumbsUpCount": 1073,
+            "thumbsDownCount": 0
+          },
+          "files": [
+            {
+              "id": 3231,
+              "sizeKB": 12.9169921875,
+              "name": "charturner.pt",
+              "type": "Model",
+              "pickleScanResult": "Success",
+              "pickleScanMessage": "**Detected Pickle imports (3)**\n```\ncollections.OrderedDict\ntorch.FloatStorage\ntorch._utils._rebuild_tensor_v2\n```",
+              "virusScanResult": "Success",
+              "virusScanMessage": null,
+              "scannedAt": "2022-12-28T23:28:40.051Z",
+              "metadata": {
+                "format": "PickleTensor",
+                "size": "full",
+                "fp": "fp16"
+              },
+              "hashes": {
+                "AutoV2": "733E24A8F4",
+                "SHA256": "733E24A8F4F9741DF4C936380BE9F25DF2F79FACD23AB956E03F9D9F75872DFD",
+                "CRC32": "45B06535",
+                "BLAKE3": "E89566CFC12D5596C9F373838C58778DE9833AED6B23348FCA0EAEEBC18ACE32"
+              },
+              "downloadUrl": "https://civitai.com/api/download/models/3334",
+              "primary": true
+            }
+          ],
+          "images": [
+            {
+              "id": 22507,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/1ade236c-eabe-4e9e-9719-37adaf55c300/width=450/22507.jpeg",
+              "nsfwLevel": 1,
+              "width": 768,
+              "height": 768,
+              "hash": "U8GRSVXmPU$*00n%IoI:BTxGn4Io?^ozxaso",
+              "type": "image"
+            },
+            {
+              "id": 22516,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/0cd2ed10-3582-40e5-8b4f-0612f6841400/width=450/22516.jpeg",
+              "nsfwLevel": 1,
+              "width": 768,
+              "height": 768,
+              "hash": "UNIX~zofRj?bxbofayay~qoetRV@%gaeofof",
+              "type": "image"
+            },
+            {
+              "id": 22515,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/1aa3e6e1-316f-4da7-3d9c-1f5934d11900/width=450/22515.jpeg",
+              "nsfwLevel": 1,
+              "width": 896,
+              "height": 576,
+              "hash": "UBGbYZ-pbIIowJWBR+t6~qoft7aeW=j[V@jY",
+              "type": "image"
+            },
+            {
+              "id": 22514,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/b76df236-a854-434e-d78e-e876ca2a0900/width=450/22514.jpeg",
+              "nsfwLevel": 1,
+              "width": 896,
+              "height": 576,
+              "hash": "U8GbSK^+00IA00kB-;?b~WITxvMy00RkRPe-",
+              "type": "image"
+            },
+            {
+              "id": 22513,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/d4bebcee-7be0-4595-3c98-93eb46460600/width=450/22513.jpeg",
+              "nsfwLevel": 1,
+              "width": 896,
+              "height": 576,
+              "hash": "U8Fg@2%2s-s:DlS~NGS2NdR*OER+{dnNofWV",
+              "type": "image"
+            },
+            {
+              "id": 22512,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/fcfed606-93b1-4d8c-451c-b2a378d70500/width=450/22512.jpeg",
+              "nsfwLevel": 1,
+              "width": 1024,
+              "height": 768,
+              "hash": "UKGuq9$%Mxxt?Hs:t7j[_NWqt8f+RkWBRjae",
+              "type": "image"
+            },
+            {
+              "id": 22511,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/3e1128ee-1d06-4923-5ffb-ee989762ad00/width=450/22511.jpeg",
+              "nsfwLevel": 1,
+              "width": 1024,
+              "height": 768,
+              "hash": "UEE:0poz%gaKaKWVWBn%~qt7WBoLazRPRjV@",
+              "type": "image"
+            },
+            {
+              "id": 22510,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/badde49e-83e2-4a5d-bb68-b19847242e00/width=450/22510.jpeg",
+              "nsfwLevel": 1,
+              "width": 1024,
+              "height": 768,
+              "hash": "UAD]PV%gsp?v~qn$R*Rj?vn$W;V@%MR*n%j[",
+              "type": "image"
+            },
+            {
+              "id": 22509,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/e64532fb-142f-4a56-1d87-56efdec04800/width=450/22509.jpeg",
+              "nsfwLevel": 1,
+              "width": 768,
+              "height": 768,
+              "hash": "U8G+tBRjx]0000ozR*%M~qo#Rj%g%hM{RPxv",
+              "type": "image"
+            },
+            {
+              "id": 22508,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/a8d05704-751f-4d8e-ab4b-3be5b50c5400/width=450/22508.jpeg",
+              "nsfwLevel": 1,
+              "width": 896,
+              "height": 576,
+              "hash": "UBHL3poM9Fiv~VWXNGt7SKV@WBof$$j?V@nO",
+              "type": "image"
+            }
+          ],
+          "downloadUrl": "https://civitai.com/api/download/models/3334"
+        }
+      ]
+    },
+    {
+      "id": 4514,
+      "name": "Pure Eros Face",
+      "description": "<p>This embedding will generate <strong>good-looking girl faces</strong>, close concept of <strong><u>kpop idols or Instagram girls</u></strong>. For <strong>SD1.5</strong> based models.</p><p></p><p><em>what means \"Pure Eros\"?</em></p><p><em>&gt; Pure Eros is a simple translation of the Chinese word \"</em><strong><em>纯欲</em></strong><em>\", which is a popular memes in the Chinese internet, the english words close to the semantics of this word are \"ulzzang face\", \"korean idol face\", so obviously this embedding will be close to the Asian aesthetic.🤗</em></p><p></p><p><strong>Recommended config:</strong></p><p>1. prompt</p><ul><li><p><strong>[:(detailed face:1.2):0.2]</strong>: When drawing high-quality faces, do not use the \"detail face\" tag at 0 steps, otherwise it may lead to deviation from the original semantics of embedding</p></li><li><p><strong>shiny eyes, looking at viewer</strong>: If your generated faces often close their eyes, adding \"shiny eyes, looking at viewer\" will open them instantly</p></li></ul><p>2. negative prompt:</p><ul><li><p><strong>long hair</strong>: add it to fix some errors caused by training data bias...(<em>although it does not always affect the output, my experiments found that it seems that the length of the hair in a certain scene will affect the quality of the clothes. In short, the relationship is very subtle, you can try to control the length of the hair to change the outfit quality)</em></p></li><li><p><strong>full body</strong>: Most of the data set is close-up, so it doesn't perform well on the \"full body\" scene, <em>I'm trying to fix it in the next version</em></p></li><li><p><strong>disabled body</strong>: If a deformed body structure is produced, please add it</p></li><li><p><strong>DeepNegative</strong>: A negative embedding I released can be used with PureErosFace very well, it is recommended to try</p><p><a target=\"_blank\" rel=\"ugc\" href=\"https://civitai.com/models/4629/deep-negative-v1x\">https://civitai.com/models/4629/deep-negative-v1x</a></p></li></ul><p></p><p></p><p><strong>Recommended model:</strong></p><p>It is best to use a model with a realistic style. If it is an anime-style model, it may output a mask-like face.</p><p></p><p><strong>1. LOFI</strong></p><p>merged model I released, works fine with this embedding</p><p><a target=\"_blank\" rel=\"ugc\" href=\"https://civitai.com/models/9052/lofi\">https://civitai.com/models/9052/lofi</a></p><img src=\"https://imagecache.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/8e1c68da-4e15-49bf-0090-25a89a438800/width=525\" /><p></p><p>examples <a target=\"_blank\" rel=\"ugc\" href=\"https://imgur.com/a/nFRE1Z4.jpg\">https://imgur.com/a/nFRE1Z4.jpg</a></p><img src=\"https://imagecache.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/29349082-39d2-45bf-4221-b49134ba3000/width=525\" /><p></p><p>2. <strong>izumi</strong></p><p>Most of my example images are generated by izumi:</p><p><a target=\"_blank\" rel=\"ugc\" href=\"https://civitai.com/models/1364/izumi\">https://civitai.com/models/1364/izumi</a></p><p></p><p>examples and test: <a target=\"_blank\" rel=\"ugc\" href=\"https://imgur.com/ZirqVWK.jpg\">https://imgur.com/ZirqVWK.jpg</a></p><img src=\"https://imagecache.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/9c53760b-fce1-4c3a-0339-d7f393e0d800/width=525\" /><p></p><p>3. <strong>F222</strong></p><p>Also produced a good-looking face, although I only experimented with a few, but they all look good for work</p><p><a target=\"_blank\" rel=\"ugc\" href=\"https://civitai.com/models/1188/f222\">https://civitai.com/models/1188/f222</a></p><p></p><p>examples and test: <a target=\"_blank\" rel=\"ugc\" href=\"https://imgur.com/ixyVXTP.jpg\">https://imgur.com/ixyVXTP.jpg</a></p><img src=\"https://imagecache.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/711d2fde-6c76-4702-b392-23f79d1ebe00/width=525\" /><p></p><p>4. <strong>HassanBlend</strong></p><p><a target=\"_blank\" rel=\"ugc\" href=\"https://civitai.com/models/1173/hassanblend-1512-and-previous-versions\">https://civitai.com/models/1173/hassanblend-1512-and-previous-versions</a></p><p></p><p>examples and test: <a target=\"_blank\" rel=\"ugc\" href=\"https://imgur.com/no066sF.jpg\">https://imgur.com/no066sF.jpg</a></p><img src=\"https://imagecache.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/885d0191-ba9f-4001-7693-6e56ff3adc00/width=525\" /><p></p><p></p><h3 id=\"heading-93\">Backup</h3><p><a target=\"_blank\" rel=\"ugc\" href=\"https://huggingface.co/lenML/PureErosFace_V1/tree/main\">https://huggingface.co/lenML/PureErosFace_V1/tree/main</a></p>",
+      "allowNoCredit": false,
+      "allowCommercialUse": ["Image", "RentCivit", "Rent"],
+      "allowDerivatives": true,
+      "allowDifferentLicense": false,
+      "type": "TextualInversion",
+      "minor": false,
+      "poi": false,
+      "nsfw": false,
+      "nsfwLevel": 15,
+      "cosmetic": null,
+      "stats": {
+        "downloadCount": 122312,
+        "favoriteCount": 0,
+        "thumbsUpCount": 13165,
+        "thumbsDownCount": 3,
+        "commentCount": 32,
+        "ratingCount": 0,
+        "rating": 0,
+        "tippedAmountCount": 220
+      },
+      "creator": {
+        "username": "lenML",
+        "image": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/625d4b36-c648-4a5d-5282-f35fe7cdd100/width=96/lenML.jpeg"
+      },
+      "tags": [
+        "girl",
+        "person",
+        "photorealistic",
+        "concept",
+        "textual inversion",
+        "beauties",
+        "asian",
+        "kpop",
+        "woman",
+        "faces",
+        "girls",
+        "photography",
+        "portraits",
+        "realistic"
+      ],
+      "modelVersions": [
+        {
+          "id": 5119,
+          "index": 0,
+          "name": "PureErosFace_v1",
+          "baseModel": "SD 1.5",
+          "baseModelType": "Standard",
+          "publishedAt": "2023-01-14T12:01:59.609Z",
+          "availability": "Public",
+          "nsfwLevel": 15,
+          "description": "<p>Training Config:</p><p>initialization text: ulzzang face,kpop idol</p><p>number of vectors per token: 1</p><p>lr: 0.05:10, 0.02:20, 0.01:60, 0.005:200, 0.002:500, 0.001:3000, 0.0005</p><p>(Here is not the complete lr formula, because I manually selected several iterations as branches during training, but I did not record it completely...here is just a part)</p><p>batch size: 10</p><p>images: 100+ images (close-up portrait girl face)</p><p>size: 512x512</p><p>steps: 1000</p>",
+          "trainedWords": ["pureerosface_v1"],
+          "stats": {
+            "downloadCount": 122312,
+            "ratingCount": 11456,
+            "rating": 5,
+            "thumbsUpCount": 13165,
+            "thumbsDownCount": 3
+          },
+          "files": [
+            {
+              "id": 5162,
+              "sizeKB": 3.9169921875,
+              "name": "pureerosface_v1.pt",
+              "type": "Model",
+              "pickleScanResult": "Success",
+              "pickleScanMessage": "**Detected Pickle imports (3)**\n```\ntorch.FloatStorage\ntorch._utils._rebuild_tensor_v2\ncollections.OrderedDict\n```",
+              "virusScanResult": "Success",
+              "virusScanMessage": null,
+              "scannedAt": "2023-01-14T12:09:02.454Z",
+              "metadata": {
+                "format": "PickleTensor",
+                "size": "full",
+                "fp": "fp16"
+              },
+              "hashes": {
+                "AutoV2": "DEDB4322E4",
+                "SHA256": "DEDB4322E42E360FE01775BA817BE03AC6A6C307744562BB0D6759368BC681DA",
+                "CRC32": "8E3194F8",
+                "BLAKE3": "7F529ED966666F01C58DE4576421C8A2FB438F82043CEBABD976CF8ECF4D308A"
+              },
+              "downloadUrl": "https://civitai.com/api/download/models/5119",
+              "primary": true
+            }
+          ],
+          "images": [
+            {
+              "id": 110973,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/9fbf8bf0-aad7-4360-eeb0-3e2e09628900/width=450/110973.jpeg",
+              "nsfwLevel": 4,
+              "width": 512,
+              "height": 768,
+              "hash": "UIG,eU~qYPAb-VITysoy00IVwJr??a$*IAS$",
+              "type": "image"
+            },
+            {
+              "id": 39166,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/fbd0cb59-8730-4a2f-120f-3a0f06e1e000/width=450/39166.jpeg",
+              "nsfwLevel": 1,
+              "width": 512,
+              "height": 768,
+              "hash": "UDJG+t170$~p}]=}0gXUXS#RRQtS0f-p-pNb",
+              "type": "image"
+            },
+            {
+              "id": 38248,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/bde04434-d879-4f9f-63e7-e7f125b63e00/width=450/38248.jpeg",
+              "nsfwLevel": 1,
+              "width": 512,
+              "height": 768,
+              "hash": "UOH13|}@D%IU6MFax[X7=exF$g%2t5wdoKof",
+              "type": "image"
+            },
+            {
+              "id": 38241,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/e8409490-308a-4a19-8d6b-e987574e9000/width=450/38241.jpeg",
+              "nsfwLevel": 2,
+              "width": 512,
+              "height": 768,
+              "hash": "UIGkI5Os0JE1OTRQ#;xbH?RQ?Ho}~BJ7xGni",
+              "type": "image"
+            },
+            {
+              "id": 38243,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/48e7d790-4366-41fb-de54-9448c28c1200/width=450/38243.jpeg",
+              "nsfwLevel": 4,
+              "width": 512,
+              "height": 768,
+              "hash": "UJJRHg?I9EWX00MyO-M|4-IV%gNG*Ibc$yxa",
+              "type": "image"
+            },
+            {
+              "id": 38247,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/e3c1055a-b9bb-4c57-428f-69206f8a2300/width=450/38247.jpeg",
+              "nsfwLevel": 1,
+              "width": 512,
+              "height": 768,
+              "hash": "UOJtYs_35*x]0{XA?I%MtTW@-:ox~qxuRjV@",
+              "type": "image"
+            },
+            {
+              "id": 38244,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/dec6d254-1f37-4dcd-8f16-353e370f9600/width=450/38244.jpeg",
+              "nsfwLevel": 1,
+              "width": 512,
+              "height": 768,
+              "hash": "UYJHR8~pEL_3NHx].8xuD%WBt6RPWBaxt7t7",
+              "type": "image"
+            },
+            {
+              "id": 38242,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/869b8476-0213-49a3-e1cc-7ba591bed200/width=450/38242.jpeg",
+              "nsfwLevel": 1,
+              "width": 512,
+              "height": 768,
+              "hash": "UKGtNf=d56%2vz}@-pJ7$l$ls:9t0gIXR--o",
+              "type": "image"
+            },
+            {
+              "id": 38246,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/7061f7bd-6425-47da-d5a6-b0c91e189800/width=450/38246.jpeg",
+              "nsfwLevel": 1,
+              "width": 512,
+              "height": 768,
+              "hash": "UMI|wDo|-:?GR~t7wcNG~UoJNeRj=xt79Zt6",
+              "type": "image"
+            },
+            {
+              "id": 38245,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/c7561317-9bf0-4e86-d484-e5d8b2d30000/width=450/38245.jpeg",
+              "nsfwLevel": 1,
+              "width": 512,
+              "height": 768,
+              "hash": "UDKmw#8_Dh8_0Kr?~qSO9F-V~WoIyDNbMcIo",
+              "type": "image"
+            },
+            {
+              "id": 110840,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/6649857a-a6aa-4f88-09d0-f70628ae4a00/width=450/110840.jpeg",
+              "nsfwLevel": 2,
+              "width": 512,
+              "height": 768,
+              "hash": "UMKTlS]~AJ$kUaK5SdOY9cIU?HnN?FxuMdkB",
+              "type": "image"
+            },
+            {
+              "id": 110839,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/f5ca23fb-e70f-4aaa-29a8-64b19de2b000/width=450/110839.jpeg",
+              "nsfwLevel": 1,
+              "width": 512,
+              "height": 768,
+              "hash": "UGHo8.0000~W00?vJV?H?vofi_D%XnIA$*x]",
+              "type": "image"
+            },
+            {
+              "id": 110838,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/bfe59471-c02a-4b5f-5c4f-14d5b4fd4a00/width=450/110838.jpeg",
+              "nsfwLevel": 2,
+              "width": 512,
+              "height": 768,
+              "hash": "UBG9Q=I900T0R19E%ht7NXD$ozx^*JWU$xnh",
+              "type": "image"
+            },
+            {
+              "id": 110837,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/0b8e9f50-065e-4e07-d4cc-b9cf8e102200/width=450/110837.jpeg",
+              "nsfwLevel": 2,
+              "width": 512,
+              "height": 768,
+              "hash": "UHDwBe0f9ExZOX$iIAxZ01%2xuV@_NELsleo",
+              "type": "image"
+            },
+            {
+              "id": 326389,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/66cbf385-9ebb-4a32-3410-a5a0cb471100/width=450/326389.jpeg",
+              "nsfwLevel": 4,
+              "width": 512,
+              "height": 768,
+              "hash": "UKHoOO.TPVxu9F?HkWNH0KX8VXjZx]S5xGnh",
+              "type": "image"
+            },
+            {
+              "id": 326388,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/9ebc63dd-0b43-49ce-9666-7b9168c87800/width=450/326388.jpeg",
+              "nsfwLevel": 4,
+              "width": 512,
+              "height": 768,
+              "hash": "UGFh#I4:0$$*5:IA^+D%01M{~pD%^*%MM{t7",
+              "type": "image"
+            },
+            {
+              "id": 508830,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/c44fbcdb-12bc-4a37-62e0-fadfa809d100/width=450/508830.jpeg",
+              "nsfwLevel": 8,
+              "width": 512,
+              "height": 768,
+              "hash": "UQHBoM~qOFX8.8-;Nao09Fxa?HWAt8xu-:t7",
+              "type": "image"
+            },
+            {
+              "id": 508857,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/83ac9484-7400-4abd-c147-6ce63a6f3f00/width=450/508857.jpeg",
+              "nsfwLevel": 8,
+              "width": 512,
+              "height": 768,
+              "hash": "UTIr1?~qx]n*_N%M-;s.W=IUxtM{-;IVIoWV",
+              "type": "image"
+            },
+            {
+              "id": 1008209,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/0743bbf6-986e-4289-abef-5f56bedcdb41/width=450/1008209.jpeg",
+              "nsfwLevel": 4,
+              "width": 512,
+              "height": 768,
+              "hash": "UeK-L5~qb_-;EdofaeM{bpD%RPs:tMR*M{Rj",
+              "type": "image"
+            }
+          ],
+          "downloadUrl": "https://civitai.com/api/download/models/5119"
+        }
+      ]
+    },
+    {
+      "id": 11772,
+      "name": "veryBadImageNegative",
+      "description": "<h1>v1.3</h1><p>veryBadImageNegative_v1.3使用了新的训练图集，在AOM3和<a target=\"_blank\" rel=\"ugc\" href=\"https://civitai.com/models/7813/viewer-mixv13\">viewer-mix_v1.7</a>中使用时表现较好。</p><p>veryBadImageNegative_v1.3 uses a new training atlas and performs well when used in AOM3 and <a target=\"_blank\" rel=\"ugc\" href=\"https://civitai.com/models/7813/viewer-mixv13\">viewer-mix_v1.7</a>.</p><p></p><h1>v1.2</h1><p>veryBadImageNegative是使用<a target=\"_blank\" rel=\"ugc\" href=\"https://civitai.com/models/7813/viewer-mixv13\">viewer-mix_v1.3</a>生成的特殊图集训练而来的负面嵌入。</p><p>所以veryBadImageNegative是<a target=\"_blank\" rel=\"ugc\" href=\"https://civitai.com/models/7813/viewer-mixv13\">viewer-mix_v1.3</a>的专用负面嵌入。</p><p>或许在其他的扩散模型中也有不错的效果，但缺乏验证。</p><p>veryBadImageNegative is a negative embedding trained from the special atlas generated by <a target=\"_blank\" rel=\"ugc\" href=\"https://civitai.com/models/7813/viewer-mixv13\">viewer-mix_v1.3</a>.</p><p>So veryBadImageNegative is the dedicated negative embedding of <a target=\"_blank\" rel=\"ugc\" href=\"https://civitai.com/models/7813/viewer-mixv13\">viewer-mix_v1.3</a>.</p><p>It may also have a good effect in other diffusion models, but it lacks verification.</p><p></p><p>关于v1.2：</p><p>增强图像的质量，削弱了风格。</p><p>在使用v1.2版本时，可以降低一些权重以获得更好的灵活性。</p><p>例如：(veryBadImageNegative_v1.2-6400:0.9)</p><p>About v1.2:</p><p>Enhance image quality and weaken style.</p><p>When using v1.2, you can reduce some weights to obtain better flexibility.</p><p>For example: (veryBadImageNegative_v1.2-6400:0.9)</p><p></p><p>关于v1.0与v1.1的差异：</p><p>几乎没有差别，仅用于训练的图集在生成参数有一些微妙的差别。</p><p>关于1600~6400的差异：</p><p>数字代表了训练步数，理论上步数越多效果越好。</p><p>About the difference between v1.0 and v1.1:</p><p>There is almost no difference. The atlas used for training only has some subtle differences in the generation parameters.</p><p>About the difference between 1600 ~ 6400:</p><p>The number represents the number of training steps. In theory, the more steps, the better the effect.</p><p></p><p></p>",
+      "allowNoCredit": true,
+      "allowCommercialUse": ["Image", "RentCivit", "Rent", "Sell"],
+      "allowDerivatives": true,
+      "allowDifferentLicense": true,
+      "type": "TextualInversion",
+      "minor": false,
+      "poi": false,
+      "nsfw": false,
+      "nsfwLevel": 7,
+      "cosmetic": null,
+      "stats": {
+        "downloadCount": 196507,
+        "favoriteCount": 0,
+        "thumbsUpCount": 12079,
+        "thumbsDownCount": 8,
+        "commentCount": 30,
+        "ratingCount": 0,
+        "rating": 0,
+        "tippedAmountCount": 61
+      },
+      "creator": {
+        "username": "yunleme",
+        "image": null
+      },
+      "tags": ["negative", "negative embedding"],
+      "modelVersions": [
+        {
+          "id": 25820,
+          "index": 0,
+          "name": "veryBadImageNegative_v1.3",
+          "baseModel": "SD 1.5",
+          "baseModelType": "Standard",
+          "publishedAt": "2023-03-19T18:54:54.849Z",
+          "availability": "Public",
+          "nsfwLevel": 1,
+          "description": null,
+          "trainedWords": ["verybadimagenegative_v1.3"],
+          "stats": {
+            "downloadCount": 174261,
+            "ratingCount": 7674,
+            "rating": 4.99,
+            "thumbsUpCount": 11462,
+            "thumbsDownCount": 8
+          },
+          "files": [
+            {
+              "id": 21434,
+              "sizeKB": 30.9169921875,
+              "name": "verybadimagenegative_v1.3.pt",
+              "type": "Model",
+              "pickleScanResult": "Success",
+              "pickleScanMessage": "No Pickle imports",
+              "virusScanResult": "Success",
+              "virusScanMessage": null,
+              "scannedAt": "2023-03-19T18:55:28.893Z",
+              "metadata": {
+                "format": "PickleTensor",
+                "size": "full",
+                "fp": "fp16"
+              },
+              "hashes": {
+                "AutoV2": "D70463F870",
+                "SHA256": "D70463F87042E2B5951C303542F3E171CF49AF9B7DF53B2F20779493786EB143",
+                "CRC32": "8236DA97",
+                "BLAKE3": "FC26A6054197C7250FAD2E377175AA77FCECA2B7DA6AE01DDDEB59E03B982390"
+              },
+              "downloadUrl": "https://civitai.com/api/download/models/25820",
+              "primary": true
+            }
+          ],
+          "images": [
+            {
+              "id": 283901,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/14337a5b-7dd1-4cab-4d8e-858f38201200/width=450/283901.jpeg",
+              "nsfwLevel": 1,
+              "width": 3840,
+              "height": 2367,
+              "hash": "UVN0*p_M_N?v?bRkRjae_3RjM{Rj?vaKWCay",
+              "type": "image"
+            },
+            {
+              "id": 319375,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/c82df32c-fb7e-49d8-d537-85d865190500/width=450/319375.jpeg",
+              "nsfwLevel": 1,
+              "width": 5120,
+              "height": 1222,
+              "hash": "UjI;;ot7jbt7~qs;f8ogtlofofof-;bHkBfi",
+              "type": "image"
+            },
+            {
+              "id": 319374,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/28447c08-da7e-46bc-0973-db9b2e81a900/width=450/319374.jpeg",
+              "nsfwLevel": 1,
+              "width": 5120,
+              "height": 1222,
+              "hash": "UkK-LXxFnixa~pt6afs:x[oyj[j[-;a|kBay",
+              "type": "image"
+            },
+            {
+              "id": 319373,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/65e503f7-addd-4476-77ee-f8248fa2c400/width=450/319373.jpeg",
+              "nsfwLevel": 1,
+              "width": 5120,
+              "height": 1222,
+              "hash": "UaJ*3no3kDS4~qt8t8oL%zozf7of%zfij[of",
+              "type": "image"
+            }
+          ],
+          "downloadUrl": "https://civitai.com/api/download/models/25820"
+        },
+        {
+          "id": 15556,
+          "index": 1,
+          "name": "v1.2-6400",
+          "baseModel": "SD 1.5",
+          "baseModelType": "Standard",
+          "publishedAt": "2023-02-26T07:16:06.154Z",
+          "availability": "Public",
+          "nsfwLevel": 1,
+          "description": null,
+          "trainedWords": ["verybadimagenegative_v1.2-6400"],
+          "stats": {
+            "downloadCount": 8515,
+            "ratingCount": 138,
+            "rating": 4.99,
+            "thumbsUpCount": 153,
+            "thumbsDownCount": 0
+          },
+          "files": [
+            {
+              "id": 13319,
+              "sizeKB": 31.109375,
+              "name": "verybadimagenegative_v1.2-6400.pt",
+              "type": "Model",
+              "pickleScanResult": "Success",
+              "pickleScanMessage": "No Pickle imports",
+              "virusScanResult": "Success",
+              "virusScanMessage": null,
+              "scannedAt": "2023-02-26T07:22:39.429Z",
+              "metadata": {
+                "format": "PickleTensor",
+                "size": "full",
+                "fp": "fp16"
+              },
+              "hashes": {
+                "AutoV2": "C8EF79979B",
+                "SHA256": "C8EF79979B082A746229405C47324777CB3A04239291A27A283D41013073BE25",
+                "CRC32": "9CA29265",
+                "BLAKE3": "A7068618198A90BC2BBE483C1A8EC363B6BC33EA06001920B3D7C3CB2E4BEACE"
+              },
+              "downloadUrl": "https://civitai.com/api/download/models/15556",
+              "primary": true
+            }
+          ],
+          "images": [
+            {
+              "id": 155139,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/1f749e1d-55e4-42e9-c336-88598b197600/width=450/155139.jpeg",
+              "nsfwLevel": 1,
+              "width": 1024,
+              "height": 1024,
+              "hash": "USG[Tj~VE1sp^+?H$*RjE0xu%LRPoIxut7Rj",
+              "type": "image"
+            }
+          ],
+          "downloadUrl": "https://civitai.com/api/download/models/15556"
+        },
+        {
+          "id": 15557,
+          "index": 2,
+          "name": "v1.2-4800",
+          "baseModel": "SD 1.5",
+          "baseModelType": "Standard",
+          "publishedAt": "2023-02-26T07:16:06.154Z",
+          "availability": "Public",
+          "nsfwLevel": 1,
+          "description": null,
+          "trainedWords": ["verybadimagenegative_v1.2-4800"],
+          "stats": {
+            "downloadCount": 1070,
+            "ratingCount": 113,
+            "rating": 5,
+            "thumbsUpCount": 120,
+            "thumbsDownCount": 0
+          },
+          "files": [
+            {
+              "id": 13320,
+              "sizeKB": 31.109375,
+              "name": "verybadimagenegative_v1.2-4800.pt",
+              "type": "Model",
+              "pickleScanResult": "Success",
+              "pickleScanMessage": "No Pickle imports",
+              "virusScanResult": "Success",
+              "virusScanMessage": null,
+              "scannedAt": "2023-02-26T07:22:36.583Z",
+              "metadata": {
+                "format": "PickleTensor",
+                "size": "full",
+                "fp": "fp16"
+              },
+              "hashes": {
+                "AutoV2": "B146574770",
+                "SHA256": "B14657477036B42A310AA6F7837AB51A266E658E39676F6EEA1564B0FC2B43F8",
+                "CRC32": "4B454460",
+                "BLAKE3": "2DA8D92BC6732646F98D81E675F53A2D3BE1EF48B050B2D5909690AD81FDA21F"
+              },
+              "downloadUrl": "https://civitai.com/api/download/models/15557",
+              "primary": true
+            }
+          ],
+          "images": [
+            {
+              "id": 155140,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/e17e3ea5-723a-4c10-27c0-a53331f96f00/width=450/155140.jpeg",
+              "nsfwLevel": 1,
+              "width": 1024,
+              "height": 1024,
+              "hash": "UOHBf0~W9txH_3?b%2V@E0x^-pM_xZxto#Rj",
+              "type": "image"
+            }
+          ],
+          "downloadUrl": "https://civitai.com/api/download/models/15557"
+        },
+        {
+          "id": 15558,
+          "index": 3,
+          "name": "v1.2-3200",
+          "baseModel": "SD 1.5",
+          "baseModelType": "Standard",
+          "publishedAt": "2023-02-26T07:16:06.154Z",
+          "availability": "Public",
+          "nsfwLevel": 1,
+          "description": null,
+          "trainedWords": ["verybadimagenegative_v1.2-3200"],
+          "stats": {
+            "downloadCount": 994,
+            "ratingCount": 128,
+            "rating": 5,
+            "thumbsUpCount": 134,
+            "thumbsDownCount": 0
+          },
+          "files": [
+            {
+              "id": 13321,
+              "sizeKB": 31.109375,
+              "name": "verybadimagenegative_v1.2-3200.pt",
+              "type": "Model",
+              "pickleScanResult": "Success",
+              "pickleScanMessage": "No Pickle imports",
+              "virusScanResult": "Success",
+              "virusScanMessage": null,
+              "scannedAt": "2023-02-26T07:22:43.056Z",
+              "metadata": {
+                "format": "PickleTensor",
+                "size": "full",
+                "fp": "fp16"
+              },
+              "hashes": {
+                "AutoV2": "47DB58D624",
+                "SHA256": "47DB58D624F9D587CD926824224ECED87040923024DA5E59CB1637E5C132C7DB",
+                "CRC32": "65E843C2",
+                "BLAKE3": "C457409C0EAE59917A3B9240F60A4EE5A724C667D83052556F4BE064D2FBCAE7"
+              },
+              "downloadUrl": "https://civitai.com/api/download/models/15558",
+              "primary": true
+            }
+          ],
+          "images": [
+            {
+              "id": 155141,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/158767fe-2151-4b77-ee7d-9850b0e4c900/width=450/155141.jpeg",
+              "nsfwLevel": 1,
+              "width": 1024,
+              "height": 1024,
+              "hash": "UQG[Zy~V9FaL~p-;soRPEKxv-pRPRixuxuV@",
+              "type": "image"
+            }
+          ],
+          "downloadUrl": "https://civitai.com/api/download/models/15558"
+        },
+        {
+          "id": 15559,
+          "index": 4,
+          "name": "v1.2-1600",
+          "baseModel": "SD 1.5",
+          "baseModelType": "Standard",
+          "publishedAt": "2023-02-26T07:16:06.154Z",
+          "availability": "Public",
+          "nsfwLevel": 1,
+          "description": null,
+          "trainedWords": ["verybadimagenegative_v1.2-1600"],
+          "stats": {
+            "downloadCount": 923,
+            "ratingCount": 125,
+            "rating": 5,
+            "thumbsUpCount": 129,
+            "thumbsDownCount": 0
+          },
+          "files": [
+            {
+              "id": 13322,
+              "sizeKB": 31.109375,
+              "name": "verybadimagenegative_v1.2-1600.pt",
+              "type": "Model",
+              "pickleScanResult": "Success",
+              "pickleScanMessage": "No Pickle imports",
+              "virusScanResult": "Success",
+              "virusScanMessage": null,
+              "scannedAt": "2023-02-26T07:22:58.503Z",
+              "metadata": {
+                "format": "PickleTensor",
+                "size": "full",
+                "fp": "fp16"
+              },
+              "hashes": {
+                "AutoV2": "1007B9B607",
+                "SHA256": "1007B9B607587073EBA443FE539B923647725D581402FCC70A57605820DF8ADA",
+                "CRC32": "B0EB9D47",
+                "BLAKE3": "E013C78A7E2A3AE82C547FAB17CBEB8A4BA0BDA9548B0B824706AF913110368C"
+              },
+              "downloadUrl": "https://civitai.com/api/download/models/15559",
+              "primary": true
+            }
+          ],
+          "images": [
+            {
+              "id": 155142,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/478f5e43-56d5-4e3f-b114-6cbdc4f96e00/width=450/155142.jpeg",
+              "nsfwLevel": 1,
+              "width": 1024,
+              "height": 1024,
+              "hash": "URG[Z#~WE2xZ~W^+%2RjE1x]%MRPWVt7t7aK",
+              "type": "image"
+            }
+          ],
+          "downloadUrl": "https://civitai.com/api/download/models/15559"
+        },
+        {
+          "id": 13906,
+          "index": 5,
+          "name": "v1.1-6400",
+          "baseModel": "SD 1.5",
+          "baseModelType": "Standard",
+          "publishedAt": "2023-02-22T16:18:26.581Z",
+          "availability": "Public",
+          "nsfwLevel": 1,
+          "description": null,
+          "trainedWords": ["verybadimagenegative_v1.1-6400"],
+          "stats": {
+            "downloadCount": 5244,
+            "ratingCount": 31,
+            "rating": 5,
+            "thumbsUpCount": 48,
+            "thumbsDownCount": 0
+          },
+          "files": [
+            {
+              "id": 12213,
+              "sizeKB": 31.109375,
+              "name": "verybadimagenegative_v1.1-6400.pt",
+              "type": "Model",
+              "pickleScanResult": "Success",
+              "pickleScanMessage": "No Pickle imports",
+              "virusScanResult": "Success",
+              "virusScanMessage": null,
+              "scannedAt": "2023-02-22T16:21:12.913Z",
+              "metadata": {
+                "format": "PickleTensor",
+                "size": "full",
+                "fp": "fp16"
+              },
+              "hashes": {
+                "AutoV2": "4B3EC07492",
+                "SHA256": "4B3EC07492F5F6165D9C69E0F8593F750D537EDBA8C1A9D31DFA2D1BEABAEFD7",
+                "CRC32": "06B4CFCC",
+                "BLAKE3": "D19BCE2FE08C63C2CC3271B036B51D233786B6DEC533269FDC88E72E6195F433"
+              },
+              "downloadUrl": "https://civitai.com/api/download/models/13906",
+              "primary": true
+            }
+          ],
+          "images": [
+            {
+              "id": 155143,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/869d37a4-a26b-4802-c2bf-5d42c9b02800/width=450/155143.jpeg",
+              "nsfwLevel": 1,
+              "width": 1024,
+              "height": 1024,
+              "hash": "UoKdxs~qNFx]-:%MNHM|M{W;ozkCx[bbRjjb",
+              "type": "image"
+            }
+          ],
+          "downloadUrl": "https://civitai.com/api/download/models/13906"
+        },
+        {
+          "id": 13907,
+          "index": 6,
+          "name": "v1.1-4800",
+          "baseModel": "SD 1.5",
+          "baseModelType": "Standard",
+          "publishedAt": "2023-02-22T16:18:26.581Z",
+          "availability": "Public",
+          "nsfwLevel": 1,
+          "description": null,
+          "trainedWords": ["verybadimagenegative_v1.1-4800"],
+          "stats": {
+            "downloadCount": 1430,
+            "ratingCount": 16,
+            "rating": 5,
+            "thumbsUpCount": 22,
+            "thumbsDownCount": 0
+          },
+          "files": [
+            {
+              "id": 12214,
+              "sizeKB": 31.109375,
+              "name": "verybadimagenegative_v1.1-4800.pt",
+              "type": "Model",
+              "pickleScanResult": "Success",
+              "pickleScanMessage": "No Pickle imports",
+              "virusScanResult": "Success",
+              "virusScanMessage": null,
+              "scannedAt": "2023-02-22T16:21:15.797Z",
+              "metadata": {
+                "format": "PickleTensor",
+                "size": "full",
+                "fp": "fp16"
+              },
+              "hashes": {
+                "AutoV2": "C1B0E1FCD3",
+                "SHA256": "C1B0E1FCD376615DB398ECFE9FE84428A7D4D66117FA4789E856616D86DD0C3B",
+                "CRC32": "56FD1003",
+                "BLAKE3": "5ADBE735B3FB442A6FB13C1E256085A1B630B99D21A6ABA8075D39D5D247FAC8"
+              },
+              "downloadUrl": "https://civitai.com/api/download/models/13907",
+              "primary": true
+            }
+          ],
+          "images": [
+            {
+              "id": 155144,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/2397a63c-f2f0-4c4a-cc78-a24188a0f900/width=450/155144.jpeg",
+              "nsfwLevel": 1,
+              "width": 1024,
+              "height": 1024,
+              "hash": "UkJHgz~pM_R:?t%LIURQk7xsxas:t6kBt7of",
+              "type": "image"
+            }
+          ],
+          "downloadUrl": "https://civitai.com/api/download/models/13907"
+        },
+        {
+          "id": 13908,
+          "index": 7,
+          "name": "v1.1-3200",
+          "baseModel": "SD 1.5",
+          "baseModelType": "Standard",
+          "publishedAt": "2023-02-22T16:18:26.581Z",
+          "availability": "Public",
+          "nsfwLevel": 1,
+          "description": null,
+          "trainedWords": ["verybadimagenegative_v1.1-3200"],
+          "stats": {
+            "downloadCount": 669,
+            "ratingCount": 11,
+            "rating": 5,
+            "thumbsUpCount": 15,
+            "thumbsDownCount": 0
+          },
+          "files": [
+            {
+              "id": 12215,
+              "sizeKB": 31.109375,
+              "name": "verybadimagenegative_v1.1-3200.pt",
+              "type": "Model",
+              "pickleScanResult": "Success",
+              "pickleScanMessage": "No Pickle imports",
+              "virusScanResult": "Success",
+              "virusScanMessage": null,
+              "scannedAt": "2023-02-22T16:21:18.176Z",
+              "metadata": {
+                "format": "PickleTensor",
+                "size": "full",
+                "fp": "fp16"
+              },
+              "hashes": {
+                "AutoV2": "4AF07AA81D",
+                "SHA256": "4AF07AA81D1BCF2D6B9BC9046152776D343B2AD7E4D044BDBB9C6BA213545DDA",
+                "CRC32": "397EC350",
+                "BLAKE3": "FDA0CEA748921C164BE60A27B6751D2A7770155A33594F63A6D3D569F1A39922"
+              },
+              "downloadUrl": "https://civitai.com/api/download/models/13908",
+              "primary": true
+            }
+          ],
+          "images": [
+            {
+              "id": 155145,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/c4d0ca84-b03e-4c83-18f1-575f0ff03e00/width=450/155145.jpeg",
+              "nsfwLevel": 1,
+              "width": 1024,
+              "height": 1024,
+              "hash": "UkJa+n~pITV{-:x[M{RPS0bvt7xa%goyV@oe",
+              "type": "image"
+            }
+          ],
+          "downloadUrl": "https://civitai.com/api/download/models/13908"
+        },
+        {
+          "id": 13909,
+          "index": 8,
+          "name": "v1.1-1600",
+          "baseModel": "SD 1.5",
+          "baseModelType": "Standard",
+          "publishedAt": "2023-02-22T16:18:26.581Z",
+          "availability": "Public",
+          "nsfwLevel": 1,
+          "description": null,
+          "trainedWords": ["verybadimagenegative_v1.1-1600"],
+          "stats": {
+            "downloadCount": 671,
+            "ratingCount": 10,
+            "rating": 5,
+            "thumbsUpCount": 14,
+            "thumbsDownCount": 0
+          },
+          "files": [
+            {
+              "id": 12216,
+              "sizeKB": 31.109375,
+              "name": "verybadimagenegative_v1.1-1600.pt",
+              "type": "Model",
+              "pickleScanResult": "Success",
+              "pickleScanMessage": "No Pickle imports",
+              "virusScanResult": "Success",
+              "virusScanMessage": null,
+              "scannedAt": "2023-02-22T16:21:21.204Z",
+              "metadata": {
+                "format": "PickleTensor",
+                "size": "full",
+                "fp": "fp16"
+              },
+              "hashes": {
+                "AutoV2": "E7CCEFC049",
+                "SHA256": "E7CCEFC0490F22225D22678D4F7D9E8DCA2BA83AF9CC7288F9F98DE0EBDC4E0F",
+                "CRC32": "25D4D366",
+                "BLAKE3": "C4AC5C0E02E8AF5C1168C1B99A6DDB4358DCE43F8D0F27CDDC5F17AE67A3EFFE"
+              },
+              "downloadUrl": "https://civitai.com/api/download/models/13909",
+              "primary": true
+            }
+          ],
+          "images": [
+            {
+              "id": 155146,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/c07b0fa4-cb06-451f-7470-c64454e10000/width=450/155146.jpeg",
+              "nsfwLevel": 1,
+              "width": 1024,
+              "height": 1024,
+              "hash": "UpJ@wi~WRPbJ?a%LInRjkRtQt7s:t5f$ofkB",
+              "type": "image"
+            }
+          ],
+          "downloadUrl": "https://civitai.com/api/download/models/13909"
+        },
+        {
+          "id": 13910,
+          "index": 9,
+          "name": "v1.0-6400",
+          "baseModel": "SD 1.5",
+          "baseModelType": "Standard",
+          "publishedAt": "2023-02-22T16:18:26.581Z",
+          "availability": "Public",
+          "nsfwLevel": 4,
+          "description": null,
+          "trainedWords": ["verybadimagenegative_v1.0-6400"],
+          "stats": {
+            "downloadCount": 915,
+            "ratingCount": 14,
+            "rating": 5,
+            "thumbsUpCount": 18,
+            "thumbsDownCount": 0
+          },
+          "files": [
+            {
+              "id": 12217,
+              "sizeKB": 31.0859375,
+              "name": "verybadimagenegative_v1.0-6400.pt",
+              "type": "Model",
+              "pickleScanResult": "Success",
+              "pickleScanMessage": "No Pickle imports",
+              "virusScanResult": "Success",
+              "virusScanMessage": null,
+              "scannedAt": "2023-02-22T16:21:19.936Z",
+              "metadata": {
+                "format": "PickleTensor",
+                "size": "full",
+                "fp": "fp16"
+              },
+              "hashes": {
+                "AutoV2": "26F6CFB67C",
+                "SHA256": "26F6CFB67C66BD85B4FB22F9A93741A19526E82DE33D097AE4B17310C9E582BA",
+                "CRC32": "AF11C56A",
+                "BLAKE3": "7BBBB0E156D87F1BFBF9ED4ABE532C015CE1F2C4F5EC2580869829F3688A34CD"
+              },
+              "downloadUrl": "https://civitai.com/api/download/models/13910",
+              "primary": true
+            }
+          ],
+          "images": [
+            {
+              "id": 155147,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/2a7cae7a-d988-4c9b-78bd-e12a87ea0300/width=450/155147.jpeg",
+              "nsfwLevel": 4,
+              "width": 1024,
+              "height": 1024,
+              "hash": "UBIEO=0000xq~D00?w%NInEP%MD$9tNG-o$g",
+              "type": "image"
+            }
+          ],
+          "downloadUrl": "https://civitai.com/api/download/models/13910"
+        },
+        {
+          "id": 13911,
+          "index": 10,
+          "name": "v1.0-4800",
+          "baseModel": "SD 1.5",
+          "baseModelType": "Standard",
+          "publishedAt": "2023-02-22T16:18:26.581Z",
+          "availability": "Public",
+          "nsfwLevel": 1,
+          "description": null,
+          "trainedWords": ["verybadimagenegative_v1.0-4800"],
+          "stats": {
+            "downloadCount": 612,
+            "ratingCount": 20,
+            "rating": 5,
+            "thumbsUpCount": 37,
+            "thumbsDownCount": 0
+          },
+          "files": [
+            {
+              "id": 12218,
+              "sizeKB": 31.0859375,
+              "name": "verybadimagenegative_v1.0-4800.pt",
+              "type": "Model",
+              "pickleScanResult": "Success",
+              "pickleScanMessage": "No Pickle imports",
+              "virusScanResult": "Success",
+              "virusScanMessage": null,
+              "scannedAt": "2023-02-22T16:21:21.889Z",
+              "metadata": {
+                "format": "PickleTensor",
+                "size": "full",
+                "fp": "fp16"
+              },
+              "hashes": {
+                "AutoV2": "EC7291C967",
+                "SHA256": "EC7291C967C1F69E4B236DE8B5DD799E059BB97F2C7CE65F762EA6675F0CFEE8",
+                "CRC32": "31B9699A",
+                "BLAKE3": "85D5AE3BEADB8959E2424111E810817AA5A288DAA8DCED24A4AC62B1A60748CC"
+              },
+              "downloadUrl": "https://civitai.com/api/download/models/13911",
+              "primary": true
+            }
+          ],
+          "images": [
+            {
+              "id": 155148,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/52fbf3db-8ea4-4c35-69a6-d31ed194de00/width=450/155148.jpeg",
+              "nsfwLevel": 1,
+              "width": 1024,
+              "height": 1024,
+              "hash": "UEI4*Q0000-U-X4-_4s;NFELxvDi58M_$*-;",
+              "type": "image"
+            }
+          ],
+          "downloadUrl": "https://civitai.com/api/download/models/13911"
+        },
+        {
+          "id": 13912,
+          "index": 11,
+          "name": "v1.0-3200",
+          "baseModel": "SD 1.5",
+          "baseModelType": "Standard",
+          "publishedAt": "2023-02-22T16:18:26.581Z",
+          "availability": "Public",
+          "nsfwLevel": 1,
+          "description": null,
+          "trainedWords": ["verybadimagenegative_v1.0-3200"],
+          "stats": {
+            "downloadCount": 581,
+            "ratingCount": 13,
+            "rating": 5,
+            "thumbsUpCount": 17,
+            "thumbsDownCount": 0
+          },
+          "files": [
+            {
+              "id": 12219,
+              "sizeKB": 31.0859375,
+              "name": "verybadimagenegative_v1.0-3200.pt",
+              "type": "Model",
+              "pickleScanResult": "Success",
+              "pickleScanMessage": "No Pickle imports",
+              "virusScanResult": "Success",
+              "virusScanMessage": null,
+              "scannedAt": "2023-02-22T16:21:23.822Z",
+              "metadata": {
+                "format": "PickleTensor",
+                "size": "full",
+                "fp": "fp16"
+              },
+              "hashes": {
+                "AutoV2": "A6B1DED89B",
+                "SHA256": "A6B1DED89B1F239A84A24719EC7D07F675DCDC490427FB0E7D2608F0C8CF0762",
+                "CRC32": "AA19BE1D",
+                "BLAKE3": "12CB32CC5D0843C53557553B750271949A8C14EBBF318A05C42A27CDABE4C985"
+              },
+              "downloadUrl": "https://civitai.com/api/download/models/13912",
+              "primary": true
+            }
+          ],
+          "images": [
+            {
+              "id": 155149,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/4cec97dd-e1b9-4669-e584-50d2b9d64300/width=450/155149.jpeg",
+              "nsfwLevel": 1,
+              "width": 1024,
+              "height": 1024,
+              "hash": "UBIX5X0000$J^m0K_4tSXm9uxBIA01R$^+$+",
+              "type": "image"
+            }
+          ],
+          "downloadUrl": "https://civitai.com/api/download/models/13912"
+        },
+        {
+          "id": 13913,
+          "index": 12,
+          "name": "v1.0-1600",
+          "baseModel": "SD 1.5",
+          "baseModelType": "Standard",
+          "publishedAt": "2023-02-22T16:18:26.581Z",
+          "availability": "Public",
+          "nsfwLevel": 2,
+          "description": null,
+          "trainedWords": ["verybadimagenegative_v1.0-1600"],
+          "stats": {
+            "downloadCount": 622,
+            "ratingCount": 14,
+            "rating": 5,
+            "thumbsUpCount": 18,
+            "thumbsDownCount": 0
+          },
+          "files": [
+            {
+              "id": 12220,
+              "sizeKB": 31.0859375,
+              "name": "verybadimagenegative_v1.0-1600.pt",
+              "type": "Model",
+              "pickleScanResult": "Success",
+              "pickleScanMessage": "No Pickle imports",
+              "virusScanResult": "Success",
+              "virusScanMessage": null,
+              "scannedAt": "2023-02-22T16:21:23.005Z",
+              "metadata": {
+                "format": "PickleTensor",
+                "size": "full",
+                "fp": "fp16"
+              },
+              "hashes": {
+                "AutoV2": "EA9AF2BFA6",
+                "SHA256": "EA9AF2BFA679CD6F4C97FB049D77B2F7706BB6AAAC47408C39F69E18D3AE1969",
+                "CRC32": "7F2B4BE4",
+                "BLAKE3": "9EF5AF98BC77569E5E0B5E20ACA2C032C7F949E407FB7A12B328E343DB2CA57B"
+              },
+              "downloadUrl": "https://civitai.com/api/download/models/13913",
+              "primary": true
+            }
+          ],
+          "images": [
+            {
+              "id": 155150,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/8253ad89-60f1-453b-7d0c-2762bc3b6200/width=450/155150.jpeg",
+              "nsfwLevel": 2,
+              "width": 1024,
+              "height": 1024,
+              "hash": "UGI|:_0000?F_44.-;t7xuM{WA9FD*NFx]-V",
+              "type": "image"
+            }
+          ],
+          "downloadUrl": "https://civitai.com/api/download/models/13913"
+        }
+      ]
+    },
+    {
+      "id": 71961,
+      "name": "Fast Negative Embedding (+ FastNegativeV2)",
+      "description": "<h1 id=\"heading-94\">Fast Negative Embedding</h1><p><strong>Do you like what I do? Consider supporting me on </strong><a target=\"_blank\" rel=\"ugc\" href=\"https://www.patreon.com/Lykon275\"><strong>Patreon</strong></a><strong> 🅿️ or feel free to </strong><a target=\"_blank\" rel=\"ugc\" href=\"https://snipfeed.co/lykon\"><strong>buy me a coffee</strong></a><strong> ☕</strong><br /></p><p>Token mix of my usual negative embedding. This way it's faster to use and easier to reproduce.</p><p>I'm also working on a much stronger one that doesn't preserve styles but it's good on base models without style loras applied. I plan to upload it during the next week, so be sure to leave a ❤️ to be notified of future updates.</p><p><s>This is very much a </s><strong><s>work in progress</s></strong><s>, but since I'm already using it in examples, I thought I should upload it.</s></p><p>It should keep styles on all my style loras. If not please tell me in the comments. <br />Additionally, if you find this too overpowering, use it with weight, like <code>(FastNegativeEmbedding:0.9)</code>.</p><p><strong>Update: </strong>added <code>FastNegativeV2</code>. It shouldn't be necessary to lower the weight.</p><p></p><p>Of course, don't use this in the positive prompt.<br />This includes Nerf's <a target=\"_blank\" rel=\"ugc\" href=\"https://civitai.com/models/56519/negativehand-negative-embedding\">Negative Hand</a> embedding.</p><p></p>",
+      "allowNoCredit": true,
+      "allowCommercialUse": ["Image", "RentCivit", "Rent"],
+      "allowDerivatives": true,
+      "allowDifferentLicense": true,
+      "type": "TextualInversion",
+      "minor": false,
+      "poi": false,
+      "nsfw": false,
+      "nsfwLevel": 3,
+      "cosmetic": null,
+      "stats": {
+        "downloadCount": 191770,
+        "favoriteCount": 0,
+        "thumbsUpCount": 11372,
+        "thumbsDownCount": 7,
+        "commentCount": 26,
+        "ratingCount": 0,
+        "rating": 0,
+        "tippedAmountCount": 180
+      },
+      "creator": {
+        "username": "Lykon",
+        "image": "https://cdn.discordapp.com/avatars/180327464155742208/59254be18ccd627daf138d053327485d.png"
+      },
+      "tags": [
+        "negative",
+        "negative embedding",
+        "textual inversion",
+        "embedding",
+        "tool"
+      ],
+      "modelVersions": [
+        {
+          "id": 94057,
+          "index": 0,
+          "name": "v2",
+          "baseModel": "SD 1.5",
+          "baseModelType": "Standard",
+          "publishedAt": "2023-06-11T19:54:48.444Z",
+          "availability": "Public",
+          "nsfwLevel": 3,
+          "description": null,
+          "trainedWords": ["FastNegativeV2"],
+          "stats": {
+            "downloadCount": 159297,
+            "ratingCount": 5365,
+            "rating": 4.98,
+            "thumbsUpCount": 10058,
+            "thumbsDownCount": 6
+          },
+          "files": [
+            {
+              "id": 65067,
+              "sizeKB": 201.9375,
+              "name": "FastNegativeV2.pt",
+              "type": "Model",
+              "pickleScanResult": "Success",
+              "pickleScanMessage": "No Pickle imports",
+              "virusScanResult": "Success",
+              "virusScanMessage": null,
+              "scannedAt": "2023-06-11T19:51:19.594Z",
+              "metadata": {
+                "format": "PickleTensor",
+                "size": null,
+                "fp": null
+              },
+              "hashes": {
+                "AutoV2": "A7465E7CC2",
+                "SHA256": "A7465E7CC2A2A27571EE020053F307B5AF54E6B60A0B0235D773F6BD55F7D078",
+                "CRC32": "3F95D721",
+                "BLAKE3": "AFC1ADB9D54ADD5F333D16F2F5995D53EC845759EA13E6DAED8C22A906EC2071"
+              },
+              "downloadUrl": "https://civitai.com/api/download/models/94057",
+              "primary": true
+            }
+          ],
+          "images": [
+            {
+              "id": 1113092,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/966617fd-89bc-4909-b51b-c4558af5aaf7/width=450/1113092.jpeg",
+              "nsfwLevel": 1,
+              "width": 712,
+              "height": 1072,
+              "hash": "UDF~EkxuE10L$y9G~q-;EMxu={-;%#NGIAxu",
+              "type": "image"
+            },
+            {
+              "id": 1113093,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/fdbc324d-b0a2-4285-aee7-fc0c3de2f57b/width=450/1113093.jpeg",
+              "nsfwLevel": 1,
+              "width": 864,
+              "height": 1192,
+              "hash": "UNK29Foi0]Dk.lotE{IUKROBxYxuTyofx[oc",
+              "type": "image"
+            },
+            {
+              "id": 1113099,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/658c662e-2448-4427-8618-c1e2868783a3/width=450/1113099.jpeg",
+              "nsfwLevel": 1,
+              "width": 864,
+              "height": 1304,
+              "hash": "UIG9Ed0000_N_3IUIUxuxuxaD%bHt8Ris:WB",
+              "type": "image"
+            },
+            {
+              "id": 1113125,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/becb9146-8ab8-4ebc-b51a-105bcbcdd2f1/width=450/1113125.jpeg",
+              "nsfwLevel": 1,
+              "width": 864,
+              "height": 1304,
+              "hash": "UEFr-PRj~q?b_3j[IU-;00-;D%ofD%j[?bD%",
+              "type": "image"
+            },
+            {
+              "id": 1113129,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/1c79846c-057a-412d-aa1d-2d9295885420/width=450/1113129.jpeg",
+              "nsfwLevel": 2,
+              "width": 1024,
+              "height": 1280,
+              "hash": "U7D9M7_400DO0MROR5oa0KE3%Mxb%ME2Dj?H",
+              "type": "image"
+            },
+            {
+              "id": 1113130,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/d6840a40-acb5-41a2-a481-260427ab8d69/width=450/1113130.jpeg",
+              "nsfwLevel": 1,
+              "width": 920,
+              "height": 1376,
+              "hash": "USJ7|B5uyYS#+%o#RQEM}@D$VqR:tnX8S%oM",
+              "type": "image"
+            },
+            {
+              "id": 1113134,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/0a728bfc-93f1-45e7-983a-a56d26202f49/width=450/1113134.jpeg",
+              "nsfwLevel": 1,
+              "width": 2592,
+              "height": 1611,
+              "hash": "UvM*NpahkSn+_4fkfjay%Na{ahkC%Lf6jZa#",
+              "type": "image"
+            },
+            {
+              "id": 1113132,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/8b8822b2-7ddd-45ac-8f28-8232fae6d2b5/width=450/1113132.jpeg",
+              "nsfwLevel": 1,
+              "width": 3680,
+              "height": 1477,
+              "hash": "UlLhJIxHbFxa~qt7jZt7-;WVj[WBxuWBbHWB",
+              "type": "image"
+            },
+            {
+              "id": 1113136,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/146c1f18-344a-41d5-9ba5-b1c03b68f3be/width=450/1113136.jpeg",
+              "nsfwLevel": 1,
+              "width": 920,
+              "height": 1264,
+              "hash": "UQJuZK^+^+^+_N~WxuWBx]WBxZWBI;M{%2D%",
+              "type": "image"
+            }
+          ],
+          "downloadUrl": "https://civitai.com/api/download/models/94057"
+        },
+        {
+          "id": 76712,
+          "index": 1,
+          "name": "v1.0 Normal [preferred for styles]",
+          "baseModel": "SD 1.5",
+          "baseModelType": "Standard",
+          "publishedAt": "2023-05-21T10:56:41.163Z",
+          "availability": "Public",
+          "nsfwLevel": 3,
+          "description": "<p>This mostly relies on the base model and loras and tries to keep the style unchanged, while making the picture look good. </p>",
+          "trainedWords": ["FastNegativeEmbedding"],
+          "stats": {
+            "downloadCount": 25210,
+            "ratingCount": 184,
+            "rating": 4.91,
+            "thumbsUpCount": 315,
+            "thumbsDownCount": 1
+          },
+          "files": [
+            {
+              "id": 52883,
+              "sizeKB": 156.9169921875,
+              "name": "FastNegativeEmbedding.pt",
+              "type": "Model",
+              "pickleScanResult": "Success",
+              "pickleScanMessage": "No Pickle imports",
+              "virusScanResult": "Success",
+              "virusScanMessage": null,
+              "scannedAt": "2023-05-21T10:56:06.831Z",
+              "metadata": {
+                "format": "Other"
+              },
+              "hashes": {
+                "AutoV2": "687B669D82",
+                "SHA256": "687B669D8234A418005CA9BFDA93464B1721285B0A6A8D92490DF0F02124AB7C",
+                "CRC32": "ECBF2024",
+                "BLAKE3": "2B028637CCF7E51716E29E9E0B76BCAAFFAE93D5176D27474AC7FFF1BF739206"
+              },
+              "downloadUrl": "https://civitai.com/api/download/models/76712",
+              "primary": true
+            }
+          ],
+          "images": [
+            {
+              "id": 886029,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/e6877c99-6167-48b7-883f-f78b516b3416/width=450/886029.jpeg",
+              "nsfwLevel": 1,
+              "width": 864,
+              "height": 1304,
+              "hash": "UXG[+x-6RiE1~XxZs.oex]-os.xuo#$%WBkC",
+              "type": "image"
+            },
+            {
+              "id": 865879,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/e5417bf6-0f79-4036-aa94-a44d5857676e/width=450/865879.jpeg",
+              "nsfwLevel": 1,
+              "width": 920,
+              "height": 1264,
+              "hash": "UVHMAvN}uP57k[bxkrcFDkE1$%%2%iIUxtsk",
+              "type": "image"
+            },
+            {
+              "id": 862630,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/cd1cb436-07ba-4815-b457-9eeb0e0467d8/width=450/862630.jpeg",
+              "nsfwLevel": 1,
+              "width": 920,
+              "height": 1376,
+              "hash": "UPI}#TJE.Tu4+*bxnS9u-WIUIT%1TMozOtr?",
+              "type": "image"
+            },
+            {
+              "id": 865652,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/d0a4b3f5-e47b-4f78-a2d0-5e7963d1baed/width=450/865652.jpeg",
+              "nsfwLevel": 1,
+              "width": 712,
+              "height": 1072,
+              "hash": "UFIg+W000y4;S|4.~Vrq7i-ln6?bE1xZs;WU",
+              "type": "image"
+            },
+            {
+              "id": 859533,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/3de7eefc-66a9-479e-84e9-2893edce4973/width=450/859533.jpeg",
+              "nsfwLevel": 2,
+              "width": 768,
+              "height": 960,
+              "hash": "UTIEFYM|0L~V?cE2D*xuxtWBIoWA%0xtsmjE",
+              "type": "image"
+            },
+            {
+              "id": 859532,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/e1e85156-793f-4d21-aa1d-295ea2483df0/width=450/859532.jpeg",
+              "nsfwLevel": 1,
+              "width": 920,
+              "height": 1376,
+              "hash": "UDJQJ~~qGu^+%g_3xv%M0K4:9GRO8_9FxWi^",
+              "type": "image"
+            },
+            {
+              "id": 863857,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/e5e46e61-0681-454f-9963-d42919c3b129/width=450/863857.jpeg",
+              "nsfwLevel": 1,
+              "width": 1024,
+              "height": 894,
+              "hash": "UiGu,nt7WBof~qfQj[of%MWBofof-;jtWBWB",
+              "type": "image"
+            },
+            {
+              "id": 863281,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/ffe77826-c861-4731-9694-630bd47a9f40/width=450/863281.jpeg",
+              "nsfwLevel": 1,
+              "width": 1424,
+              "height": 1245,
+              "hash": "UZKKZuM|j[D%?vWBayNG?w%2j]xu^+ogaet7",
+              "type": "image"
+            },
+            {
+              "id": 865880,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/e2adb680-493d-4005-9de2-4a47dc7427e8/width=450/865880.jpeg",
+              "nsfwLevel": 1,
+              "width": 2760,
+              "height": 1477,
+              "hash": "UeJ+GpsEkCxu?wWAR*WB={kBjGWD~qNGWCbb",
+              "type": "image"
+            },
+            {
+              "id": 866112,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/0f8a28a6-8661-4054-beca-33ba55eac7ab/width=450/866112.jpeg",
+              "nsfwLevel": 1,
+              "width": 2760,
+              "height": 1477,
+              "hash": "UfL#Rm$+bHxa~qozaet7?bR*WBayxbRjj[Rj",
+              "type": "image"
+            }
+          ],
+          "downloadUrl": "https://civitai.com/api/download/models/76712"
+        },
+        {
+          "id": 76985,
+          "index": 2,
+          "name": "v1.0 Strong",
+          "baseModel": "SD 1.5",
+          "baseModelType": "Standard",
+          "publishedAt": "2023-05-21T15:53:20.493Z",
+          "availability": "Public",
+          "nsfwLevel": 1,
+          "description": "<p>This will alter the style a bit but tries to greatly improve the final result. Might not work on all models. </p>",
+          "trainedWords": ["FastNegativeEmbeddingStrong"],
+          "stats": {
+            "downloadCount": 7263,
+            "ratingCount": 1193,
+            "rating": 5,
+            "thumbsUpCount": 1214,
+            "thumbsDownCount": 0
+          },
+          "files": [
+            {
+              "id": 53075,
+              "sizeKB": 156.9169921875,
+              "name": "FastNegativeEmbeddingStrong.pt",
+              "type": "Model",
+              "pickleScanResult": "Success",
+              "pickleScanMessage": "No Pickle imports",
+              "virusScanResult": "Success",
+              "virusScanMessage": null,
+              "scannedAt": "2023-05-21T15:56:09.224Z",
+              "metadata": {
+                "format": "PickleTensor",
+                "size": null,
+                "fp": null
+              },
+              "hashes": {
+                "AutoV2": "71A4BED4D9",
+                "SHA256": "71A4BED4D91ADE5D853EF6C20EE4679D9082E8AAC024B93A4F7D1B4728B77B53",
+                "CRC32": "060BE18D",
+                "BLAKE3": "040291614E4FBF7337F940B2D7D539F74F1E9C14642B3F7C7C4D6317778017AF"
+              },
+              "downloadUrl": "https://civitai.com/api/download/models/76985",
+              "primary": true
+            }
+          ],
+          "images": [
+            {
+              "id": 865642,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/0c11c0a7-88a6-4b70-8d4e-636c06b9d6a9/width=450/865642.jpeg",
+              "nsfwLevel": 1,
+              "width": 712,
+              "height": 1072,
+              "hash": "UDIN:Y000fR;In0K_2rDPq?GR5.8XTnhxbkV",
+              "type": "image"
+            },
+            {
+              "id": 863859,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/a48a1de5-0b32-416a-83ee-152d3e9b438a/width=450/863859.jpeg",
+              "nsfwLevel": 1,
+              "width": 1024,
+              "height": 894,
+              "hash": "UiGu,nt7WBof~qfQj[of%MWBofof-;jtWBWB",
+              "type": "image"
+            },
+            {
+              "id": 863288,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/d2112e6a-a1fd-41eb-9212-7accbc162cd3/width=450/863288.jpeg",
+              "nsfwLevel": 1,
+              "width": 1424,
+              "height": 1245,
+              "hash": "UZKKZuM|j[D%?vWBayNG?w%2j]xu^+ogaet7",
+              "type": "image"
+            },
+            {
+              "id": 865875,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/c6780899-7829-496a-82a7-60ba51e75ca3/width=450/865875.jpeg",
+              "nsfwLevel": 1,
+              "width": 920,
+              "height": 1264,
+              "hash": "UVHMAvN}uP57k[bxkrcFDkE1$%%2%iIUxtsk",
+              "type": "image"
+            },
+            {
+              "id": 863031,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/1c28baad-9942-4e17-b6ab-54a5ea1eeeba/width=450/863031.jpeg",
+              "nsfwLevel": 1,
+              "width": 920,
+              "height": 1376,
+              "hash": "UdI#$6MxM{NG~qIUR*WB%MM{aeayxuozV@M{",
+              "type": "image"
+            },
+            {
+              "id": 865878,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/afee5ca7-3be9-4583-8672-fce5b4c9edca/width=450/865878.jpeg",
+              "nsfwLevel": 1,
+              "width": 2760,
+              "height": 1477,
+              "hash": "UeJ+GpsEkCxu?wWAR*WB={kBjGWD~qNGWCbb",
+              "type": "image"
+            },
+            {
+              "id": 866107,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/bc25c3f4-eb51-4a0f-ae88-794e2ec2dea9/width=450/866107.jpeg",
+              "nsfwLevel": 1,
+              "width": 2760,
+              "height": 1477,
+              "hash": "UfL#Rm$+bHxa~qozaet7?bR*WBayxbRjj[Rj",
+              "type": "image"
+            }
+          ],
+          "downloadUrl": "https://civitai.com/api/download/models/76985"
+        }
+      ]
+    },
+    {
+      "id": 72437,
+      "name": "BadDream + UnrealisticDream (Negative Embeddings)",
+      "description": "<h1>Bad Dream + <a rel=\"ugc\" href=\"https://civitai.com/models/72437?modelVersionId=77173\">Unrealistic Dream</a></h1><h2>(Negative Embeddings, make sure to grab BOTH)</h2><p><strong>Do you like what I do? Consider supporting me on </strong><a target=\"_blank\" rel=\"ugc\" href=\"https://www.patreon.com/Lykon275\"><strong>Patreon</strong></a><strong> 🅿️ or feel free to </strong><a target=\"_blank\" rel=\"ugc\" href=\"https://snipfeed.co/lykon\"><strong>buy me a coffee</strong></a><strong> ☕</strong></p><p><br />Since I was refactoring my usual negative prompt with <a target=\"_blank\" rel=\"ugc\" href=\"https://civitai.com/models/71961/fast-negative-embedding\">FastNegativeEmbedding</a>, why not do the same with my super long <a target=\"_blank\" rel=\"ugc\" href=\"https://civitai.com/models/4384\"><strong>DreamShaper</strong></a> negative prompts?</p><p>I decided to condense them into 2 words which are the two embeddings presented here.</p><p>BadDream is good for \"dreamshaper style\" stuff, while <a target=\"_blank\" rel=\"ugc\" href=\"https://civitai.com/models/72437?modelVersionId=77173\">UnrealisticDream</a> is more suited for realistic images, but <strong>it's not standalone</strong>. You should use it together with BadDream or with other negative words.</p><p>They can also both be combined with <a target=\"_blank\" rel=\"ugc\" href=\"https://civitai.com/models/71961/fast-negative-embedding\">FastNegativeEmbedding</a>.</p><p>Enjoy!</p>",
+      "allowNoCredit": true,
+      "allowCommercialUse": ["Image", "RentCivit", "Rent"],
+      "allowDerivatives": true,
+      "allowDifferentLicense": true,
+      "type": "TextualInversion",
+      "minor": false,
+      "poi": false,
+      "nsfw": false,
+      "nsfwLevel": 7,
+      "cosmetic": null,
+      "stats": {
+        "downloadCount": 276821,
+        "favoriteCount": 0,
+        "thumbsUpCount": 9454,
+        "thumbsDownCount": 7,
+        "commentCount": 50,
+        "ratingCount": 0,
+        "rating": 0,
+        "tippedAmountCount": 440
+      },
+      "creator": {
+        "username": "Lykon",
+        "image": "https://cdn.discordapp.com/avatars/180327464155742208/59254be18ccd627daf138d053327485d.png"
+      },
+      "tags": [
+        "negative",
+        "negative embedding",
+        "photo realistic",
+        "embedding",
+        "photography",
+        "tool",
+        "dreamshaperart",
+        "semi realistic"
+      ],
+      "modelVersions": [
+        {
+          "id": 77169,
+          "index": 0,
+          "name": "BadDream v1.0",
+          "baseModel": "SD 1.5",
+          "baseModelType": "Standard",
+          "publishedAt": "2023-05-21T19:10:28.656Z",
+          "availability": "Public",
+          "nsfwLevel": 1,
+          "description": null,
+          "trainedWords": ["BadDream"],
+          "stats": {
+            "downloadCount": 174693,
+            "ratingCount": 829,
+            "rating": 4.85,
+            "thumbsUpCount": 2503,
+            "thumbsDownCount": 4
+          },
+          "files": [
+            {
+              "id": 53202,
+              "sizeKB": 207.8544921875,
+              "name": "BadDream.pt",
+              "type": "Model",
+              "pickleScanResult": "Success",
+              "pickleScanMessage": "No Pickle imports",
+              "virusScanResult": "Success",
+              "virusScanMessage": null,
+              "scannedAt": "2023-05-21T19:11:04.155Z",
+              "metadata": {
+                "format": "PickleTensor",
+                "size": null,
+                "fp": null
+              },
+              "hashes": {
+                "AutoV2": "758AAC4435",
+                "SHA256": "758AAC44351557CCFAE2FC6BDF3A29670464E4E4EABB61F08C5B8531C221649C",
+                "CRC32": "A1D22783",
+                "BLAKE3": "4A4AB59678A17FEB75F01AD066A934BC5B3362D60F617156D860C46969560E46"
+              },
+              "downloadUrl": "https://civitai.com/api/download/models/77169",
+              "primary": true
+            }
+          ],
+          "images": [
+            {
+              "id": 865300,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/03dbe944-2b6c-46c1-885e-ed90a32dc256/width=450/865300.jpeg",
+              "nsfwLevel": 1,
+              "width": 816,
+              "height": 1120,
+              "hash": "UQF#%M~VENIo-;t7%1s,-;ofV@V@%ft6WBWC",
+              "type": "image"
+            },
+            {
+              "id": 998685,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/5184344c-f935-4063-b5b3-10be10163d60/width=450/998685.jpeg",
+              "nsfwLevel": 1,
+              "width": 920,
+              "height": 1224,
+              "hash": "UEJ*YdD*pw~V00xu-;jEBY^+rXE1JWD%t89a",
+              "type": "image"
+            },
+            {
+              "id": 886028,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/3eff02bc-b7de-46bc-b894-ec4f8d2c7b6b/width=450/886028.jpeg",
+              "nsfwLevel": 1,
+              "width": 864,
+              "height": 1304,
+              "hash": "UXG[+x-6RiE1~XxZs.oex]-os.xuo#$%WBkC",
+              "type": "image"
+            },
+            {
+              "id": 887889,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/6b6fe29b-3c7a-49a6-9a95-071c9066de40/width=450/887889.jpeg",
+              "nsfwLevel": 1,
+              "width": 896,
+              "height": 1232,
+              "hash": "UFI50#?Htm9F9F~q008_o~M{?bNG.8t7%1ay",
+              "type": "image"
+            },
+            {
+              "id": 865276,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/bfd8b2f1-eae9-4423-b643-3efc033ba89a/width=450/865276.jpeg",
+              "nsfwLevel": 1,
+              "width": 816,
+              "height": 1120,
+              "hash": "UOFE}$~VEhI:-;xu%Ls.-;kCaLjF%MofWCWC",
+              "type": "image"
+            },
+            {
+              "id": 865299,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/f5fe54e4-3e8d-4ad3-af48-767cf7df9b53/width=450/865299.jpeg",
+              "nsfwLevel": 1,
+              "width": 4000,
+              "height": 1327,
+              "hash": "UvJas1xut7s:_NWBWBWB_3ayayay?bj@a{a}",
+              "type": "image"
+            },
+            {
+              "id": 887958,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/6e09fbaa-dc17-4fd5-a4d5-555f9b847686/width=450/887958.jpeg",
+              "nsfwLevel": 1,
+              "width": 896,
+              "height": 1232,
+              "hash": "U9D[tj%100E1-nNG56^j9a?Gxu4:0ekB~CRj",
+              "type": "image"
+            },
+            {
+              "id": 865266,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/a5a45c4f-6049-4b9d-bc38-c7ad19f08aa6/width=450/865266.jpeg",
+              "nsfwLevel": 1,
+              "width": 712,
+              "height": 1072,
+              "hash": "UJH-uw000xENr;9Z_3xCPXRgVZ~VIS%MX8bc",
+              "type": "image"
+            },
+            {
+              "id": 865296,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/014f9c0b-b235-4e4b-9edf-cb844db09506/width=450/865296.jpeg",
+              "nsfwLevel": 1,
+              "width": 1728,
+              "height": 1144,
+              "hash": "U=JRdVRjayWB~qoffQof%Mj[ofj[t7ayofWB",
+              "type": "image"
+            },
+            {
+              "id": 865297,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/3a75b673-c1cf-48f3-9bfd-d3b6ba6d212a/width=450/865297.jpeg",
+              "nsfwLevel": 1,
+              "width": 2848,
+              "height": 1285,
+              "hash": "UlKde^ofaeWB_3fka}fQ?wofazof^+ofaxoL",
+              "type": "image"
+            },
+            {
+              "id": 865635,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/27dfa39b-6566-4b67-b32b-f78adeac6b7c/width=450/865635.jpeg",
+              "nsfwLevel": 1,
+              "width": 3560,
+              "height": 1388,
+              "hash": "UqLD[Uj[afWA~qkCWBfl?wofWBof?HofWBoL",
+              "type": "image"
+            },
+            {
+              "id": 886013,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/7806633d-b89e-498c-b763-8c5918f70b73/width=450/886013.jpeg",
+              "nsfwLevel": 1,
+              "width": 920,
+              "height": 1376,
+              "hash": "U6DI|50#}PR*=E4:?b0L00emtl4:9a4.Rj?b",
+              "type": "image"
+            },
+            {
+              "id": 886021,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/ed01f9ce-2a13-4181-b150-19ba97953284/width=450/886021.jpeg",
+              "nsfwLevel": 1,
+              "width": 1072,
+              "height": 1432,
+              "hash": "UBBMoT_29tIo~p-:I:RjOEt7t6xatlofaKt6",
+              "type": "image"
+            }
+          ],
+          "downloadUrl": "https://civitai.com/api/download/models/77169"
+        },
+        {
+          "id": 77173,
+          "index": 1,
+          "name": "UnrealisticDream v1.0",
+          "baseModel": "SD 1.5",
+          "baseModelType": "Standard",
+          "publishedAt": "2023-05-21T19:13:15.489Z",
+          "availability": "Public",
+          "nsfwLevel": 7,
+          "description": null,
+          "trainedWords": ["UnrealisticDream"],
+          "stats": {
+            "downloadCount": 102128,
+            "ratingCount": 4620,
+            "rating": 4.99,
+            "thumbsUpCount": 7886,
+            "thumbsDownCount": 3
+          },
+          "files": [
+            {
+              "id": 53204,
+              "sizeKB": 111.8544921875,
+              "name": "UnrealisticDream.pt",
+              "type": "Model",
+              "pickleScanResult": "Success",
+              "pickleScanMessage": "No Pickle imports",
+              "virusScanResult": "Success",
+              "virusScanMessage": null,
+              "scannedAt": "2023-05-21T19:16:08.764Z",
+              "metadata": {
+                "format": "PickleTensor",
+                "size": null,
+                "fp": null
+              },
+              "hashes": {
+                "AutoV2": "A77451E7EA",
+                "SHA256": "A77451E7EA075C7F72D488D2B740B3D3970C671C0AC39DD3155F3C3B129DF959",
+                "CRC32": "96F44F4A",
+                "BLAKE3": "622432A48767161890795B5F247CFDCD7B62B5A092E3F1C809115A9F875BB816"
+              },
+              "downloadUrl": "https://civitai.com/api/download/models/77173",
+              "primary": true
+            }
+          ],
+          "images": [
+            {
+              "id": 998690,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/d15645f6-35e8-4217-9140-d16312a700be/width=450/998690.jpeg",
+              "nsfwLevel": 1,
+              "width": 920,
+              "height": 1264,
+              "hash": "ULIqZJ?F0#Ej00xtDiM{uPIp=xw{WSxtjZj]",
+              "type": "image"
+            },
+            {
+              "id": 998692,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/414aec68-ccaa-41a7-9808-ff01954ba762/width=450/998692.jpeg",
+              "nsfwLevel": 1,
+              "width": 920,
+              "height": 1376,
+              "hash": "UOGbM0~qtm-=9v?b-ptRxvR+oMt6IoM|oLjY",
+              "type": "image"
+            },
+            {
+              "id": 887959,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/bdf68f91-cb0f-415e-b318-8273bfb7dee9/width=450/887959.jpeg",
+              "nsfwLevel": 1,
+              "width": 896,
+              "height": 1232,
+              "hash": "UFI50#?Htm9F9F~q008_o~M{?bNG.8t7%1ay",
+              "type": "image"
+            },
+            {
+              "id": 887890,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/667c31ec-4f54-4de4-ba79-f0618a505612/width=450/887890.jpeg",
+              "nsfwLevel": 4,
+              "width": 896,
+              "height": 1232,
+              "hash": "U9D[tj%100E1-nNG56^j9a?Gxu4:0ekB~CRj",
+              "type": "image"
+            },
+            {
+              "id": 865322,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/e99ea480-5d13-414f-b61f-e81b8efcaca7/width=450/865322.jpeg",
+              "nsfwLevel": 1,
+              "width": 816,
+              "height": 1120,
+              "hash": "UQF#%M~VENIo-;t7%1s,-;ofV@V@%ft6WBWC",
+              "type": "image"
+            },
+            {
+              "id": 998687,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/05a2e191-3589-4ba1-ad09-6ec787454ee1/width=450/998687.jpeg",
+              "nsfwLevel": 2,
+              "width": 920,
+              "height": 1264,
+              "hash": "UIIWWFRk0ft60gt7xZI:~AWBxFWY57xZ-VxZ",
+              "type": "image"
+            },
+            {
+              "id": 998686,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/4370d5e7-7948-4fc0-a3ca-e20ccc3b37de/width=450/998686.jpeg",
+              "nsfwLevel": 1,
+              "width": 920,
+              "height": 1376,
+              "hash": "UCC%5C~q%MxuM{D%t7-;00t7D%9F00ofofIU",
+              "type": "image"
+            },
+            {
+              "id": 865325,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/dee5d3bf-9246-4395-9612-aa49f98ff7c9/width=450/865325.jpeg",
+              "nsfwLevel": 1,
+              "width": 712,
+              "height": 1072,
+              "hash": "UHHnd3010e4:WT9Z^+r=GcM^eU~VImxuxuNG",
+              "type": "image"
+            },
+            {
+              "id": 865331,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/78a4d59f-255c-49f1-9942-bc37667ef08d/width=450/865331.jpeg",
+              "nsfwLevel": 1,
+              "width": 4000,
+              "height": 1327,
+              "hash": "UvJas1xut7s:_NWBWBWB_3ayayay?bj@a{a}",
+              "type": "image"
+            },
+            {
+              "id": 865332,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/96faabdb-09c2-4a26-a547-be04f37e788f/width=450/865332.jpeg",
+              "nsfwLevel": 1,
+              "width": 1728,
+              "height": 1144,
+              "hash": "U=JRdVRjayWB~qoffQof%Mj[ofj[t7ayofWB",
+              "type": "image"
+            },
+            {
+              "id": 865333,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/0ac81ac0-1cec-4275-9da8-d54d1e924897/width=450/865333.jpeg",
+              "nsfwLevel": 1,
+              "width": 2848,
+              "height": 1285,
+              "hash": "UlKde^ofaeWB_3fka}fQ?wofazof^+ofaxoL",
+              "type": "image"
+            },
+            {
+              "id": 865636,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/7aba7ce1-6f3b-40a6-802b-fe49677e0ec7/width=450/865636.jpeg",
+              "nsfwLevel": 1,
+              "width": 3560,
+              "height": 1388,
+              "hash": "UqLNY{j[afWA~qkCWBfl?wofWBof?HofWBoL",
+              "type": "image"
+            },
+            {
+              "id": 886012,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/64d9f51d-c262-4788-985f-6751cce4da7b/width=450/886012.jpeg",
+              "nsfwLevel": 1,
+              "width": 920,
+              "height": 1376,
+              "hash": "U6DI|50#}PR*=E4:?b0L00emtl4:9a4.Rj?b",
+              "type": "image"
+            },
+            {
+              "id": 886020,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/971bee00-9f35-463a-9930-fb339e861e0a/width=450/886020.jpeg",
+              "nsfwLevel": 2,
+              "width": 1072,
+              "height": 1432,
+              "hash": "UBBMoT_29tIo~p-:I:RjOEt7t6xatlofaKt6",
+              "type": "image"
+            },
+            {
+              "id": 886027,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/6c229c39-42db-4136-b4fd-5ce0704b8e61/width=450/886027.jpeg",
+              "nsfwLevel": 1,
+              "width": 864,
+              "height": 1304,
+              "hash": "UXG[+x-6RiE1~XxZs.oex]-os.xuo#$%WBkC",
+              "type": "image"
+            }
+          ],
+          "downloadUrl": "https://civitai.com/api/download/models/77173"
+        }
+      ]
+    },
+    {
+      "id": 65214,
+      "name": "Age Slider",
+      "description": "<p><em>Update June 13th adding updated Young Versions... V2</em></p><p>I developed this age slider to work with my <a target=\"_blank\" rel=\"ugc\" href=\"https://civitai.com/models/64544/childrens-stories\"><strong>Children's Stories</strong></a> model. Some Stable Diffusion models have difficulty generating younger people. This embedding will fix that for you. It can make anyone, in any Lora, on any model, younger. Even animals and fantasy creatures.</p><p>Follow me to make sure you see new <a target=\"_blank\" rel=\"ugc\" href=\"https://civitai.com/tag/zstyle\">styles</a>, <a target=\"_blank\" rel=\"ugc\" href=\"https://civitai.com/tag/zpose\">poses</a> and <a target=\"_blank\" rel=\"ugc\" href=\"https://civitai.com/tag/znobody\">Nobodys</a> when I post them. Things move fast on this site, it's easy to miss.</p><p></p><p><strong>How to use:</strong><br />Just use one of the positive prompts listed to get the desired results. Use them at strength of 1. That means to put them at the beginning of your prompt or make sure they have the appropriate modifier brackets. Example, for automatic1111 it would be (AS-YoungerV2) or (AS-YoungerV2:1.0), the parenthesis are required. They are stackable, so you can combine them together to help with stubborn models. A negative embedding is also included for extra brute force if needed. There are 4 files to download for younger, and 4 for older, check the version tabs at the top.</p><p><u>These embeddings make people/creatures/characters younger.</u></p><ul><li><p><strong>AS-YoungV2-Neg:</strong> Place in your negative prompt at strength of 1.0 to 1.3, generally removes adults from the scene.</p></li><li><p><strong>AS-YoungV2:</strong> Place at the beginning of your positive prompt at strength of 1.0 to 1.3. Conceptually teenager, may vary by model, lora, or prompts.</p></li><li><p><strong>AS-YoungerV2:</strong> Place at the beginning of your positive prompt at strength of 1.0 to 1.3. Conceptually child, may vary by model, lora, or prompts.</p></li><li><p><strong>AS-YoungestV2:</strong> Place at the beginning of your positive prompt at strength of 1.0 to 1.3. Conceptually toddler/baby, may vary by model, lora, or prompts</p></li></ul><p><u>These embeddings make people/creatures/characters adult or older.</u></p><ul><li><p><strong>AS-Adult-Neg:</strong> Place in your negative prompt at strength of 1.0 to 1.3. This will remove any young people and/or youth from the scene.</p></li><li><p><strong>AS-Adult:</strong> Place at the beginning of your positive prompt at strength of 1.0 to 1.3. Conceptually fully matured adult 20s to 30s, may vary by model, lora, or prompts.</p></li><li><p><strong>AS-MidAged:</strong> Place at the beginning of your positive prompt at strength of 1.0 to 1.3. Conceptually middle-aged adult 40s to 60s, may vary by model, lora, or prompts.</p></li><li><p><strong>AS-Elderly:</strong> Place at the beginning of your positive prompt at strength of 1.0 to 1.3. Conceptually elderly adult 70s +, may vary by model, lora, or prompts.</p></li></ul><p>These are the concepts for the embeddings. Some models, character LoRAs, or embeddings might be too rigid, so increase strength or stack on multiple to get the desired result. Additional prompts may help as well.</p><p></p><p><span style=\"color:#40c057\">Do you have requests? I've been putting in many more hours lately with this. That's my problem, not yours. But if you'd like to tip me, buy me a beer. Beer encourages me to ignore work and make AI models instead. Tip and make a request. I'll give it a shot if I can.</span> <a target=\"_blank\" rel=\"ugc\" href=\"https://ko-fi.com/zovya\">Here at Ko-Fi</a></p>",
+      "allowNoCredit": false,
+      "allowCommercialUse": ["Image"],
+      "allowDerivatives": true,
+      "allowDifferentLicense": false,
+      "type": "TextualInversion",
+      "minor": false,
+      "poi": false,
+      "nsfw": false,
+      "nsfwLevel": 1,
+      "cosmetic": null,
+      "stats": {
+        "downloadCount": 329768,
+        "favoriteCount": 0,
+        "thumbsUpCount": 8787,
+        "thumbsDownCount": 4,
+        "commentCount": 111,
+        "ratingCount": 0,
+        "rating": 0,
+        "tippedAmountCount": 1778
+      },
+      "creator": {
+        "username": "Zovya",
+        "image": "https://avatars.githubusercontent.com/u/110301217?v=4"
+      },
+      "tags": ["young", "aged", "tool", "age slider"],
+      "modelVersions": [
+        {
+          "id": 94765,
+          "index": 0,
+          "name": "Young Negative V2",
+          "baseModel": "SD 1.5",
+          "baseModelType": "Standard",
+          "publishedAt": "2023-06-12T21:43:10.189Z",
+          "availability": "Public",
+          "nsfwLevel": 1,
+          "description": null,
+          "trainedWords": ["AS-YoungV2"],
+          "stats": {
+            "downloadCount": 71320,
+            "ratingCount": 168,
+            "rating": 4.9,
+            "thumbsUpCount": 665,
+            "thumbsDownCount": 3
+          },
+          "files": [
+            {
+              "id": 65622,
+              "sizeKB": 36.9375,
+              "name": "AS-YoungV2-neg.pt",
+              "type": "Negative",
+              "pickleScanResult": "Success",
+              "pickleScanMessage": "No Pickle imports",
+              "virusScanResult": "Success",
+              "virusScanMessage": null,
+              "scannedAt": "2023-06-12T21:41:18.437Z",
+              "metadata": {
+                "format": "Other",
+                "size": null,
+                "fp": null
+              },
+              "hashes": {
+                "AutoV2": "BB190AE478",
+                "SHA256": "BB190AE47836752E7C311DA3C1CAD905DFB251BF9D126D699E9FDECFC4E746BF",
+                "CRC32": "91995F65",
+                "BLAKE3": "3FDB9A270F6B99EEA3B4CB34A38C85F4344123162EAE18D251A1BF6421CAACEE"
+              },
+              "downloadUrl": "https://civitai.com/api/download/models/94765",
+              "primary": true
+            }
+          ],
+          "images": [
+            {
+              "id": 1123881,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/b661b0c0-0346-4444-b269-2f3ee8ff9b9a/width=450/1123881.jpeg",
+              "nsfwLevel": 1,
+              "width": 1024,
+              "height": 2048,
+              "hash": "UEF5gY?^TJae%g9[WVxGQ7tRrraKIBMdnio}",
+              "type": "image"
+            },
+            {
+              "id": 1123885,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/e88226fe-ec58-4716-8295-45294505219a/width=450/1123885.jpeg",
+              "nsfwLevel": 1,
+              "width": 1024,
+              "height": 1536,
+              "hash": "UJH_3;007f%4~U9ZR*xwK%aeiI%NTJD%rXoz",
+              "type": "image"
+            },
+            {
+              "id": 1123887,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/88b7fb7f-2ba7-4fe9-a18e-54c682110b39/width=450/1123887.jpeg",
+              "nsfwLevel": 1,
+              "width": 1024,
+              "height": 1536,
+              "hash": "UgFsMk%g%f%M~q%Mt7xu%MRQe.jtofoyV@WC",
+              "type": "image"
+            },
+            {
+              "id": 1123886,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/3d6afe99-2440-4902-866d-33c3c03cb2ee/width=450/1123886.jpeg",
+              "nsfwLevel": 1,
+              "width": 1024,
+              "height": 1536,
+              "hash": "UFGR;t050w9bZg?]Om0Mu3JBwexW7hog,:r=",
+              "type": "image"
+            },
+            {
+              "id": 1123889,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/abf575fe-4735-4383-97cf-7baabfb61e86/width=450/1123889.jpeg",
+              "nsfwLevel": 1,
+              "width": 1024,
+              "height": 1536,
+              "hash": "UgH2A-adORtQ~At6X4t7auxaaKs:R%oeaKjt",
+              "type": "image"
+            },
+            {
+              "id": 1123888,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/bd7b25da-5020-4c3e-9ab2-5366949fe99b/width=450/1123888.jpeg",
+              "nsfwLevel": 1,
+              "width": 1024,
+              "height": 1536,
+              "hash": "UBF#L5D%G7IV0hS4I9~V9Zr@m7KO~pInyCsp",
+              "type": "image"
+            },
+            {
+              "id": 1123890,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/30a22a7b-e269-4df2-8ec5-4f3c8ef3eaf3/width=450/1123890.jpeg",
+              "nsfwLevel": 1,
+              "width": 1024,
+              "height": 1536,
+              "hash": "UiEDM2V?%gaJ_4n~t7V?xaV@nNbbkqR*jEkW",
+              "type": "image"
+            },
+            {
+              "id": 1123891,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/8c92a542-9ab8-4346-ab13-b2a088cd6eee/width=450/1123891.jpeg",
+              "nsfwLevel": 1,
+              "width": 1024,
+              "height": 1536,
+              "hash": "U6BDTY?IH]D*?[R.0=D+V|RPskxZ9HIT^a%1",
+              "type": "image"
+            },
+            {
+              "id": 1123893,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/e8e5d8b3-b7c5-446a-8798-df37415fc169/width=450/1123893.jpeg",
+              "nsfwLevel": 1,
+              "width": 1024,
+              "height": 1536,
+              "hash": "U7CPeX%ME+^+?FozEl-p~qE4EQt7-=jG^+E2",
+              "type": "image"
+            },
+            {
+              "id": 1123895,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/5348d52b-2cfd-42e7-b4a2-85f22ea943de/width=450/1123895.jpeg",
+              "nsfwLevel": 1,
+              "width": 1024,
+              "height": 1536,
+              "hash": "UUH2TPRP-oxt57s:M{Rk.9t6Mxoe_NRj%2of",
+              "type": "image"
+            },
+            {
+              "id": 1123894,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/418b861e-36e2-469c-b686-a5ec39b06395/width=450/1123894.jpeg",
+              "nsfwLevel": 1,
+              "width": 1024,
+              "height": 1536,
+              "hash": "UJJ@%o~W00%Kacxu~q%M9ZM{?b%M-;Rms;ax",
+              "type": "image"
+            },
+            {
+              "id": 1123897,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/177e326c-0adc-4fd8-b8e3-0e676a08d732/width=450/1123897.jpeg",
+              "nsfwLevel": 1,
+              "width": 1024,
+              "height": 1536,
+              "hash": "U5AmPGjE00_2~pIp01NG9FkC-:Mx9GM|-:^*",
+              "type": "image"
+            },
+            {
+              "id": 1123896,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/ad495f6e-effd-4384-9ba6-dbb40830f7e0/width=450/1123896.jpeg",
+              "nsfwLevel": 1,
+              "width": 1024,
+              "height": 1536,
+              "hash": "U28NUw004T-,9v_24nDi0NNG~U02=^4;^+-n",
+              "type": "image"
+            }
+          ],
+          "downloadUrl": "https://civitai.com/api/download/models/94765"
+        },
+        {
+          "id": 94703,
+          "index": 1,
+          "name": "Young V2",
+          "baseModel": "SD 1.5",
+          "baseModelType": "Standard",
+          "publishedAt": "2023-06-12T19:34:10.256Z",
+          "availability": "Public",
+          "nsfwLevel": 1,
+          "description": null,
+          "trainedWords": ["AS-YoungV2"],
+          "stats": {
+            "downloadCount": 39008,
+            "ratingCount": 57,
+            "rating": 4.84,
+            "thumbsUpCount": 164,
+            "thumbsDownCount": 1
+          },
+          "files": [
+            {
+              "id": 65568,
+              "sizeKB": 51.86328125,
+              "name": "AS-YoungV2.pt",
+              "type": "Model",
+              "pickleScanResult": "Success",
+              "pickleScanMessage": "No Pickle imports",
+              "virusScanResult": "Success",
+              "virusScanMessage": null,
+              "scannedAt": "2023-06-12T19:36:33.573Z",
+              "metadata": {
+                "format": "PickleTensor",
+                "size": null,
+                "fp": null
+              },
+              "hashes": {
+                "AutoV2": "714BBA6525",
+                "SHA256": "714BBA6525DE69CD16CDD5E05D49DFB7CE4D5A8257062444D58800EEE485B9C9",
+                "CRC32": "1EC8508D",
+                "BLAKE3": "987346583FAE2F9382A485FEA29D9E6DCEF8D8BABB5A7007513F3522D2D674A1"
+              },
+              "downloadUrl": "https://civitai.com/api/download/models/94703",
+              "primary": true
+            }
+          ],
+          "images": [
+            {
+              "id": 1122786,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/966890ad-4c21-4317-9280-532c28d4f978/width=450/1122786.jpeg",
+              "nsfwLevel": 1,
+              "width": 1024,
+              "height": 1650,
+              "hash": "UCA]+~XSXSr@*Jx[WVaKBoPAs:iw%MS~g3nO",
+              "type": "image"
+            }
+          ],
+          "downloadUrl": "https://civitai.com/api/download/models/94703"
+        },
+        {
+          "id": 95275,
+          "index": 2,
+          "name": "Younger V2",
+          "baseModel": "SD 1.5",
+          "baseModelType": "Standard",
+          "publishedAt": "2023-06-13T16:01:36.716Z",
+          "availability": "Public",
+          "nsfwLevel": 1,
+          "description": null,
+          "trainedWords": ["AS-YoungerV2"],
+          "stats": {
+            "downloadCount": 37234,
+            "ratingCount": 84,
+            "rating": 4.98,
+            "thumbsUpCount": 176,
+            "thumbsDownCount": 0
+          },
+          "files": [
+            {
+              "id": 66027,
+              "sizeKB": 48.931640625,
+              "name": "AS-YoungerV2.pt",
+              "type": "Model",
+              "pickleScanResult": "Success",
+              "pickleScanMessage": "No Pickle imports",
+              "virusScanResult": "Success",
+              "virusScanMessage": null,
+              "scannedAt": "2023-06-13T16:01:37.210Z",
+              "metadata": {
+                "format": "PickleTensor",
+                "size": null,
+                "fp": null
+              },
+              "hashes": {
+                "AutoV2": "4880490A41",
+                "SHA256": "4880490A41BA6A5D680532F4ABCC2377C2B820A01DC65187F6BA0E86A6F14F40",
+                "CRC32": "3C7DD9FD",
+                "BLAKE3": "99D3B8FA0A7C47B5AFE6699A2D823805448D4ED8AAA240364CAF1B0247053544"
+              },
+              "downloadUrl": "https://civitai.com/api/download/models/95275",
+              "primary": true
+            }
+          ],
+          "images": [
+            {
+              "id": 1132128,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/896ab8c4-5160-4e0e-91e8-e77e77259395/width=450/1132128.jpeg",
+              "nsfwLevel": 1,
+              "width": 1024,
+              "height": 1650,
+              "hash": "UBA],0iwZ$tR.mw_Z$XSADOrwcae#mR,cEni",
+              "type": "image"
+            }
+          ],
+          "downloadUrl": "https://civitai.com/api/download/models/95275"
+        },
+        {
+          "id": 95528,
+          "index": 3,
+          "name": "Youngest V2",
+          "baseModel": "SD 1.5",
+          "baseModelType": "Standard",
+          "publishedAt": "2023-06-14T00:59:02.091Z",
+          "availability": "Public",
+          "nsfwLevel": 1,
+          "description": null,
+          "trainedWords": ["AS-YoungestV2"],
+          "stats": {
+            "downloadCount": 29101,
+            "ratingCount": 3129,
+            "rating": 5,
+            "thumbsUpCount": 5279,
+            "thumbsDownCount": 0
+          },
+          "files": [
+            {
+              "id": 66244,
+              "sizeKB": 48.9345703125,
+              "name": "AS-YoungestV2.pt",
+              "type": "Model",
+              "pickleScanResult": "Success",
+              "pickleScanMessage": "No Pickle imports",
+              "virusScanResult": "Success",
+              "virusScanMessage": null,
+              "scannedAt": "2023-06-14T01:07:04.065Z",
+              "metadata": {
+                "format": "PickleTensor",
+                "size": null,
+                "fp": null
+              },
+              "hashes": {
+                "AutoV2": "C71427A287",
+                "SHA256": "C71427A287B5C2A0357518C78BF49CB25C9F13E9932FE19B361EE8D657748BF0",
+                "CRC32": "0E3713C2",
+                "BLAKE3": "B737C039C160C50E50248DF5B95A2FBC3D7D3AAED7D00A22F1920EE90A3AEBE6"
+              },
+              "downloadUrl": "https://civitai.com/api/download/models/95528",
+              "primary": true
+            }
+          ],
+          "images": [
+            {
+              "id": 1137065,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/ea45038e-cb74-47bf-99b3-a63f8d0526a3/width=450/1137065.jpeg",
+              "nsfwLevel": 1,
+              "width": 1024,
+              "height": 1650,
+              "hash": "U8A]+~mRTJtl?^$OWBX84.LLv}iw-BOEkVo0",
+              "type": "image"
+            }
+          ],
+          "downloadUrl": "https://civitai.com/api/download/models/95528"
+        },
+        {
+          "id": 74332,
+          "index": 4,
+          "name": "Older Negative",
+          "baseModel": "SD 1.5",
+          "baseModelType": "Standard",
+          "publishedAt": "2023-05-18T20:25:44.644Z",
+          "availability": "Public",
+          "nsfwLevel": 1,
+          "description": null,
+          "trainedWords": ["AS-Adult"],
+          "stats": {
+            "downloadCount": 20188,
+            "ratingCount": 243,
+            "rating": 5,
+            "thumbsUpCount": 285,
+            "thumbsDownCount": 0
+          },
+          "files": [
+            {
+              "id": 51397,
+              "sizeKB": 36.931640625,
+              "name": "AS-Adult-neg.pt",
+              "type": "Negative",
+              "pickleScanResult": "Success",
+              "pickleScanMessage": "No Pickle imports",
+              "virusScanResult": "Success",
+              "virusScanMessage": null,
+              "scannedAt": "2023-05-18T20:26:37.174Z",
+              "metadata": {
+                "format": "Other",
+                "size": null,
+                "fp": null
+              },
+              "hashes": {
+                "AutoV2": "53BBE9D7FF",
+                "SHA256": "53BBE9D7FFF19414E1CE62197DEC0FD190533E484CC169072A3D9F9994B38927",
+                "CRC32": "6DB06872",
+                "BLAKE3": "E2145D804DD446327261948DE4DB59FD0B0A70049DAA93933BB185CFADE0D6CC"
+              },
+              "downloadUrl": "https://civitai.com/api/download/models/74332",
+              "primary": true
+            }
+          ],
+          "images": [
+            {
+              "id": 843801,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/323129ee-aa6a-4929-93ae-7394776e2087/width=450/843801.jpeg",
+              "nsfwLevel": 1,
+              "width": 1024,
+              "height": 2048,
+              "hash": "UBH2l[z;xbIoD44.OEkC00_NV@s:HCrXw^tR",
+              "type": "image"
+            },
+            {
+              "id": 831042,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/8eda3a0f-5ad5-4c6f-a3ff-06fde66320d7/width=450/831042.jpeg",
+              "nsfwLevel": 1,
+              "width": 1024,
+              "height": 1536,
+              "hash": "U8DuY*5U0K};02-UxtNc0~R%]UV]O7S#w$sW",
+              "type": "image"
+            },
+            {
+              "id": 831044,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/4d6c6586-3b82-42ac-975f-cc48259f57fd/width=450/831044.jpeg",
+              "nsfwLevel": 1,
+              "width": 1024,
+              "height": 1536,
+              "hash": "U7CFq*IVAt4o^0NG01IV01~U-;?a02E2~Cxt",
+              "type": "image"
+            },
+            {
+              "id": 845146,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/baea8193-2cf2-42fd-b2ad-fc574420bca1/width=450/845146.jpeg",
+              "nsfwLevel": 1,
+              "width": 1024,
+              "height": 1536,
+              "hash": "U27^f0}@0N0g}raK0M0#01M|E}OX~A%2XT-:",
+              "type": "image"
+            },
+            {
+              "id": 845149,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/6ac85d4a-577b-4676-97c8-000cca94160b/width=450/845149.jpeg",
+              "nsfwLevel": 1,
+              "width": 1024,
+              "height": 1536,
+              "hash": "USIXa0s%9sxY?]avE1NHcZV?#*ofxsackXs.",
+              "type": "image"
+            },
+            {
+              "id": 845153,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/0235025f-087f-4553-b7f7-a687ff0f64e4/width=450/845153.jpeg",
+              "nsfwLevel": 1,
+              "width": 1024,
+              "height": 1536,
+              "hash": "U6E1y^-U00$g7fS~DOR%0:NI}9S5IBaL-;af",
+              "type": "image"
+            },
+            {
+              "id": 845156,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/38c82184-373d-482f-88ed-e78a7bfcc8b9/width=450/845156.jpeg",
+              "nsfwLevel": 1,
+              "width": 1024,
+              "height": 1536,
+              "hash": "UJIOUpoy~W-:?HofNGWBMzayoxWB%MayjGof",
+              "type": "image"
+            },
+            {
+              "id": 845148,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/5cd42a35-7bff-41a0-a657-642c42ff7fa2/width=450/845148.jpeg",
+              "nsfwLevel": 1,
+              "width": 1024,
+              "height": 1536,
+              "hash": "UEF5mSxa-nbG~UodjGxa0MIVR*ofR*t7R,oe",
+              "type": "image"
+            },
+            {
+              "id": 845147,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/d1fd4f78-6142-43b6-b1ca-9e356d5b7d04/width=450/845147.jpeg",
+              "nsfwLevel": 1,
+              "width": 1024,
+              "height": 1536,
+              "hash": "U59jlwRk~pt7V?xuxujs9uNHRlRko}E2%MNG",
+              "type": "image"
+            },
+            {
+              "id": 845145,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/8e6f7537-24da-4a46-b4c2-e4a53234726b/width=450/845145.jpeg",
+              "nsfwLevel": 1,
+              "width": 1024,
+              "height": 1536,
+              "hash": "U2AJ$eIoJ4t7~C%M~pIo4=xvR7IV0Mxux^M{",
+              "type": "image"
+            },
+            {
+              "id": 831040,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/98cbaa0a-fdda-434b-a395-1ab429c2bf26/width=450/831040.jpeg",
+              "nsfwLevel": 1,
+              "width": 1024,
+              "height": 1536,
+              "hash": "UHC?cXo#I?j[~px]t7ae?bWCt7aes.aeRjWB",
+              "type": "image"
+            },
+            {
+              "id": 831043,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/5f238884-6346-4ea0-b0d9-88daa6a3b688/width=450/831043.jpeg",
+              "nsfwLevel": 1,
+              "width": 1024,
+              "height": 1536,
+              "hash": "U7D+o2IJ0d}@o|I-0L%M1RxZ=WI@-.H@t1IU",
+              "type": "image"
+            },
+            {
+              "id": 831039,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/47b790b8-0c9a-4700-bad4-077a02ff2c91/width=450/831039.jpeg",
+              "nsfwLevel": 1,
+              "width": 1024,
+              "height": 1536,
+              "hash": "UIF#%6?G%2t5~B%LxZjuIoj[IoayIWxZs.Rk",
+              "type": "image"
+            },
+            {
+              "id": 831041,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/40d674f6-1933-4d2c-9da9-45f753c92963/width=450/831041.jpeg",
+              "nsfwLevel": 1,
+              "width": 1024,
+              "height": 1536,
+              "hash": "UIFsPW_MNgof?^RjtORj%gWXRPxt_3RjRRj]",
+              "type": "image"
+            },
+            {
+              "id": 845151,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/29e18562-447b-44e1-a553-51836c994e3f/width=450/845151.jpeg",
+              "nsfwLevel": 1,
+              "width": 1024,
+              "height": 1536,
+              "hash": "UTH1#,xaIowJ~WxaM{ni?vRQrsR*T0M{e.WB",
+              "type": "image"
+            },
+            {
+              "id": 845154,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/293f6ee5-b175-4b03-a3d9-86af19cb6e1c/width=450/845154.jpeg",
+              "nsfwLevel": 1,
+              "width": 1024,
+              "height": 1536,
+              "hash": "UIELpcx^J5jE~W?bNGRi~W-;$*M{?atRspRj",
+              "type": "image"
+            },
+            {
+              "id": 845152,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/b26e6273-f0d8-42f8-980b-f0f256e53238/width=450/845152.jpeg",
+              "nsfwLevel": 1,
+              "width": 1024,
+              "height": 1536,
+              "hash": "UIF;vR?FX9-T~Vt7t8n%#+WCR*SOM{xGs8j[",
+              "type": "image"
+            },
+            {
+              "id": 845150,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/a48450db-d42c-4956-892a-4c0ead59a6db/width=450/845150.jpeg",
+              "nsfwLevel": 1,
+              "width": 1024,
+              "height": 1536,
+              "hash": "UDE_%4nNKP$$9b-ntRaK~UE3s+Rk0LENadWY",
+              "type": "image"
+            }
+          ],
+          "downloadUrl": "https://civitai.com/api/download/models/74332"
+        },
+        {
+          "id": 75443,
+          "index": 5,
+          "name": "Adult",
+          "baseModel": "SD 1.5",
+          "baseModelType": "Standard",
+          "publishedAt": "2023-05-20T00:58:05.193Z",
+          "availability": "Public",
+          "nsfwLevel": 1,
+          "description": null,
+          "trainedWords": ["AS-Adult"],
+          "stats": {
+            "downloadCount": 22503,
+            "ratingCount": 66,
+            "rating": 4.98,
+            "thumbsUpCount": 110,
+            "thumbsDownCount": 0
+          },
+          "files": [
+            {
+              "id": 52087,
+              "sizeKB": 27.857421875,
+              "name": "AS-Adult.pt",
+              "type": "Model",
+              "pickleScanResult": "Success",
+              "pickleScanMessage": "No Pickle imports",
+              "virusScanResult": "Success",
+              "virusScanMessage": null,
+              "scannedAt": "2023-05-20T01:01:24.652Z",
+              "metadata": {
+                "format": "PickleTensor",
+                "size": null,
+                "fp": null
+              },
+              "hashes": {
+                "AutoV2": "5D558EC2FB",
+                "SHA256": "5D558EC2FB1ECDBDDE06329355560CF6BCA29868F59FF81DAE49611A915DB19E",
+                "CRC32": "FB8243E1",
+                "BLAKE3": "C45BFC149135C37F15D81FAAB42902A5D11802B0500ED4D08766D2628D15956B"
+              },
+              "downloadUrl": "https://civitai.com/api/download/models/75443",
+              "primary": true
+            }
+          ],
+          "images": [
+            {
+              "id": 843814,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/a6e8d1e4-6c98-425d-9cbc-e56f461c2027/width=450/843814.jpeg",
+              "nsfwLevel": 1,
+              "width": 1024,
+              "height": 1620,
+              "hash": "UAHxjD4otliw4nNaNGR500?vWB-U.mt,n*R6",
+              "type": "image"
+            }
+          ],
+          "downloadUrl": "https://civitai.com/api/download/models/75443"
+        },
+        {
+          "id": 75557,
+          "index": 6,
+          "name": "MidAged",
+          "baseModel": "SD 1.5",
+          "baseModelType": "Standard",
+          "publishedAt": "2023-05-20T04:04:22.629Z",
+          "availability": "Public",
+          "nsfwLevel": 1,
+          "description": null,
+          "trainedWords": ["AS-MidAged"],
+          "stats": {
+            "downloadCount": 19107,
+            "ratingCount": 237,
+            "rating": 5,
+            "thumbsUpCount": 273,
+            "thumbsDownCount": 0
+          },
+          "files": [
+            {
+              "id": 52163,
+              "sizeKB": 48.86328125,
+              "name": "AS-MidAged.pt",
+              "type": "Model",
+              "pickleScanResult": "Success",
+              "pickleScanMessage": "No Pickle imports",
+              "virusScanResult": "Success",
+              "virusScanMessage": null,
+              "scannedAt": "2023-05-20T04:06:14.930Z",
+              "metadata": {
+                "format": "PickleTensor",
+                "size": null,
+                "fp": null
+              },
+              "hashes": {
+                "AutoV2": "D9A9546A59",
+                "SHA256": "D9A9546A597AD34497D4A5A24624478DF056B5A9426A1934EFDBFD65177B120D",
+                "CRC32": "3A5BB8FA",
+                "BLAKE3": "0F1AA0BBE6D001F0B6E52DF67A6D60546E5E2AB90D1CEA14D3731AAC48EA50F4"
+              },
+              "downloadUrl": "https://civitai.com/api/download/models/75557",
+              "primary": true
+            }
+          ],
+          "images": [
+            {
+              "id": 845182,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/963a21f7-732c-4e1e-9fe2-71cc6df0858c/width=450/845182.jpeg",
+              "nsfwLevel": 1,
+              "width": 1024,
+              "height": 1620,
+              "hash": "U9HxjD4Ts=XS4nR5MeNa00?vVY-;.mtlrXR+",
+              "type": "image"
+            }
+          ],
+          "downloadUrl": "https://civitai.com/api/download/models/75557"
+        },
+        {
+          "id": 77257,
+          "index": 7,
+          "name": "Elderly",
+          "baseModel": "SD 1.5",
+          "baseModelType": "Standard",
+          "publishedAt": "2023-05-21T21:01:21.016Z",
+          "availability": "Public",
+          "nsfwLevel": 1,
+          "description": null,
+          "trainedWords": ["AS-Elderly"],
+          "stats": {
+            "downloadCount": 16392,
+            "ratingCount": 1462,
+            "rating": 5,
+            "thumbsUpCount": 1489,
+            "thumbsDownCount": 0
+          },
+          "files": [
+            {
+              "id": 53245,
+              "sizeKB": 45.86328125,
+              "name": "AS-Elderly.pt",
+              "type": "Model",
+              "pickleScanResult": "Success",
+              "pickleScanMessage": "No Pickle imports",
+              "virusScanResult": "Success",
+              "virusScanMessage": null,
+              "scannedAt": "2023-05-21T21:01:21.983Z",
+              "metadata": {
+                "format": "PickleTensor",
+                "size": null,
+                "fp": null
+              },
+              "hashes": {
+                "AutoV2": "C19D044E3C",
+                "SHA256": "C19D044E3C1AA50E29A0B409B4AD1FD8AACD7D599E0F63A2D7ACD0E5EFAA993C",
+                "CRC32": "AA591012",
+                "BLAKE3": "10591E0FE8D0F8D8182A775C60DBC49BE39F0582D2BB96921951CE62D2411D17"
+              },
+              "downloadUrl": "https://civitai.com/api/download/models/77257",
+              "primary": true
+            }
+          ],
+          "images": [
+            {
+              "id": 866262,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/fea7f825-e8e0-45c0-a458-f0181be2403e/width=450/866262.jpeg",
+              "nsfwLevel": 1,
+              "width": 1024,
+              "height": 1620,
+              "hash": "U9HxjD4Tt,XS4nQ-J8Nb00?bSz-;.mxbofR+",
+              "type": "image"
+            }
+          ],
+          "downloadUrl": "https://civitai.com/api/download/models/77257"
+        },
+        {
+          "id": 69898,
+          "index": 8,
+          "name": "Young Negative",
+          "baseModel": "SD 1.5",
+          "baseModelType": "Standard",
+          "publishedAt": "2023-05-13T19:27:56.151Z",
+          "availability": "Public",
+          "nsfwLevel": 1,
+          "description": null,
+          "trainedWords": ["AS-Young"],
+          "stats": {
+            "downloadCount": 27340,
+            "ratingCount": 66,
+            "rating": 4.97,
+            "thumbsUpCount": 91,
+            "thumbsDownCount": 0
+          },
+          "files": [
+            {
+              "id": 48790,
+              "sizeKB": 30.931640625,
+              "name": "AS-Young-neg.pt",
+              "type": "Negative",
+              "pickleScanResult": "Success",
+              "pickleScanMessage": "No Pickle imports",
+              "virusScanResult": "Success",
+              "virusScanMessage": null,
+              "scannedAt": "2023-05-13T19:30:56.654Z",
+              "metadata": {
+                "format": "Other",
+                "size": null,
+                "fp": null
+              },
+              "hashes": {
+                "AutoV2": "077A3A9610",
+                "SHA256": "077A3A96101C3516A84F41BAD73EF2FAE32E85B3A55D8C04297345EDDFD52956",
+                "CRC32": "4DE618E2",
+                "BLAKE3": "73485D9ADA91B9B702A8554371DCCD4ED65249400CAAD21B3F4F8AE9EE212557"
+              },
+              "downloadUrl": "https://civitai.com/api/download/models/69898",
+              "primary": true
+            }
+          ],
+          "images": [
+            {
+              "id": 1122930,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/d99394ab-e0fd-4cf0-870f-19b09c07e279/width=450/1122930.jpeg",
+              "nsfwLevel": 1,
+              "width": 1024,
+              "height": 2048,
+              "hash": "UEF5gY?^TJae%g9[WVxGQ7tRrraKIBMdnio}",
+              "type": "image"
+            },
+            {
+              "id": 780563,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/058802d4-39f0-467c-bf12-ac78287df29e/width=450/780563.jpeg",
+              "nsfwLevel": 1,
+              "width": 1024,
+              "height": 1536,
+              "hash": "UhH-lVRjE*NGM_IUNGWB_NWB$%WBNKV@i_WV",
+              "type": "image"
+            },
+            {
+              "id": 780558,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/91299b6e-055c-40d3-86bd-7404ac5cea13/width=450/780558.jpeg",
+              "nsfwLevel": 1,
+              "width": 1024,
+              "height": 1536,
+              "hash": "UPFrbQ00%z$%~q4nT0xZxBD%kEaK%1RkR+R*",
+              "type": "image"
+            },
+            {
+              "id": 780556,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/202be936-82c0-4e09-8b4f-d110971bc9a8/width=450/780556.jpeg",
+              "nsfwLevel": 1,
+              "width": 1024,
+              "height": 1536,
+              "hash": "UHFheH~o5TX5~V~U-:kCkp-o%2tQSeR+$%-.",
+              "type": "image"
+            },
+            {
+              "id": 780559,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/c46dc742-ef0c-4e6a-a307-f99e54cb7bbe/width=450/780559.jpeg",
+              "nsfwLevel": 1,
+              "width": 1024,
+              "height": 1536,
+              "hash": "U8BpXp_1Dj4:_L_2-Ta0=s_1TJn5KMwI%M%L",
+              "type": "image"
+            },
+            {
+              "id": 780554,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/8bd9c714-a2b7-4fdf-97b3-767cfe3608af/width=450/780554.jpeg",
+              "nsfwLevel": 1,
+              "width": 1024,
+              "height": 1536,
+              "hash": "UMK-IHoh9sXTWr%M~qRjbI-;-;M{t8M{Rjt7",
+              "type": "image"
+            },
+            {
+              "id": 780562,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/54ec1470-d6d2-43cb-b589-d460ba730516/width=450/780562.jpeg",
+              "nsfwLevel": 1,
+              "width": 1024,
+              "height": 1536,
+              "hash": "UMEeohQ-EL%g~pIAIVt+_2IoV@xtw]NbOExZ",
+              "type": "image"
+            },
+            {
+              "id": 780567,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/a0527d2b-f5f3-480f-a270-e2fd2c90d84d/width=450/780567.jpeg",
+              "nsfwLevel": 1,
+              "width": 1024,
+              "height": 1536,
+              "hash": "UWG+tEWYs*W=pdbHxuNG~qkCR5WB9tofRPae",
+              "type": "image"
+            },
+            {
+              "id": 780561,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/42eae57b-e74c-461c-81e7-9ba9f7084606/width=450/780561.jpeg",
+              "nsfwLevel": 1,
+              "width": 1024,
+              "height": 1536,
+              "hash": "URH1xw%M1HE2~VShM|M{%yS$,@r??HWYt6Rj",
+              "type": "image"
+            },
+            {
+              "id": 780565,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/1d47cc7f-a347-4c3a-b250-6ecd1bf7ef6d/width=450/780565.jpeg",
+              "nsfwLevel": 1,
+              "width": 1024,
+              "height": 1536,
+              "hash": "UjF$2=NGX8%1~oR*Rkt6ozj@M{NHRkWCM|Rj",
+              "type": "image"
+            },
+            {
+              "id": 780557,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/6b3f353f-b456-4b3c-90ad-a6671e5a51a8/width=450/780557.jpeg",
+              "nsfwLevel": 1,
+              "width": 1024,
+              "height": 2048,
+              "hash": "UDCPeY?^S~V@J79tWCxZy?x]niV@D%MdjFoz",
+              "type": "image"
+            }
+          ],
+          "downloadUrl": "https://civitai.com/api/download/models/69898"
+        },
+        {
+          "id": 69844,
+          "index": 9,
+          "name": "Young",
+          "baseModel": "SD 1.5",
+          "baseModelType": "Standard",
+          "publishedAt": "2023-05-13T18:10:52.273Z",
+          "availability": "Public",
+          "nsfwLevel": 1,
+          "description": null,
+          "trainedWords": ["AS-Young"],
+          "stats": {
+            "downloadCount": 16403,
+            "ratingCount": 21,
+            "rating": 4.95,
+            "thumbsUpCount": 39,
+            "thumbsDownCount": 0
+          },
+          "files": [
+            {
+              "id": 48756,
+              "sizeKB": 42.8603515625,
+              "name": "AS-Young.pt",
+              "type": "Model",
+              "pickleScanResult": "Success",
+              "pickleScanMessage": "No Pickle imports",
+              "virusScanResult": "Success",
+              "virusScanMessage": null,
+              "scannedAt": "2023-05-13T18:11:11.744Z",
+              "metadata": {
+                "format": "PickleTensor",
+                "size": null,
+                "fp": null
+              },
+              "hashes": {
+                "AutoV2": "AFE3F9EC65",
+                "SHA256": "AFE3F9EC65FE1CE5400E483FB8C905ED5A29B9D1F93948E9A3D874AB87CF165E",
+                "CRC32": "5B6939AD",
+                "BLAKE3": "342AD98D6BEEBE940870A31B522F3636702CCEDB80A18424B4277DF4EDB79FD1"
+              },
+              "downloadUrl": "https://civitai.com/api/download/models/69844",
+              "primary": true
+            }
+          ],
+          "images": [
+            {
+              "id": 780514,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/ff02cd51-a962-4816-9c92-23b3e6e41e22/width=450/780514.jpeg",
+              "nsfwLevel": 1,
+              "width": 1024,
+              "height": 1650,
+              "hash": "UCA]+~XSXSr@*Jx[WVaKBoPAs:iw%MS~g3nO",
+              "type": "image"
+            }
+          ],
+          "downloadUrl": "https://civitai.com/api/download/models/69844"
+        },
+        {
+          "id": 69852,
+          "index": 10,
+          "name": "Younger",
+          "baseModel": "SD 1.5",
+          "baseModelType": "Standard",
+          "publishedAt": "2023-05-13T18:22:54.754Z",
+          "availability": "Public",
+          "nsfwLevel": 1,
+          "description": null,
+          "trainedWords": ["AS-Younger"],
+          "stats": {
+            "downloadCount": 16515,
+            "ratingCount": 62,
+            "rating": 5,
+            "thumbsUpCount": 76,
+            "thumbsDownCount": 0
+          },
+          "files": [
+            {
+              "id": 48762,
+              "sizeKB": 42.8603515625,
+              "name": "AS-Younger.pt",
+              "type": "Model",
+              "pickleScanResult": "Success",
+              "pickleScanMessage": "No Pickle imports",
+              "virusScanResult": "Success",
+              "virusScanMessage": null,
+              "scannedAt": "2023-05-13T18:25:56.778Z",
+              "metadata": {
+                "format": "PickleTensor",
+                "size": null,
+                "fp": null
+              },
+              "hashes": {
+                "AutoV2": "BB0B7E68D9",
+                "SHA256": "BB0B7E68D9FBF97A8C06FC5A670C2C26712F9FAD37C08F500B89126CF277B8B2",
+                "CRC32": "C93D3101",
+                "BLAKE3": "43B341700FB264A164A04565C629ABCDB4FE38F9BD631FA6E5A43AA95FB8FDE7"
+              },
+              "downloadUrl": "https://civitai.com/api/download/models/69852",
+              "primary": true
+            }
+          ],
+          "images": [
+            {
+              "id": 780471,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/f1de9713-c856-4b6c-96ff-cd46d685f2c7/width=450/780471.jpeg",
+              "nsfwLevel": 1,
+              "width": 1024,
+              "height": 1650,
+              "hash": "UBA],0iwZ$tR.mw_Z$XSADOrwcae#mR,cEni",
+              "type": "image"
+            }
+          ],
+          "downloadUrl": "https://civitai.com/api/download/models/69852"
+        },
+        {
+          "id": 69933,
+          "index": 11,
+          "name": "Youngest",
+          "baseModel": "SD 1.5",
+          "baseModelType": "Standard",
+          "publishedAt": "2023-05-13T20:31:38.353Z",
+          "availability": "Public",
+          "nsfwLevel": 1,
+          "description": null,
+          "trainedWords": ["AS-Youngest"],
+          "stats": {
+            "downloadCount": 14657,
+            "ratingCount": 810,
+            "rating": 5,
+            "thumbsUpCount": 827,
+            "thumbsDownCount": 0
+          },
+          "files": [
+            {
+              "id": 48813,
+              "sizeKB": 42.8603515625,
+              "name": "AS-Youngest.pt",
+              "type": "Model",
+              "pickleScanResult": "Success",
+              "pickleScanMessage": "No Pickle imports",
+              "virusScanResult": "Success",
+              "virusScanMessage": null,
+              "scannedAt": "2023-05-13T20:35:56.825Z",
+              "metadata": {
+                "format": "PickleTensor",
+                "size": null,
+                "fp": null
+              },
+              "hashes": {
+                "AutoV2": "A4E11EA278",
+                "SHA256": "A4E11EA27857A5B4A5AAF6260823A39B039BD026D21C6664EA665A6700D86CE1",
+                "CRC32": "AD837DBE",
+                "BLAKE3": "0597DE039E43030B3BB9A7FE33043A33D8F1B807D568B031DEDC57868314AED5"
+              },
+              "downloadUrl": "https://civitai.com/api/download/models/69933",
+              "primary": true
+            }
+          ],
+          "images": [
+            {
+              "id": 780997,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/edc60b82-95de-40e5-b2fe-82638ccf2a94/width=450/780997.jpeg",
+              "nsfwLevel": 1,
+              "width": 1024,
+              "height": 1650,
+              "hash": "U8B3QmmRTJtl?^$OWBX84.LLv}iw-BOEkVo0",
+              "type": "image"
+            }
+          ],
+          "downloadUrl": "https://civitai.com/api/download/models/69933"
+        }
+      ]
+    },
+    {
+      "id": 5224,
+      "name": "Bad artist Negative embedding ",
+      "description": "<h3><strong>I AM NOT THE ORIGINAL CREATOR OF THIS EMBEDDING</strong></h3><p>HE IS -</p><p><a target=\"_blank\" rel=\"ugc\" href=\"https://huggingface.co/nick-x-hacker/bad-artist\">https://huggingface.co/nick-x-hacker/bad-artist</a></p><p>The images above were generated with <strong>only \"solo\"</strong> in the positive prompt, and \"sketch by bad-artist\" (this embedding) in the negative.<br />The embedding uses only <strong>2 tokens</strong>.</p><p>Textual-inversion embedding for use in unconditional (negative) prompt.<br />Inspired partly by <a target=\"_blank\" rel=\"ugc\" href=\"https://huggingface.co/datasets/Nerfgun3/bad_prompt\"><strong><u>https://huggingface.co/datasets/Nerfgun3/bad_prompt</u></strong></a>.</p><p>There are currently 2 version:</p><ul><li><p>'bad-artist': Not as strong, but produces pretty unique images (recommended)</p></li><li><p>'bad-artist-anime': More generic anime style (this was the first version uploaded)</p></li></ul><p>I recommend using with 'by', so for example \"sketch <strong>by bad-artist</strong>\", or \"painting <strong>by bad-artist</strong>\", or \"photograph <strong>by bad-artist</strong>\", etc.</p><p>Trained with 2 vectors per token for 15000 (1850x8) steps, at 500x500, on an Anything-v3-based model.</p><p>Full generation parameters for images above (using the 'bad-artist' version, not the 'bad-artist-anime' version):</p><pre><code>solo\nNegative prompt: sketch by bad-artist\nSteps: 15, Sampler: DPM++ 2M Karras, CFG scale: 4, Seed: 1476197242, Size: 512x640, Clip skip: 2</code></pre>",
+      "allowNoCredit": true,
+      "allowCommercialUse": ["Image", "RentCivit", "Rent", "Sell"],
+      "allowDerivatives": true,
+      "allowDifferentLicense": true,
+      "type": "TextualInversion",
+      "minor": false,
+      "poi": false,
+      "nsfw": false,
+      "nsfwLevel": 1,
+      "cosmetic": null,
+      "stats": {
+        "downloadCount": 121446,
+        "favoriteCount": 0,
+        "thumbsUpCount": 8148,
+        "thumbsDownCount": 7,
+        "commentCount": 19,
+        "ratingCount": 0,
+        "rating": 0,
+        "tippedAmountCount": 90
+      },
+      "creator": {
+        "username": "Ocean5",
+        "image": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/9ef93702-5d2c-4d5c-2af9-51e810d23a00/width=96/Ocean5.jpeg"
+      },
+      "tags": ["bad artist"],
+      "modelVersions": [
+        {
+          "id": 6056,
+          "index": 0,
+          "name": "Bad artist ",
+          "baseModel": "SD 1.5",
+          "baseModelType": "Standard",
+          "publishedAt": "2023-01-25T06:11:36.905Z",
+          "availability": "Public",
+          "nsfwLevel": 1,
+          "description": null,
+          "trainedWords": ["By bad artist "],
+          "stats": {
+            "downloadCount": 92345,
+            "ratingCount": 516,
+            "rating": 4.85,
+            "thumbsUpCount": 1294,
+            "thumbsDownCount": 3
+          },
+          "files": [
+            {
+              "id": 6310,
+              "sizeKB": 6.9169921875,
+              "name": "By bad artist -neg.pt",
+              "type": "Negative",
+              "pickleScanResult": "Success",
+              "pickleScanMessage": "**Detected Pickle imports (3)**\n```\ncollections.OrderedDict\ntorch.FloatStorage\ntorch._utils._rebuild_tensor_v2\n```",
+              "virusScanResult": "Success",
+              "virusScanMessage": null,
+              "scannedAt": "2023-01-25T06:19:33.578Z",
+              "metadata": {
+                "format": "Other"
+              },
+              "hashes": {
+                "AutoV2": "2D35613490",
+                "SHA256": "2D356134903E8F47BF6CF519BDF577CDCEE42FC717EF264498162E94F130843A",
+                "CRC32": "B64B5295",
+                "BLAKE3": "251BA8F2EE852EA7837794807809CB1B84C36BA7FE99775994323077DD8FC7F2"
+              },
+              "downloadUrl": "https://civitai.com/api/download/models/6056",
+              "primary": true
+            }
+          ],
+          "images": [
+            {
+              "id": 52078,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/cb4bd554-c7ed-4837-3803-8f24fa8fc900/width=450/52078.jpeg",
+              "nsfwLevel": 1,
+              "width": 3072,
+              "height": 1920,
+              "hash": "U5IXdW}^9X?vwFIUOq?a_3t6IS$y~W%M%L-:",
+              "type": "image"
+            }
+          ],
+          "downloadUrl": "https://civitai.com/api/download/models/6056"
+        },
+        {
+          "id": 6057,
+          "index": 1,
+          "name": "Bad artist anime ",
+          "baseModel": "SD 1.5",
+          "baseModelType": "Standard",
+          "publishedAt": "2023-01-25T06:20:36.784Z",
+          "availability": "Public",
+          "nsfwLevel": 1,
+          "description": null,
+          "trainedWords": ["By bad artist "],
+          "stats": {
+            "downloadCount": 29101,
+            "ratingCount": 5142,
+            "rating": 4.99,
+            "thumbsUpCount": 7204,
+            "thumbsDownCount": 4
+          },
+          "files": [
+            {
+              "id": 6311,
+              "sizeKB": 6.9169921875,
+              "name": "By bad artist -neg.pt",
+              "type": "Negative",
+              "pickleScanResult": "Success",
+              "pickleScanMessage": "**Detected Pickle imports (3)**\n```\ntorch.FloatStorage\ncollections.OrderedDict\ntorch._utils._rebuild_tensor_v2\n```",
+              "virusScanResult": "Success",
+              "virusScanMessage": null,
+              "scannedAt": "2023-01-25T06:31:02.214Z",
+              "metadata": {
+                "format": "Other"
+              },
+              "hashes": {
+                "AutoV2": "5F7BEA8875",
+                "SHA256": "5F7BEA88750C97A0B8C9BA9F5BC0D13648C3A17A69AAAC855903229D5F58C34B",
+                "CRC32": "2D58B9AF",
+                "BLAKE3": "D00F9701F4B71DC175FE784998EE5588FB050801B748459699DF5B834613A521"
+              },
+              "downloadUrl": "https://civitai.com/api/download/models/6057",
+              "primary": true
+            }
+          ],
+          "images": [
+            {
+              "id": 52079,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/b1ebed82-d4e3-4213-d4dd-8b2b7696ba00/width=450/52079.jpeg",
+              "nsfwLevel": 1,
+              "width": 3072,
+              "height": 1920,
+              "hash": "U5IXdW}^9X?vwFIUOq?a_3t6IS$y~W%M%L-:",
+              "type": "image"
+            }
+          ],
+          "downloadUrl": "https://civitai.com/api/download/models/6057"
+        }
+      ]
+    },
+    {
+      "id": 55700,
+      "name": "bad_prompt Negative Embedding",
+      "description": "<h2>bad_prompt Version 1 and 2 (reupload from Huggingface)</h2><h2><a rel=\"ugc\" href=\"https://civitai.com/models/56519/negativehand-negative-embedding\">~Check out my new negative Embedding!~</a></h2><h3><strong>Foreword</strong></h3><p><strong>Since alot of people asked for it. Here is a reupload to civitai for my negative Embedding.</strong></p><p><strong>Disclaimer: A new negative embedding is still under develop and I will upload it on civit soon!</strong></p><p></p><p><strong>~Text from Huggingface~</strong></p><p><strong>Link: </strong><a target=\"_blank\" rel=\"ugc\" href=\"https://huggingface.co/datasets/Nerfgun3/bad_prompt\"><strong>https://huggingface.co/datasets/Nerfgun3/bad_prompt</strong></a></p><p></p><h2><strong>Idea</strong></h2><p>The idea behind this embedding was to somehow train the negative prompt as an embedding, thus unifying the basis of the negative prompt into one word or embedding.</p><p>Side note: Embedding has proven to be very helpful for the generation of hands! :)</p><h2>Usage</h2><p>To use this embedding you have to download the file aswell as drop it into the \"\\stable-diffusion-webui\\embeddings\" folder.</p><p>To activate the embedding, you will have to write the name of the file in the negative prompt!</p><p><strong>Please put the embedding in the negative prompt to get the right results!</strong></p><p>For special negative tags such as \"malformed sword\", you still need to add them yourself. The negative embedding is trained on a basic skeleton for the negative prompt, which should provide a high-resolution image as a result.</p><h3>Version 1:</h3><p>Issue: Changing the style to much.</p><p>~not downloadable on civit~</p><h3>Version 2:</h3><p>With this version I tried to reduce the amount of vectors used, aswell as the issue with the changing artstyle. The newer version is still a work in progress, but its already way better than the first version. Its in files section!</p><p>To use it in the negative prompt: <code>\"bad_prompt_version2\"</code></p><p>I hope you enjoy the embedding. If you have any questions, you can ask me anything via Discord: \"Nerfgun3#7508\"</p>",
+      "allowNoCredit": false,
+      "allowCommercialUse": ["Image", "RentCivit", "Rent"],
+      "allowDerivatives": true,
+      "allowDifferentLicense": true,
+      "type": "TextualInversion",
+      "minor": false,
+      "poi": false,
+      "nsfw": false,
+      "nsfwLevel": 1,
+      "cosmetic": null,
+      "stats": {
+        "downloadCount": 155715,
+        "favoriteCount": 0,
+        "thumbsUpCount": 6341,
+        "thumbsDownCount": 4,
+        "commentCount": 7,
+        "ratingCount": 0,
+        "rating": 0,
+        "tippedAmountCount": 152
+      },
+      "creator": {
+        "username": "Nerfgun3",
+        "image": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/6d89b406-336b-44f6-ea07-c4e1c2db8800/width=96/Nerfgun3.jpeg"
+      },
+      "tags": ["concept", "negative embedding", "embedding", "orginal content"],
+      "modelVersions": [
+        {
+          "id": 60095,
+          "index": 0,
+          "name": "bad_prompt_version2",
+          "baseModel": "SD 1.5",
+          "baseModelType": "Standard",
+          "publishedAt": "2023-05-01T21:36:15.032Z",
+          "availability": "Public",
+          "nsfwLevel": 1,
+          "description": "<p>The better and improved version of bad_prompt.</p>",
+          "trainedWords": ["bad_prompt_version2"],
+          "stats": {
+            "downloadCount": 155715,
+            "ratingCount": 4183,
+            "rating": 4.98,
+            "thumbsUpCount": 6341,
+            "thumbsDownCount": 4
+          },
+          "files": [
+            {
+              "id": 42594,
+              "sizeKB": 24.9169921875,
+              "name": "bad_prompt_version2-neg.pt",
+              "type": "Negative",
+              "pickleScanResult": "Success",
+              "pickleScanMessage": "No Pickle imports",
+              "virusScanResult": "Success",
+              "virusScanMessage": null,
+              "scannedAt": "2023-05-01T21:40:36.624Z",
+              "metadata": {
+                "format": "Other",
+                "size": null,
+                "fp": null
+              },
+              "hashes": {
+                "AutoV2": "6F35E7DD81",
+                "SHA256": "6F35E7DD816AE04BB3F774A9A17EBFBC50C0E3A53F69A9A40BED05936D3A3812",
+                "CRC32": "DC3150FB",
+                "BLAKE3": "F4D331398F7081F8064B296485A49AE906E4C95A8830E3DA94658414218690C7"
+              },
+              "downloadUrl": "https://civitai.com/api/download/models/60095",
+              "primary": true
+            }
+          ],
+          "images": [
+            {
+              "id": 656105,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/0f12ec45-0d26-4e15-0bb1-6e23230d8700/width=450/656105.jpeg",
+              "nsfwLevel": 1,
+              "width": 2048,
+              "height": 1024,
+              "hash": "UIHBPZn2tnS%~B=_EkTK$y-oD*bw^*RjNHM|",
+              "type": "image"
+            }
+          ],
+          "downloadUrl": "https://civitai.com/api/download/models/60095"
+        }
+      ]
+    },
+    {
+      "id": 17083,
+      "name": "bad-picture negative embedding for ChilloutMix",
+      "description": "<p>March 17, 2023 edit: quick note on how to use a negative embeddings.  You download the file and put it into your embeddings folder.  Since I use A1111 Webui, that is stable-diffusion-webui/embeddings.  If you use a different program you will have to check with its documentation on where to put embeddings.  </p><p>After you have put the file in the appropriate folder, you then use the embedding by entering its name into the \"negative prompt\" box instead of the normal prompt.  The name, by default, will be either bad-picture-chill-75v, bad-picture-chill-32v, or bad-picture-chill-1v, depending on which one you downloaded.  If you rename the file, that will change the activation word to whatever you renamed the file.  So if you renamed \"bad-picture-chill-75v.pt\" to \"pizza-is-great.pt\" the activation phrase changes to \"pizza-is-great\"</p><p>End of edit.</p><p></p><p></p><p>This is a \"bad prompt\" style embedding- it is trained to be used in the negative prompt. It is made specifically for ChilloutMix (version chilloutmix_NiPrunedFp32Fix.safetensors [fc2511737a]), so it may or may not work well on a non-chilloutmix model. The prompts used for the pictures were mostly taken from the comment section on the ChilloutMix page.</p><p></p><p>It comes in 1 vector, 32 vector, and 75 vector versions- the higher you go, the more detail you will be able to squeeze out, but the closer you will get to deep-frying your image. Check out the comparison images that I uploaded as part of the 75 vector version- you'll probably have to right-click and \"open image in new tab\" to properly zoom in.</p><p></p><p>The 'Training Images\" download for each version is a .zip that has all the saved .pt versions that were generated during the training. Look there if you want a version that has more or less steps. If you want the <em>actual</em> training images, click on the \"Actual Training Images\" version which should be below the 1V version of the embedding.</p><p></p><p>Preview images: all preview images were generated at 512x512 with highres enabled @ a factor of 2 and 0.75 denoising, resulting in a final image of 1024x1024. Model: chilloutmix_NiPrunedFp32Fix.safetensors [fc2511737a]</p><p></p><p>Sometimes the original prompt or original negative prompt will include a LORA or embedding- here are links to them. <strong>Note:</strong> these are not used in the single image previews, only the original prompts that I borrowed and put into the stacked comparison images.</p><p><a target=\"_blank\" rel=\"ugc\" href=\"https://huggingface.co/AnonPerson/ChilloutMix/blob/main/Japanese-doll-likeness.safetensors\">Japanese Dolllikeness lora (robot lady image)</a></p><p><a target=\"_blank\" rel=\"ugc\" href=\"https://civitai.com/models/7808/easynegative\">easynegative embed (armored lady) (impossibly tight black bodysuit lady)</a></p><p><a target=\"_blank\" rel=\"ugc\" href=\"https://huggingface.co/datasets/Nerfgun3/bad_prompt/tree/main\">bad-prompt embed (evil dogzilla looking thing)</a></p><p><a target=\"_blank\" rel=\"ugc\" href=\"https://civitai.com/models/4629/deep-negative-v1x\">ng_deepnegative_v1_75 embed (fox ears lady)</a></p>",
+      "allowNoCredit": true,
+      "allowCommercialUse": ["Image", "RentCivit"],
+      "allowDerivatives": true,
+      "allowDifferentLicense": false,
+      "type": "TextualInversion",
+      "minor": false,
+      "poi": false,
+      "nsfw": false,
+      "nsfwLevel": 15,
+      "cosmetic": null,
+      "stats": {
+        "downloadCount": 88048,
+        "favoriteCount": 0,
+        "thumbsUpCount": 5718,
+        "thumbsDownCount": 2,
+        "commentCount": 29,
+        "ratingCount": 0,
+        "rating": 0,
+        "tippedAmountCount": 222
+      },
+      "creator": {
+        "username": "SeekerOfTheThicc",
+        "image": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/1798e04e-ff51-41bb-acd7-86762e165000/width=96/SeekerOfTheThicc.jpeg"
+      },
+      "tags": [
+        "negative embedding",
+        "textual inversion",
+        "bad prompt",
+        "embedding",
+        "tool"
+      ],
+      "modelVersions": [
+        {
+          "id": 20170,
+          "index": 0,
+          "name": "75 Vector Version",
+          "baseModel": "SD 1.5",
+          "baseModelType": "Standard",
+          "publishedAt": "2023-03-08T09:09:09.547Z",
+          "availability": "Public",
+          "nsfwLevel": 15,
+          "description": "<p>Trained until step 2101 @ 4batch 5grad with a variable learning rate using an <a target=\"_blank\" rel=\"ugc\" href=\"https://github.com/aria1th/Hypernetwork-MonkeyPatch-Extension\">extension for WebUI</a> that has advanced TI training features. The training .zip contains saves with lesser and higher step counts.</p>",
+          "trainedWords": ["bad-picture-chill-75v"],
+          "stats": {
+            "downloadCount": 79581,
+            "ratingCount": 265,
+            "rating": 4.84,
+            "thumbsUpCount": 781,
+            "thumbsDownCount": 2
+          },
+          "files": [
+            {
+              "id": 16825,
+              "sizeKB": 226.09765625,
+              "name": "bad-picture-chill-75v.pt",
+              "type": "Model",
+              "pickleScanResult": "Success",
+              "pickleScanMessage": "No Pickle imports",
+              "virusScanResult": "Success",
+              "virusScanMessage": null,
+              "scannedAt": "2023-03-08T09:11:00.315Z",
+              "metadata": {
+                "format": "PickleTensor",
+                "size": "full",
+                "fp": "fp16"
+              },
+              "hashes": {
+                "AutoV2": "7D9CC5F549",
+                "SHA256": "7D9CC5F549D7972F24803A3A9880A923FB9A1B68C1443DA3CE1FF2F7EFF25AE9",
+                "CRC32": "83F5C1F3",
+                "BLAKE3": "91A6DAD40975764161EF3BEA1EDC8D5EC302BFCCE6A685FA9DF2A73057710FAC"
+              },
+              "downloadUrl": "https://civitai.com/api/download/models/20170",
+              "primary": true
+            },
+            {
+              "id": 16995,
+              "sizeKB": 18599.8828125,
+              "name": "badPictureNegative_75VectorVersion_trainingData.zip",
+              "type": "Training Data",
+              "pickleScanResult": "Success",
+              "pickleScanMessage": "No Pickle imports",
+              "virusScanResult": "Success",
+              "virusScanMessage": null,
+              "scannedAt": "2023-03-08T18:40:57.531Z",
+              "metadata": {
+                "format": "Other"
+              },
+              "hashes": {
+                "AutoV1": "778366CE",
+                "AutoV2": "34FA8B15EE",
+                "SHA256": "34FA8B15EEAF12AE2E6B4D40EFAADE4E555832BC47264E4DE1F193A8029B1D42",
+                "CRC32": "914D5C1F",
+                "BLAKE3": "F4052F4B30E8197ABF369EF58B64BBFCB973891BAE200E2AC3C61292FDC1A027"
+              },
+              "downloadUrl": "https://civitai.com/api/download/models/20170?type=Training%20Data"
+            }
+          ],
+          "images": [
+            {
+              "id": 213186,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/b5cd1669-7a84-44e8-7cb3-6a7565636500/width=450/213186.jpeg",
+              "nsfwLevel": 2,
+              "width": 1024,
+              "height": 1024,
+              "hash": "UZKBH^9a%#-:*0RjxvNHM|WYMwNGjFaeM{t7",
+              "type": "image"
+            },
+            {
+              "id": 213184,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/835686da-7d81-43b9-65d4-5b6d94e8a100/width=450/213184.jpeg",
+              "nsfwLevel": 1,
+              "width": 1024,
+              "height": 1024,
+              "hash": "UH8}DID$In%N?wITM{tR.8M{M_t7%NRPV@t7",
+              "type": "image"
+            },
+            {
+              "id": 213185,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/cdb3352c-f15f-440e-d96f-a64cef58be00/width=450/213185.jpeg",
+              "nsfwLevel": 2,
+              "width": 1024,
+              "height": 1024,
+              "hash": "U7HTpm02zU~V03XS0ME257=x%f?F?tRjICNH",
+              "type": "image"
+            },
+            {
+              "id": 213182,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/92927d80-30b9-4fd0-ba6f-634c98397400/width=450/213182.jpeg",
+              "nsfwLevel": 1,
+              "width": 1024,
+              "height": 1024,
+              "hash": "UeG[cut7axM|~qRkjsRk%MIVWBofR+M|jss:",
+              "type": "image"
+            },
+            {
+              "id": 213183,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/d58d57b8-a58b-43da-7c2e-72ec5b245900/width=450/213183.jpeg",
+              "nsfwLevel": 1,
+              "width": 1024,
+              "height": 1024,
+              "hash": "UOAdl;DiD$%g_NMxIAxu-:RjM_t7x]WBRPt7",
+              "type": "image"
+            },
+            {
+              "id": 213214,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/0ca5c062-0217-4c83-e426-09ffd23c9600/width=450/213214.jpeg",
+              "nsfwLevel": 4,
+              "width": 1024,
+              "height": 1024,
+              "hash": "UPIg+SDh1u$iGvD$-BaK?wRPsqE1IqxuxtRP",
+              "type": "image"
+            },
+            {
+              "id": 213181,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/61a9c675-80f4-4d6a-cb9c-dea9947bb200/width=450/213181.jpeg",
+              "nsfwLevel": 1,
+              "width": 1024,
+              "height": 1024,
+              "hash": "U8D]k~Dh00_NIA%20LIUk=t7-AIo4:-;?H4.",
+              "type": "image"
+            },
+            {
+              "id": 215910,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/d7ff9046-6108-4167-1287-a9b026416f00/width=450/215910.jpeg",
+              "nsfwLevel": 4,
+              "width": 1024,
+              "height": 6144,
+              "hash": "URJt^|E3u4_NxuRjj]W=WoNGoeoLxvWBozkC",
+              "type": "image"
+            },
+            {
+              "id": 213229,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/e12242ca-3b8b-412a-2c77-816271da7300/width=450/213229.jpeg",
+              "nsfwLevel": 1,
+              "width": 1024,
+              "height": 6144,
+              "hash": "U78EPY8_9F?woeaybHWBM_ofofV@smj[bbWB",
+              "type": "image"
+            },
+            {
+              "id": 215909,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/036decc4-f7d3-4bac-52c9-4d909f4b1e00/width=450/215909.jpeg",
+              "nsfwLevel": 2,
+              "width": 1024,
+              "height": 6144,
+              "hash": "UCGjpX0}ZN~BiyX8VtNHNJbbWCR*xEs.o0n%",
+              "type": "image"
+            },
+            {
+              "id": 213227,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/125dae12-d829-480c-5e93-7ae7010b0f00/width=450/213227.jpeg",
+              "nsfwLevel": 1,
+              "width": 1024,
+              "height": 6144,
+              "hash": "UDGR#R~pxrxZx]ayWBofNFf6bGj[%LWBR*fP",
+              "type": "image"
+            },
+            {
+              "id": 213228,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/141ae4f3-90f0-41bf-ea91-ec76f9f7c100/width=450/213228.jpeg",
+              "nsfwLevel": 8,
+              "width": 1024,
+              "height": 6144,
+              "hash": "UC9@@p8_4m?wtlWBoLayRjofogWBozaxj[jZ",
+              "type": "image"
+            },
+            {
+              "id": 213226,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/924994d2-5b76-4b39-b771-4e8127759000/width=450/213226.jpeg",
+              "nsfwLevel": 4,
+              "width": 1024,
+              "height": 6144,
+              "hash": "U8HnHR8w0J~AQ-IqNwV[n4RRXSR*o}M{xZt7",
+              "type": "image"
+            },
+            {
+              "id": 213231,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/374dc1f9-a2bd-4c2e-607e-8b66ce509800/width=450/213231.jpeg",
+              "nsfwLevel": 1,
+              "width": 1024,
+              "height": 6144,
+              "hash": "UDDJeexW0L?wx]t6RPWBjrogV@j?xWjZV?V@",
+              "type": "image"
+            }
+          ],
+          "downloadUrl": "https://civitai.com/api/download/models/20170"
+        },
+        {
+          "id": 20171,
+          "index": 1,
+          "name": "32 Vector Version",
+          "baseModel": "SD 1.5",
+          "baseModelType": "Standard",
+          "publishedAt": "2023-03-08T09:09:09.547Z",
+          "availability": "Public",
+          "nsfwLevel": 7,
+          "description": "<p>Trained @ either 20 or 25 batch on Colab for 449 steps with a variable learning rate using an <a target=\"_blank\" rel=\"ugc\" href=\"https://github.com/aria1th/Hypernetwork-MonkeyPatch-Extension\">extension for WebUI</a> that has advanced TI training features. It is its highest training save, so the .zip will only contain versions with less steps. There are no .optim files to resume training in this .zip, as I hadn't remembered to get WebUI to save them.</p>",
+          "trainedWords": ["bad-picture-chill-32v"],
+          "stats": {
+            "downloadCount": 5111,
+            "ratingCount": 10,
+            "rating": 5,
+            "thumbsUpCount": 55,
+            "thumbsDownCount": 0
+          },
+          "files": [
+            {
+              "id": 16826,
+              "sizeKB": 97.0947265625,
+              "name": "bad-picture-chill-32v.pt",
+              "type": "Model",
+              "pickleScanResult": "Success",
+              "pickleScanMessage": "No Pickle imports",
+              "virusScanResult": "Success",
+              "virusScanMessage": null,
+              "scannedAt": "2023-03-08T09:11:07.015Z",
+              "metadata": {
+                "format": "PickleTensor",
+                "size": "full",
+                "fp": "fp16"
+              },
+              "hashes": {
+                "AutoV2": "6705729FB3",
+                "SHA256": "6705729FB31C53AB5DD39DA42E8B167BBE152C77B63C29EB7EABEE8015398290",
+                "CRC32": "8244EA1B",
+                "BLAKE3": "4F5935EB86C16FB276D0255E0A216D84A5FA127BFE80278C4289F09E3F6EA6B5"
+              },
+              "downloadUrl": "https://civitai.com/api/download/models/20171",
+              "primary": true
+            },
+            {
+              "id": 16996,
+              "sizeKB": 628.48046875,
+              "name": "badPictureNegative_32VectorVersion_trainingData.zip",
+              "type": "Training Data",
+              "pickleScanResult": "Success",
+              "pickleScanMessage": "No Pickle imports",
+              "virusScanResult": "Success",
+              "virusScanMessage": null,
+              "scannedAt": "2023-03-08T18:40:56.790Z",
+              "metadata": {
+                "format": "Other"
+              },
+              "hashes": {
+                "AutoV2": "2ACB1751BE",
+                "SHA256": "2ACB1751BE9D737DB81C3FDB125CC6B063266993E1F43B731B7A43472158E10A",
+                "CRC32": "0E902196",
+                "BLAKE3": "7961702B878D6346BA3E0A1B9F6B15FEA0230D1ED9F5EADB72DF46EB0B0AC5ED"
+              },
+              "downloadUrl": "https://civitai.com/api/download/models/20171?type=Training%20Data"
+            }
+          ],
+          "images": [
+            {
+              "id": 213192,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/00576fc6-fd9a-4d4d-a1f2-de815118f800/width=450/213192.jpeg",
+              "nsfwLevel": 4,
+              "width": 1024,
+              "height": 1024,
+              "hash": "UdKUH0D+yX%MyZRjxvNHM|flMxRjR+n%M{og",
+              "type": "image"
+            },
+            {
+              "id": 213190,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/52efccc3-7908-4cbc-b476-f4f39b847e00/width=450/213190.jpeg",
+              "nsfwLevel": 1,
+              "width": 1024,
+              "height": 1024,
+              "hash": "UG8}ABDiM{%g?wIARit7-=M_RPt7x]RPadoz",
+              "type": "image"
+            },
+            {
+              "id": 213191,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/a94d91f1-6f99-408b-1daf-0aed62a01000/width=450/213191.jpeg",
+              "nsfwLevel": 2,
+              "width": 1024,
+              "height": 1024,
+              "hash": "UCI3w70L*|~V0Nbv57I;EL$%o|%0%fM|RRog",
+              "type": "image"
+            },
+            {
+              "id": 213188,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/0967e3d9-307f-4687-3465-98a472c31f00/width=450/213188.jpeg",
+              "nsfwLevel": 1,
+              "width": 1024,
+              "height": 1024,
+              "hash": "UbHUk9t7aeM|~qRkn$Rk%MIVRkkCR+Ipaeof",
+              "type": "image"
+            },
+            {
+              "id": 213189,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/0af06ce1-f729-468a-407e-64fad40f5b00/width=450/213189.jpeg",
+              "nsfwLevel": 1,
+              "width": 1024,
+              "height": 1024,
+              "hash": "UFAwxR4TDi?v?wM_IUWB-;M{M{xu%MRjM{xu",
+              "type": "image"
+            },
+            {
+              "id": 213187,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/bf9411aa-4f9a-484e-2a9d-cd3f5a72c500/width=450/213187.jpeg",
+              "nsfwLevel": 4,
+              "width": 1024,
+              "height": 1024,
+              "hash": "UNIXQ,9E0|=yLMIA-oM{.ARPxIE1S%t6xaV?",
+              "type": "image"
+            },
+            {
+              "id": 213193,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/4528f946-bbe1-4f01-5c13-c7de2896a500/width=450/213193.jpeg",
+              "nsfwLevel": 1,
+              "width": 1024,
+              "height": 1024,
+              "hash": "UBD]uQI90M_4nNjE01D%u4-;-UNG4.tRxG9F",
+              "type": "image"
+            }
+          ],
+          "downloadUrl": "https://civitai.com/api/download/models/20171"
+        },
+        {
+          "id": 20172,
+          "index": 2,
+          "name": "1 Vector Version",
+          "baseModel": "SD 1.5",
+          "baseModelType": "Standard",
+          "publishedAt": "2023-03-08T09:09:09.547Z",
+          "availability": "Public",
+          "nsfwLevel": 7,
+          "description": "<p>Trained @ 4batch for 5000 steps using a variable learning rate using an <a target=\"_blank\" rel=\"ugc\" href=\"https://github.com/aria1th/Hypernetwork-MonkeyPatch-Extension\">extension for WebUI</a> that has advanced TI training features. The training .zip contains slightly higher step counts with mostly lesser step counts.</p>",
+          "trainedWords": ["bad-picture-chill-1v"],
+          "stats": {
+            "downloadCount": 2360,
+            "ratingCount": 0,
+            "rating": 0,
+            "thumbsUpCount": 6,
+            "thumbsDownCount": 0
+          },
+          "files": [
+            {
+              "id": 16827,
+              "sizeKB": 4.0947265625,
+              "name": "bad-picture-chill-1v.pt",
+              "type": "Model",
+              "pickleScanResult": "Success",
+              "pickleScanMessage": "No Pickle imports",
+              "virusScanResult": "Success",
+              "virusScanMessage": null,
+              "scannedAt": "2023-03-08T09:11:05.438Z",
+              "metadata": {
+                "format": "PickleTensor",
+                "size": "full",
+                "fp": "fp16"
+              },
+              "hashes": {
+                "AutoV2": "B17FBD3DEF",
+                "SHA256": "B17FBD3DEF5F9DB53C77FBCC8C494B54339A270F5F6D6630562E5A96A76FD6CB",
+                "CRC32": "D58FBD06",
+                "BLAKE3": "058722C186E76B56E8AB26AA93AAC23C56F942B2F0A639F670BB0D184B0BE0AA"
+              },
+              "downloadUrl": "https://civitai.com/api/download/models/20172",
+              "primary": true
+            },
+            {
+              "id": 16997,
+              "sizeKB": 672.8564453125,
+              "name": "badPictureNegative_1VectorVersion_trainingData.zip",
+              "type": "Training Data",
+              "pickleScanResult": "Success",
+              "pickleScanMessage": "No Pickle imports",
+              "virusScanResult": "Success",
+              "virusScanMessage": null,
+              "scannedAt": "2023-03-08T18:40:57.501Z",
+              "metadata": {
+                "format": "Other"
+              },
+              "hashes": {
+                "AutoV2": "92F91100DE",
+                "SHA256": "92F91100DEAE00C5D139CED2DCA0E168120D1C3293F166EE17207412ED54DCE7",
+                "CRC32": "930898AB",
+                "BLAKE3": "88E247FB778B6F9C85AEA15FBDB637EEAB4CB9E43472777C67798238A1F4D435"
+              },
+              "downloadUrl": "https://civitai.com/api/download/models/20172?type=Training%20Data"
+            }
+          ],
+          "images": [
+            {
+              "id": 213199,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/4bdce983-e18b-4336-c59a-e8b6c226d800/width=450/213199.jpeg",
+              "nsfwLevel": 1,
+              "width": 1024,
+              "height": 1024,
+              "hash": "UcKd*+D+t,%gyZIoxuNHaeR+MxRjs,oKMxf+",
+              "type": "image"
+            },
+            {
+              "id": 213197,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/68f5605d-b942-467f-807d-dba86fe03c00/width=450/213197.jpeg",
+              "nsfwLevel": 1,
+              "width": 1024,
+              "height": 1024,
+              "hash": "UG9aX5DiIo%g_NITM{t7.8M{Mxt7%gRPRPt7",
+              "type": "image"
+            },
+            {
+              "id": 213198,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/7299bd7d-f788-44bc-79c1-94da1a87bd00/width=450/213198.jpeg",
+              "nsfwLevel": 2,
+              "width": 1024,
+              "height": 1024,
+              "hash": "U5H,kr00.n.S02yC02570L#-l8}??[VsiexH",
+              "type": "image"
+            },
+            {
+              "id": 213195,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/60e5683a-5ad8-4163-8b3b-f5b94a2da000/width=450/213195.jpeg",
+              "nsfwLevel": 1,
+              "width": 1024,
+              "height": 1024,
+              "hash": "UbHxTmxuadNG~qR,n$WBxuE2NGofRkM|axt6",
+              "type": "image"
+            },
+            {
+              "id": 213196,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/084c8619-2d1a-401b-dac0-f22c1a1af900/width=450/213196.jpeg",
+              "nsfwLevel": 1,
+              "width": 1024,
+              "height": 1024,
+              "hash": "UMBgi39EDi%g_NM{IAkC%gV[Mxoe%MRjM{of",
+              "type": "image"
+            },
+            {
+              "id": 213194,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/4243bcdd-3d80-4182-1fa1-5e615c709e00/width=450/213194.jpeg",
+              "nsfwLevel": 4,
+              "width": 1024,
+              "height": 1024,
+              "hash": "UQIqZH9E0|-9L3IA%2Mx.ARPxHE1S%xtxFRi",
+              "type": "image"
+            },
+            {
+              "id": 213200,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/82282191-37dd-4bcd-915f-504bb32ea000/width=450/213200.jpeg",
+              "nsfwLevel": 1,
+              "width": 1024,
+              "height": 1024,
+              "hash": "UAE3Yh9E0M_4Q,xt4oE1PB%M$fE14.oz%2IA",
+              "type": "image"
+            }
+          ],
+          "downloadUrl": "https://civitai.com/api/download/models/20172"
+        },
+        {
+          "id": 20387,
+          "index": 3,
+          "name": "Actual Training Images",
+          "baseModel": "SD 1.5",
+          "baseModelType": "Standard",
+          "publishedAt": "2023-03-08T18:40:01.986Z",
+          "availability": "Public",
+          "nsfwLevel": 9,
+          "description": "<p>This contains all 5000 training images that I generated and used to train all versions of the embedding.  Download this if you want to train the embedding using your own training parameters.  The preview images contain the image generation parameters.  Pictures were selected to give an idea of what the entire image set contains.</p>",
+          "trainedWords": ["none"],
+          "stats": {
+            "downloadCount": 996,
+            "ratingCount": 4996,
+            "rating": 5,
+            "thumbsUpCount": 4995,
+            "thumbsDownCount": 0
+          },
+          "files": [
+            {
+              "id": 16994,
+              "sizeKB": 1244253.755859375,
+              "name": "badPictureNegative_actualTrainingImages_trainingData.zip",
+              "type": "Training Data",
+              "pickleScanResult": "Success",
+              "pickleScanMessage": "No Pickle imports",
+              "virusScanResult": "Success",
+              "virusScanMessage": null,
+              "scannedAt": "2023-03-08T18:45:31.426Z",
+              "metadata": {
+                "format": "Other"
+              },
+              "hashes": {
+                "AutoV1": "D17C54D2",
+                "AutoV2": "D34C8A3CA8",
+                "SHA256": "D34C8A3CA822AAB517FC16145D5A4A2B8B4882A1E215446BB7694F3AE2873AF7",
+                "CRC32": "26FC0646",
+                "BLAKE3": "90A4D138999452012E6DCFC0F5D17F129E8BBE61590DA34D97BA5D3C06FA2EB9"
+              },
+              "downloadUrl": "https://civitai.com/api/download/models/20387",
+              "primary": true
+            }
+          ],
+          "images": [
+            {
+              "id": 215908,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/24f2a961-d911-40b1-58e9-1cf9e6b2eb00/width=450/215908.jpeg",
+              "nsfwLevel": 8,
+              "width": 512,
+              "height": 512,
+              "hash": "UNIXmN%2%%tRxaofkDa$pKaexBjYt5jZoekB",
+              "type": "image"
+            },
+            {
+              "id": 215907,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/f5c70e8c-0ff2-4de1-c195-3d894e3dbd00/width=450/215907.jpeg",
+              "nsfwLevel": 8,
+              "width": 512,
+              "height": 512,
+              "hash": "U4M@ir_3-;~q~qM{j[M{IUofxut7-;%MM{WB",
+              "type": "image"
+            },
+            {
+              "id": 215906,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/f17eb70c-e381-48d7-b2ef-3ae9026b5300/width=450/215906.jpeg",
+              "nsfwLevel": 8,
+              "width": 512,
+              "height": 512,
+              "hash": "U7L;jW?b00oeIURj~qWB%MRj_3xu-:ofofof",
+              "type": "image"
+            },
+            {
+              "id": 216019,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/60c4b2de-648c-403c-991a-7311ffdd9400/width=450/216019.jpeg",
+              "nsfwLevel": 8,
+              "width": 512,
+              "height": 512,
+              "hash": "U3N,_D?b00WB_3ofayj[00M{WBxu?bofWBD%",
+              "type": "image"
+            },
+            {
+              "id": 215905,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/a7a09363-178b-408e-d662-668eeeeeab00/width=450/215905.jpeg",
+              "nsfwLevel": 8,
+              "width": 512,
+              "height": 512,
+              "hash": "URLC^lt8~8xH.RoeXSoe%0bEkCobx[fkWEW;",
+              "type": "image"
+            },
+            {
+              "id": 215904,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/c552d56e-f5a6-4b53-2a23-c863b66eec00/width=450/215904.jpeg",
+              "nsfwLevel": 8,
+              "width": 512,
+              "height": 512,
+              "hash": "U8Lg^W%M?u%M-;ayj[WB~qWAIVj[t7t7f8WB",
+              "type": "image"
+            },
+            {
+              "id": 215903,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/2946f99e-91f8-47a1-db8f-e13cf6033b00/width=450/215903.jpeg",
+              "nsfwLevel": 1,
+              "width": 512,
+              "height": 512,
+              "hash": "UBK_I9xu~q%Mofjtt7j[-;j[ofof%MfPayj[",
+              "type": "image"
+            },
+            {
+              "id": 215899,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/5751ddd5-572e-474e-2548-e7d4f70db300/width=450/215899.jpeg",
+              "nsfwLevel": 1,
+              "width": 512,
+              "height": 512,
+              "hash": "U7L#2%?b4nIUM_D%%M?b00WB_3t8~qxuIAIA",
+              "type": "image"
+            },
+            {
+              "id": 215902,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/1417a856-d521-4f9e-707e-57c9ac750200/width=450/215902.jpeg",
+              "nsfwLevel": 1,
+              "width": 512,
+              "height": 512,
+              "hash": "U5OWvn~q00_3-qofWBM{00Rj_3WB-;RPRjWB",
+              "type": "image"
+            },
+            {
+              "id": 215901,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/70c97984-8381-4b41-aec2-c4f7694d1a00/width=450/215901.jpeg",
+              "nsfwLevel": 1,
+              "width": 512,
+              "height": 512,
+              "hash": "UCNAzd?Y}|-m%JIXt6kC=mj=~Ss.--D-s,M}",
+              "type": "image"
+            },
+            {
+              "id": 216018,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/b0921830-f337-4738-27ba-575188d45600/width=450/216018.jpeg",
+              "nsfwLevel": 8,
+              "width": 512,
+              "height": 512,
+              "hash": "UPLEN3%B?KDvN6M,t3tIxds=M_x=t7xtk7M}",
+              "type": "image"
+            },
+            {
+              "id": 215900,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/a93c6175-cda4-4d0b-5684-28abb02dd500/width=450/215900.jpeg",
+              "nsfwLevel": 8,
+              "width": 512,
+              "height": 512,
+              "hash": "U3N,_D?bkD?b_3j[offk%Nf7axax_3j@j[fj",
+              "type": "image"
+            },
+            {
+              "id": 215898,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/2bbe61b8-dff5-4bc9-ad8d-1db030c7af00/width=450/215898.jpeg",
+              "nsfwLevel": 1,
+              "width": 512,
+              "height": 512,
+              "hash": "U7NA;R~oS:.4x.M}k8M{EGxZSixb_1E2Rixu",
+              "type": "image"
+            },
+            {
+              "id": 215897,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/0a3a8b92-74ef-40eb-da36-17e022105b00/width=450/215897.jpeg",
+              "nsfwLevel": 8,
+              "width": 512,
+              "height": 512,
+              "hash": "UBLXSo%M8_j[xuayaxof4TWB~qxut7j[ofj[",
+              "type": "image"
+            },
+            {
+              "id": 215896,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/10a7011f-af4f-4334-800d-b59c5c744800/width=450/215896.jpeg",
+              "nsfwLevel": 8,
+              "width": 512,
+              "height": 512,
+              "hash": "ULIERcj@0mfQWGR+NKf506az~RoeS5j[azR+",
+              "type": "image"
+            }
+          ],
+          "downloadUrl": "https://civitai.com/api/download/models/20387"
+        }
+      ]
+    },
+    {
+      "id": 81575,
+      "name": "Amazing Embeddings - fcNegative + fcPortrait suite",
+      "description": "<p>fcNeg is a Negative Embedding. You just install it in the embedding folder and then type fcNeg in the negative prompt. I don't know why it shows two trigger words. Ignore \"fcneg-neg\"</p><h3 id=\"heading-14\"><strong>My Links: </strong><a target=\"_blank\" rel=\"ugc\" href=\"https://twitter.com/fitCorderAI\"><strong>twitter</strong></a><strong>, </strong><a target=\"_blank\" rel=\"ugc\" href=\"https://discord.gg/v8wqjWc9Eh\"><strong>discord</strong></a><strong>, </strong><a target=\"_blank\" rel=\"ugc\" href=\"https://www.instagram.com/fitcorder/\"><strong>IG</strong></a></h3><p><strong>Subscribe for FBB images @ </strong><a target=\"_blank\" rel=\"ugc\" href=\"https://patreon.com/fitCorderAI\"><strong>https://patreon.com/fitCorderAI</strong></a></p><p>These prompts are positive prompts.</p><p>fcPortrait now has three variations, the base one, one with a sweaty/heat effect and another that adds detail and vibrancy. <em>You only need to use one per image generation.</em></p><p>Designed to amplify the impact of your visual narratives, fcPortrait seamlessly blends a suite of powerful photography techniques into one game-changing embedding. From the dramatic emphasis of rim lighting to the dreamy allure of a bokeh background, every detail is accounted for. It harnesses the sophistication of a fast shutter speed to freeze motion and a low ISO setting to minimize noise, providing clarity that is second to none. The tool's ability to fill the frame with your subject, coupled with an eye-level angle, ensures a neutral yet compelling perspective. Prepare to elevate your artistry with fcPortrait.</p>",
+      "allowNoCredit": true,
+      "allowCommercialUse": ["Image", "RentCivit", "Rent", "Sell"],
+      "allowDerivatives": true,
+      "allowDifferentLicense": true,
+      "type": "TextualInversion",
+      "minor": false,
+      "poi": false,
+      "nsfw": false,
+      "nsfwLevel": 15,
+      "cosmetic": null,
+      "stats": {
+        "downloadCount": 70455,
+        "favoriteCount": 0,
+        "thumbsUpCount": 4922,
+        "thumbsDownCount": 3,
+        "commentCount": 13,
+        "ratingCount": 0,
+        "rating": 0,
+        "tippedAmountCount": 144
+      },
+      "creator": {
+        "username": "fitCorder",
+        "image": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/6d8dddb9-908d-4e67-8de3-9e04b4076d38/width=96/fitCorder.jpeg"
+      },
+      "tags": ["style", "woman"],
+      "modelVersions": [
+        {
+          "id": 97691,
+          "index": 0,
+          "name": "fcNeg",
+          "baseModel": "SD 1.5",
+          "baseModelType": "Standard",
+          "publishedAt": "2023-06-17T04:57:40.713Z",
+          "availability": "Public",
+          "nsfwLevel": 15,
+          "description": null,
+          "trainedWords": ["fcNeg"],
+          "stats": {
+            "downloadCount": 44011,
+            "ratingCount": 1919,
+            "rating": 4.97,
+            "thumbsUpCount": 4473,
+            "thumbsDownCount": 2
+          },
+          "files": [
+            {
+              "id": 67955,
+              "sizeKB": 3.92578125,
+              "name": "fcNeg-neg.pt",
+              "type": "Negative",
+              "pickleScanResult": "Success",
+              "pickleScanMessage": "No Pickle imports",
+              "virusScanResult": "Success",
+              "virusScanMessage": null,
+              "scannedAt": "2023-06-17T04:56:03.736Z",
+              "metadata": {
+                "format": "Other",
+                "size": null,
+                "fp": null
+              },
+              "hashes": {
+                "AutoV2": "F257FCA133",
+                "SHA256": "F257FCA13352B7E00CD12D4D2257719C8A8944E4E8565C5EB17A5C1F673C9458",
+                "CRC32": "495224CA",
+                "BLAKE3": "0891F40193EE3894396030912B488A1A00F99E1166EF7EF0240F5B6F9C295412"
+              },
+              "downloadUrl": "https://civitai.com/api/download/models/97691",
+              "primary": true
+            }
+          ],
+          "images": [
+            {
+              "id": 1174448,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/ef785124-976c-4bf5-9b44-179102eee6d5/width=450/1174448.jpeg",
+              "nsfwLevel": 1,
+              "width": 1024,
+              "height": 1536,
+              "hash": "UaHeB_~V%0xa%LxuIpRlM_%2-;ofM{bbt7n~",
+              "type": "image"
+            },
+            {
+              "id": 1174457,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/71445e8f-fefb-4648-9717-60826942ce9c/width=450/1174457.jpeg",
+              "nsfwLevel": 4,
+              "width": 1024,
+              "height": 1536,
+              "hash": "UEHUhB0K1O.800%LROnh00-:IAM{~pIB%gWq",
+              "type": "image"
+            },
+            {
+              "id": 1174450,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/1df0cc5b-0635-4a21-b1be-5d116e00dcae/width=450/1174450.jpeg",
+              "nsfwLevel": 4,
+              "width": 1024,
+              "height": 1536,
+              "hash": "U8Fh@i_200000JRoOT${0KIY^+sj?^som,Nf",
+              "type": "image"
+            },
+            {
+              "id": 1174446,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/293ad724-9cdc-42e0-9bfb-f9a0fdaaab84/width=450/1174446.jpeg",
+              "nsfwLevel": 4,
+              "width": 1024,
+              "height": 1536,
+              "hash": "UCGkj|4.0.~V00?HQ,M|_3t6~WM|9FaeM{j[",
+              "type": "image"
+            },
+            {
+              "id": 1174449,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/3bd65538-8c70-44b1-a58b-9bee02dd8bd4/width=450/1174449.jpeg",
+              "nsfwLevel": 1,
+              "width": 1024,
+              "height": 1536,
+              "hash": "UUE{z-s,WC9E.Tt6WAM{NHWWM{xuWEWBjYof",
+              "type": "image"
+            },
+            {
+              "id": 1174451,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/42dbfa0e-f8c3-49a9-a867-8e8fc4ee4423/width=450/1174451.jpeg",
+              "nsfwLevel": 4,
+              "width": 1024,
+              "height": 1536,
+              "hash": "UjKm|Z_NpJozx^%NRPM{R-xZaJt6x]WCxaWV",
+              "type": "image"
+            },
+            {
+              "id": 1174453,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/8ae5d92a-204a-4b22-902b-186b7f402629/width=450/1174453.jpeg",
+              "nsfwLevel": 1,
+              "width": 1024,
+              "height": 1536,
+              "hash": "UJE3J1NGDh8_%%oe4TRO?cxt%1M{XUD%WAkC",
+              "type": "image"
+            },
+            {
+              "id": 1174452,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/984f89b0-530e-4e60-94f9-fc8571d5b607/width=450/1174452.jpeg",
+              "nsfwLevel": 1,
+              "width": 1024,
+              "height": 1536,
+              "hash": "UAF=w7lV9E?I0BXoXmawQlMcD$R5~UITn3t7",
+              "type": "image"
+            },
+            {
+              "id": 1174447,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/63c9bf1b-00be-44a8-a407-eb81bfd119e1/width=450/1174447.jpeg",
+              "nsfwLevel": 4,
+              "width": 1024,
+              "height": 1536,
+              "hash": "U9EB?P%2o;xYEkxZD*V@00WX0*R-~8M|?Iof",
+              "type": "image"
+            },
+            {
+              "id": 1174455,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/717d10af-2525-4123-a89d-d88c5bf69cdd/width=450/1174455.jpeg",
+              "nsfwLevel": 1,
+              "width": 1024,
+              "height": 1536,
+              "hash": "UiJQco~W9uE2E2aeWBM{-pt7t7xuNHt7t7R+",
+              "type": "image"
+            },
+            {
+              "id": 1174454,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/fe3380df-33e2-4fab-a70a-d8430bd96f90/width=450/1174454.jpeg",
+              "nsfwLevel": 2,
+              "width": 1024,
+              "height": 1536,
+              "hash": "UFIqAf}R0z0MFqE,9FH@~9E0XoE1RQM{xuSj",
+              "type": "image"
+            },
+            {
+              "id": 1174456,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/5e566b96-c346-4d2f-8c2a-ac05f7f920a5/width=450/1174456.jpeg",
+              "nsfwLevel": 4,
+              "width": 1024,
+              "height": 1536,
+              "hash": "U4I3]x00001Z05=r}u0M00={2ZtS1z}@GAXo",
+              "type": "image"
+            },
+            {
+              "id": 1174458,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/6b3939be-6a2d-4cf7-b49c-bd528d2971a9/width=450/1174458.jpeg",
+              "nsfwLevel": 1,
+              "width": 1024,
+              "height": 1536,
+              "hash": "UMJ%n38^0MOZ~WQ+o~5XE9NE%MoNT0xs9atR",
+              "type": "image"
+            },
+            {
+              "id": 1174461,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/87046a1e-5ca4-4275-acf3-5bb53e9bc4ba/width=450/1174461.jpeg",
+              "nsfwLevel": 1,
+              "width": 1024,
+              "height": 1536,
+              "hash": "USGS4H00I9-=?wM_ROoz%Mt7IoM_S6s:oeM{",
+              "type": "image"
+            },
+            {
+              "id": 1174460,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/38fa89d1-c3a9-4694-beb1-880c987b6c5c/width=450/1174460.jpeg",
+              "nsfwLevel": 4,
+              "width": 1024,
+              "height": 1536,
+              "hash": "URJ*9yn3CmyE9N-oM$SiWFOrt6WU5?ajIpRk",
+              "type": "image"
+            },
+            {
+              "id": 1174459,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/33b6a849-48e5-4787-ad6e-4d0b9f42a67d/width=450/1174459.jpeg",
+              "nsfwLevel": 1,
+              "width": 1024,
+              "height": 1536,
+              "hash": "URH2TYo0x[^+%%xvoct7JqX9MxNGS%ozROkD",
+              "type": "image"
+            },
+            {
+              "id": 1174463,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/305582fe-b517-4043-b03c-19eb73f4a814/width=450/1174463.jpeg",
+              "nsfwLevel": 1,
+              "width": 1024,
+              "height": 1536,
+              "hash": "UGF#m[M{rVj]0Ut7NxWBNbt7sRs:}@NaIAR-",
+              "type": "image"
+            },
+            {
+              "id": 1174462,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/54f5f238-fc1c-4bcf-824d-82401afd1b1d/width=450/1174462.jpeg",
+              "nsfwLevel": 8,
+              "width": 1024,
+              "height": 1536,
+              "hash": "UQK9u$~V0fM{5Q%1oyX8k9R+xuNw9tj[ShE2",
+              "type": "image"
+            }
+          ],
+          "downloadUrl": "https://civitai.com/api/download/models/97691"
+        },
+        {
+          "id": 86566,
+          "index": 1,
+          "name": "fcPortrait",
+          "baseModel": "SD 1.5",
+          "baseModelType": "Standard",
+          "publishedAt": "2023-05-31T21:52:50.002Z",
+          "availability": "Public",
+          "nsfwLevel": 3,
+          "description": null,
+          "trainedWords": ["fcPortrait"],
+          "stats": {
+            "downloadCount": 10315,
+            "ratingCount": 328,
+            "rating": 5,
+            "thumbsUpCount": 421,
+            "thumbsDownCount": 1
+          },
+          "files": [
+            {
+              "id": 59187,
+              "sizeKB": 48.86328125,
+              "name": "fcPortrait.pt",
+              "type": "Model",
+              "pickleScanResult": "Success",
+              "pickleScanMessage": "No Pickle imports",
+              "virusScanResult": "Success",
+              "virusScanMessage": null,
+              "scannedAt": "2023-05-31T21:50:36.342Z",
+              "metadata": {
+                "format": "PickleTensor",
+                "size": null,
+                "fp": null
+              },
+              "hashes": {
+                "AutoV2": "10B4088760",
+                "SHA256": "10B40887609A000C7B6E34FF77C31365912A93473DDEDC9A7666FB4F39D72D3F",
+                "CRC32": "2657EC67",
+                "BLAKE3": "7FF7F593AA85DF521F85BD57580EB498917D1AEEAA4190275B250785E17609DC"
+              },
+              "downloadUrl": "https://civitai.com/api/download/models/86566",
+              "primary": true
+            }
+          ],
+          "images": [
+            {
+              "id": 986088,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/a120a9ca-94d9-4967-9f86-e1591e829f89/width=450/986088.jpeg",
+              "nsfwLevel": 1,
+              "width": 512,
+              "height": 768,
+              "hash": "UGF}~6bb00~p00xu-=s.F|Rj-BjG4:D*MyIo",
+              "type": "image"
+            },
+            {
+              "id": 986089,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/7a6b8888-1e35-424c-84a5-94c77bfd0a0a/width=450/986089.jpeg",
+              "nsfwLevel": 1,
+              "width": 512,
+              "height": 768,
+              "hash": "UFE.qsIT9@~pL#%#x^xWCAE1,?M{0KIUVYNI",
+              "type": "image"
+            },
+            {
+              "id": 986080,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/80a5289e-7ae8-4801-9dd2-3e3d1ba9e777/width=450/986080.jpeg",
+              "nsfwLevel": 1,
+              "width": 512,
+              "height": 768,
+              "hash": "UOFOor9GtRx[~WM|x[xu9v%2-pt7ODoe-ps:",
+              "type": "image"
+            },
+            {
+              "id": 986078,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/c451498d-cf66-4f33-ba08-e957ee9b9de0/width=450/986078.jpeg",
+              "nsfwLevel": 1,
+              "width": 1024,
+              "height": 859,
+              "hash": "UhIXv,flRPIU~qoft7j]x^t6bHt7-;jZayof",
+              "type": "image"
+            },
+            {
+              "id": 986082,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/af49e6a7-ec1b-434d-b5b3-8e34c41f7b98/width=450/986082.jpeg",
+              "nsfwLevel": 1,
+              "width": 512,
+              "height": 768,
+              "hash": "U9G]Xe00_1-;00^*00r:4:?a$d4n%%IqQ,9G",
+              "type": "image"
+            },
+            {
+              "id": 986079,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/17d16a8b-5264-40c5-8a53-df28af140989/width=450/986079.jpeg",
+              "nsfwLevel": 1,
+              "width": 1024,
+              "height": 859,
+              "hash": "UVJ8x6jFoHD%${ogWBxt?boga#xu~qkCt6WB",
+              "type": "image"
+            },
+            {
+              "id": 986077,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/47558fa5-22fb-4cc6-bfad-a97a211420f0/width=450/986077.jpeg",
+              "nsfwLevel": 2,
+              "width": 512,
+              "height": 768,
+              "hash": "UEFhq@==5S9F00%2j=ENu69ZV@EN^i%L^+Md",
+              "type": "image"
+            },
+            {
+              "id": 986081,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/c669a8c7-0fda-4abe-bad9-66f65ea7f64c/width=450/986081.jpeg",
+              "nsfwLevel": 2,
+              "width": 1024,
+              "height": 859,
+              "hash": "UfJaWS?Gf,aejFRQV@s:?wR*t7js~pt7R*Wq",
+              "type": "image"
+            },
+            {
+              "id": 986091,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/6e855796-128d-4ece-a83b-4e3fa70be2b2/width=450/986091.jpeg",
+              "nsfwLevel": 1,
+              "width": 512,
+              "height": 768,
+              "hash": "UKDSL2-;Te~W?bW=o#%30zIo$iIoE2adniRj",
+              "type": "image"
+            },
+            {
+              "id": 986090,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/534d349e-0c74-4272-870b-15863237ba4d/width=450/986090.jpeg",
+              "nsfwLevel": 1,
+              "width": 1408,
+              "height": 3163,
+              "hash": "UvLXGL~q_3-;ofofj[azt7ayWBayxaaza|j[",
+              "type": "image"
+            },
+            {
+              "id": 986084,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/da312623-f507-48ec-9a96-a9c6caf86a09/width=450/986084.jpeg",
+              "nsfwLevel": 2,
+              "width": 512,
+              "height": 768,
+              "hash": "U8E.hI=vtl0L9a00_NIV%g-p4oIU0K%L4n^+",
+              "type": "image"
+            },
+            {
+              "id": 986085,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/59338ac3-0c60-4270-88cf-c763a59dd370/width=450/986085.jpeg",
+              "nsfwLevel": 1,
+              "width": 512,
+              "height": 768,
+              "hash": "UPF#RK?b57wc~BxZM|xZ?G-naLI:?G%2Rkj=",
+              "type": "image"
+            },
+            {
+              "id": 986087,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/3257c871-48ce-4d27-abf3-33553978d8b7/width=450/986087.jpeg",
+              "nsfwLevel": 1,
+              "width": 512,
+              "height": 768,
+              "hash": "UFGRPFrC0e_M9Z.7V[IVkrRP$*EMnh%1ozX8",
+              "type": "image"
+            },
+            {
+              "id": 986086,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/c6b4ba2b-8be6-4e7a-8837-5bc4d036a616/width=450/986086.jpeg",
+              "nsfwLevel": 1,
+              "width": 512,
+              "height": 768,
+              "hash": "UKGug%jDOr~p4T%g%gxuu6D*nOIp9ZM_V@tR",
+              "type": "image"
+            },
+            {
+              "id": 986623,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/e29c4c08-835e-4d9d-8878-e22b49df08f6/width=450/986623.jpeg",
+              "nsfwLevel": 1,
+              "width": 1024,
+              "height": 1536,
+              "hash": "UKI;ed4:Ejsl9u4nslV@TJWA~pIBkWMxbb%2",
+              "type": "image"
+            },
+            {
+              "id": 986622,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/42849f7c-98ea-4f0e-9172-332d630769df/width=450/986622.jpeg",
+              "nsfwLevel": 2,
+              "width": 1024,
+              "height": 1536,
+              "hash": "UGG*Zu0fO?S3?c9ZOsR*TeMw~Ven579F~VIU",
+              "type": "image"
+            },
+            {
+              "id": 1077069,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/9ab91f5f-0bc0-495e-89be-b963ad3e9508/width=450/1077069.jpeg",
+              "nsfwLevel": 2,
+              "width": 4000,
+              "height": 2675,
+              "hash": "UaLD[T_N?v_3x]RjoLWBxtbGWCaeShWBxas.",
+              "type": "image"
+            }
+          ],
+          "downloadUrl": "https://civitai.com/api/download/models/86566"
+        },
+        {
+          "id": 91967,
+          "index": 2,
+          "name": "fcDetailPortrait",
+          "baseModel": "SD 1.5",
+          "baseModelType": "Standard",
+          "publishedAt": "2023-06-08T20:15:43.298Z",
+          "availability": "Public",
+          "nsfwLevel": 15,
+          "description": null,
+          "trainedWords": ["fcDetailPortrait"],
+          "stats": {
+            "downloadCount": 8767,
+            "ratingCount": 107,
+            "rating": 4.94,
+            "thumbsUpCount": 192,
+            "thumbsDownCount": 0
+          },
+          "files": [
+            {
+              "id": 63386,
+              "sizeKB": 48.86328125,
+              "name": "fcDetailPortrait.pt",
+              "type": "Model",
+              "pickleScanResult": "Success",
+              "pickleScanMessage": "No Pickle imports",
+              "virusScanResult": "Success",
+              "virusScanMessage": null,
+              "scannedAt": "2023-06-08T20:16:12.176Z",
+              "metadata": {
+                "format": "PickleTensor",
+                "size": null,
+                "fp": null
+              },
+              "hashes": {
+                "AutoV2": "16BD7741E1",
+                "SHA256": "16BD7741E19D3F0663C90621167B1C77776E1BD8868C4F0F7C4E5DEFD8A44547",
+                "CRC32": "1E26D608",
+                "BLAKE3": "53E9C54DEDEBA2FF221EE460A37C70EA4BD91137BF5E1178CC3E5DAF57451631"
+              },
+              "downloadUrl": "https://civitai.com/api/download/models/91967",
+              "primary": true
+            }
+          ],
+          "images": [
+            {
+              "id": 1077282,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/8f85cdba-cfbc-4eb2-b0da-05b5d63dc1ef/width=450/1077282.jpeg",
+              "nsfwLevel": 2,
+              "width": 1024,
+              "height": 1536,
+              "hash": "UFHLYvxu03kD|:js00Rj0,WVrXR+L3bHrsWr",
+              "type": "image"
+            },
+            {
+              "id": 1077280,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/1e909bc9-b09c-4f61-96f3-28feb688c48a/width=450/1077280.jpeg",
+              "nsfwLevel": 4,
+              "width": 1024,
+              "height": 1536,
+              "hash": "UJI|?*~W00D%K6xuV@MyX9jZr=WAg2j?9tIp",
+              "type": "image"
+            },
+            {
+              "id": 1077267,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/7e868f64-6614-4b71-be5f-0f243cbdf634/width=450/1077267.jpeg",
+              "nsfwLevel": 4,
+              "width": 1024,
+              "height": 1536,
+              "hash": "USH_ui%4%y~q%%x^b{xvNLb^x^MyA0M_IANH",
+              "type": "image"
+            },
+            {
+              "id": 1077278,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/dc635236-e4b6-4871-844e-f7998ec66f82/width=450/1077278.jpeg",
+              "nsfwLevel": 4,
+              "width": 1024,
+              "height": 1536,
+              "hash": "USH1om9FJDyDpfRNwHOakRIUrpb^E,NGRjt6",
+              "type": "image"
+            },
+            {
+              "id": 1077275,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/120e9ff1-8027-4b9c-82f3-cd58f4d7facf/width=450/1077275.jpeg",
+              "nsfwLevel": 4,
+              "width": 1024,
+              "height": 1536,
+              "hash": "U9H19^;_K$~AFa^%-oox00yDrX-UW?D*Q.$+",
+              "type": "image"
+            },
+            {
+              "id": 1077268,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/949e088e-5e42-4216-8345-3e185a2155d2/width=450/1077268.jpeg",
+              "nsfwLevel": 4,
+              "width": 1024,
+              "height": 1536,
+              "hash": "UFF=p_-OGa~WHX-;H?DiTd$e_3I=$g-:skt6",
+              "type": "image"
+            },
+            {
+              "id": 1077285,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/0798c1b7-94a3-4b7b-88fb-0fb6ad36bb59/width=450/1077285.jpeg",
+              "nsfwLevel": 4,
+              "width": 1024,
+              "height": 1536,
+              "hash": "ULGkdzn#9t?Gt-xZIUn%O@NHMxE2~WRQ9Gxt",
+              "type": "image"
+            },
+            {
+              "id": 1077276,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/a41abc8c-6b32-4e48-bcc8-69a8ad29f570/width=450/1077276.jpeg",
+              "nsfwLevel": 4,
+              "width": 1024,
+              "height": 1536,
+              "hash": "UHIDwn%e;pk]0c+Z-3WG2$F=0wK000ryrrvz",
+              "type": "image"
+            },
+            {
+              "id": 1077281,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/53aabf83-7604-48fb-be68-2bcfc0fd8e08/width=450/1077281.jpeg",
+              "nsfwLevel": 4,
+              "width": 1024,
+              "height": 1536,
+              "hash": "UUJuDQ?]0d-4kq%h%gj;R-RoM|NGXNWBi^n$",
+              "type": "image"
+            },
+            {
+              "id": 1077270,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/c65f2769-d202-4837-b69b-d8f3cc2b0117/width=450/1077270.jpeg",
+              "nsfwLevel": 1,
+              "width": 1024,
+              "height": 1536,
+              "hash": "UQGut54;M{sm_4E1t6Si5A-nayW=0g-:jFV@",
+              "type": "image"
+            },
+            {
+              "id": 1077274,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/88e810ef-d611-46ea-94d1-f0288e9fbe53/width=450/1077274.jpeg",
+              "nsfwLevel": 1,
+              "width": 1024,
+              "height": 1536,
+              "hash": "UMD]^|~p%gkWxu%M%f%2%gxuWBkDk=R+tSIU",
+              "type": "image"
+            },
+            {
+              "id": 1077283,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/a9836db3-24c0-4c9a-bed7-8fe2b60372e7/width=450/1077283.jpeg",
+              "nsfwLevel": 8,
+              "width": 1024,
+              "height": 1536,
+              "hash": "U8KmFL0000~p00E1xs^*9G%L}tv}F@M{^*$$",
+              "type": "image"
+            },
+            {
+              "id": 1077284,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/71a6667b-7568-4d9a-b92d-f0e7d927689b/width=450/1077284.jpeg",
+              "nsfwLevel": 1,
+              "width": 1024,
+              "height": 1536,
+              "hash": "UgHyBwtS4naf?wbcV?xatmR+ocxaIoM{t7Rk",
+              "type": "image"
+            },
+            {
+              "id": 1077286,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/390b58ae-59e3-4614-937d-edb1c867240b/width=450/1077286.jpeg",
+              "nsfwLevel": 1,
+              "width": 1024,
+              "height": 1536,
+              "hash": "ULD,Ao9ZVr4n_NfkE1jEtSRPa#oK.8axM_WB",
+              "type": "image"
+            },
+            {
+              "id": 1077269,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/096bf402-f83d-4f51-a745-a2edf1401177/width=450/1077269.jpeg",
+              "nsfwLevel": 4,
+              "width": 1024,
+              "height": 1536,
+              "hash": "UHI5Vg_2004-9ZxokGIo??x[?ZV=b|tRDjIU",
+              "type": "image"
+            },
+            {
+              "id": 1077277,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/e3ec8d09-a423-486a-b0d5-deb6e908ac3c/width=450/1077277.jpeg",
+              "nsfwLevel": 2,
+              "width": 1024,
+              "height": 1536,
+              "hash": "UTJaM}00Rj%1~p9GS#RkM{t5bdW;D*WVt7jG",
+              "type": "image"
+            },
+            {
+              "id": 1077273,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/7a35d588-ad42-4754-a719-08a3155e82c8/width=450/1077273.jpeg",
+              "nsfwLevel": 4,
+              "width": 1024,
+              "height": 1536,
+              "hash": "UADStLIo0O^+00xG}mE2r;xZ^+IUX:OZ?H%2",
+              "type": "image"
+            },
+            {
+              "id": 1077271,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/74a05c3b-d27e-40f1-b266-26dd2d1b1a92/width=450/1077271.jpeg",
+              "nsfwLevel": 2,
+              "width": 1024,
+              "height": 1536,
+              "hash": "UOIN{nt64=j]00j@IpWB?wjuNbRk0KWCR.oe",
+              "type": "image"
+            },
+            {
+              "id": 1077279,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/aa10d129-a0c9-4651-b1c8-1b868fc4d581/width=450/1077279.jpeg",
+              "nsfwLevel": 2,
+              "width": 1024,
+              "height": 1536,
+              "hash": "UYJ7{[_NPA%0Tf%hxus9TJkXNHNFT0V[tQS$",
+              "type": "image"
+            },
+            {
+              "id": 1077272,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/3ea4aa5d-3c8a-476e-ba37-482a93fc68b4/width=450/1077272.jpeg",
+              "nsfwLevel": 4,
+              "width": 1024,
+              "height": 1536,
+              "hash": "UFKcqiIo00oy0yxa~VM{9Fa{~Vxt9^$*oeWW",
+              "type": "image"
+            }
+          ],
+          "downloadUrl": "https://civitai.com/api/download/models/91967"
+        },
+        {
+          "id": 91959,
+          "index": 3,
+          "name": "fcHeatPortrait",
+          "baseModel": "SD 1.5",
+          "baseModelType": "Standard",
+          "publishedAt": "2023-06-08T20:08:39.953Z",
+          "availability": "Public",
+          "nsfwLevel": 15,
+          "description": null,
+          "trainedWords": ["fcHeatPortrait"],
+          "stats": {
+            "downloadCount": 7362,
+            "ratingCount": 21,
+            "rating": 4.95,
+            "thumbsUpCount": 87,
+            "thumbsDownCount": 0
+          },
+          "files": [
+            {
+              "id": 63379,
+              "sizeKB": 48.943359375,
+              "name": "fcHeatPortrait.pt",
+              "type": "Model",
+              "pickleScanResult": "Success",
+              "pickleScanMessage": "No Pickle imports",
+              "virusScanResult": "Success",
+              "virusScanMessage": null,
+              "scannedAt": "2023-06-08T20:06:00.419Z",
+              "metadata": {
+                "format": "PickleTensor",
+                "size": null,
+                "fp": null
+              },
+              "hashes": {
+                "AutoV2": "240F0D7160",
+                "SHA256": "240F0D71600E7CB0329061186CEFDEE1E4FE103F3AF6DC74452273E49AC2046B",
+                "CRC32": "B2D4E5E5",
+                "BLAKE3": "6E96D11468FF131357B65B937306F661F17DA6E24C08A2737AFE8F117D615B36"
+              },
+              "downloadUrl": "https://civitai.com/api/download/models/91959",
+              "primary": true
+            }
+          ],
+          "images": [
+            {
+              "id": 1077155,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/55ab28bb-d6a7-4c8d-962e-33f9cd05017c/width=450/1077155.jpeg",
+              "nsfwLevel": 1,
+              "width": 1024,
+              "height": 1536,
+              "hash": "UCGaXe^i4?9I5sS#04=t0g5AxYt5}+j=$l$$",
+              "type": "image"
+            },
+            {
+              "id": 1077152,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/e41bbef4-42f3-4244-ab38-1a035fdd5315/width=450/1077152.jpeg",
+              "nsfwLevel": 4,
+              "width": 1024,
+              "height": 1536,
+              "hash": "UPHxKLO[Tv-;E_xbS_w{55R5rVE1~UE0ITNG",
+              "type": "image"
+            },
+            {
+              "id": 1077167,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/c45ed2df-f17b-42ed-aaab-8210fb1bc166/width=450/1077167.jpeg",
+              "nsfwLevel": 8,
+              "width": 1024,
+              "height": 1536,
+              "hash": "UEK9iZ0000%f0L-V9u-p56^jIpNa~BD*xbbv",
+              "type": "image"
+            },
+            {
+              "id": 1077170,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/06a8b7df-14df-47c4-9b65-70fc8fcc475f/width=450/1077170.jpeg",
+              "nsfwLevel": 1,
+              "width": 1024,
+              "height": 1536,
+              "hash": "UXH-uu0MxZ%2~VIpt6RjtRxtM{R*t8t7M{xa",
+              "type": "image"
+            },
+            {
+              "id": 1077161,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/2095b670-054c-4cc0-b920-04b9802e700c/width=450/1077161.jpeg",
+              "nsfwLevel": 2,
+              "width": 1024,
+              "height": 1536,
+              "hash": "UDIDz9~B0}E10fD*WTIoTK9bt8R.kTE2%MM{",
+              "type": "image"
+            },
+            {
+              "id": 1077166,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/5ec0315a-e42a-41f4-8f57-d4a5ce17e1d8/width=450/1077166.jpeg",
+              "nsfwLevel": 8,
+              "width": 1024,
+              "height": 1536,
+              "hash": "UFI4hWWX00RjO[%2n3Rj~qR*WAadf+ofD*oe",
+              "type": "image"
+            },
+            {
+              "id": 1077164,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/8c310130-7a94-46c7-8e15-3ab8aee8ca45/width=450/1077164.jpeg",
+              "nsfwLevel": 8,
+              "width": 1024,
+              "height": 1536,
+              "hash": "UHJuW9^500L40;n9_N*0H]o%M#JBOmBWRMvz",
+              "type": "image"
+            },
+            {
+              "id": 1077154,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/ae991bd8-dd03-4ded-8768-4f0d8d2c3630/width=450/1077154.jpeg",
+              "nsfwLevel": 4,
+              "width": 1024,
+              "height": 1536,
+              "hash": "UFF#eACDMIM._6Tl]kVjyry4;0DmEG-;%1VF",
+              "type": "image"
+            },
+            {
+              "id": 1077169,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/7033c23d-771f-49f0-bee4-66b2cb8c2485/width=450/1077169.jpeg",
+              "nsfwLevel": 4,
+              "width": 1024,
+              "height": 1536,
+              "hash": "U9HKU+={0e}@00%14:oL}S={%#5S0Mn%^jEM",
+              "type": "image"
+            },
+            {
+              "id": 1077168,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/1d16cb0b-90e1-4819-8e3a-59504f88210f/width=450/1077168.jpeg",
+              "nsfwLevel": 8,
+              "width": 1024,
+              "height": 1536,
+              "hash": "UEIDv^RkB.?ZT_-o%L-V5mJ8~AIB~B9aE29a",
+              "type": "image"
+            },
+            {
+              "id": 1077163,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/94960d89-f6b1-44fb-a891-b755edbfecbc/width=450/1077163.jpeg",
+              "nsfwLevel": 4,
+              "width": 1024,
+              "height": 1536,
+              "hash": "UNI}R^X9CN_2.Atmt-xvFf%h%fozIxo~ICR.",
+              "type": "image"
+            },
+            {
+              "id": 1077160,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/bfffff30-01fd-45d0-b3a2-eea2e472f184/width=450/1077160.jpeg",
+              "nsfwLevel": 4,
+              "width": 1024,
+              "height": 1536,
+              "hash": "UHK9cW4TCRsp~q4o?IR*7AE1BONF9FJ-InR-",
+              "type": "image"
+            },
+            {
+              "id": 1077165,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/24043835-a00f-4c36-b8e8-d3c38e8d7010/width=450/1077165.jpeg",
+              "nsfwLevel": 2,
+              "width": 1024,
+              "height": 1536,
+              "hash": "UkHw}m~VoyxtRjIoE2Rk9aR+tRWBIps:xabb",
+              "type": "image"
+            },
+            {
+              "id": 1077153,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/17c5dbc4-fd3e-4fa4-8d5f-d22385dfcfb2/width=450/1077153.jpeg",
+              "nsfwLevel": 4,
+              "width": 1024,
+              "height": 1536,
+              "hash": "UGEf1qxau4~V^*xZS5%g00M{IBD*4nM{IV9Z",
+              "type": "image"
+            },
+            {
+              "id": 1077162,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/25c944ba-6da2-4ff1-9d4b-eab47f82c4da/width=450/1077162.jpeg",
+              "nsfwLevel": 1,
+              "width": 1024,
+              "height": 1536,
+              "hash": "UJD9q~~V-n~qwI-;%gxu9ZWYj]M{t,M{ROf6",
+              "type": "image"
+            },
+            {
+              "id": 1077156,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/2ad68cd5-6c3e-4734-b2f2-12b88f1d399b/width=450/1077156.jpeg",
+              "nsfwLevel": 4,
+              "width": 1024,
+              "height": 1536,
+              "hash": "UFHCcG0200OA.i00?c%Mx_NWrexI.8V=R5V{",
+              "type": "image"
+            },
+            {
+              "id": 1077158,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/00800bac-14ec-485f-a7f7-111290aa265e/width=450/1077158.jpeg",
+              "nsfwLevel": 4,
+              "width": 1024,
+              "height": 1536,
+              "hash": "UCFFT,00.mIUPAw00f_2%}01?uIAxZIr-oo2",
+              "type": "image"
+            },
+            {
+              "id": 1077171,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/1708ef82-1c2e-4e2d-88bc-083505f9e10b/width=450/1077171.jpeg",
+              "nsfwLevel": 4,
+              "width": 1024,
+              "height": 1536,
+              "hash": "USG8Tdof4.oM9Eay9sWB~DoLWVj[SJa#WBj@",
+              "type": "image"
+            },
+            {
+              "id": 1077157,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/9424d471-8364-42ca-baf9-2b34e084c27f/width=450/1077157.jpeg",
+              "nsfwLevel": 4,
+              "width": 1024,
+              "height": 1536,
+              "hash": "UKJswj-p00%1V=xa~Vt60Kj[xvWBJBn$MyoL",
+              "type": "image"
+            },
+            {
+              "id": 1077159,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/f579d65c-540d-4e1a-a5d1-e6b7ea914140/width=450/1077159.jpeg",
+              "nsfwLevel": 1,
+              "width": 1024,
+              "height": 1536,
+              "hash": "URK,Wn~TIWMz01RQShxZtlE4M|xrDjae%LtQ",
+              "type": "image"
+            }
+          ],
+          "downloadUrl": "https://civitai.com/api/download/models/91959"
+        }
+      ]
+    },
+    {
+      "id": 77976,
+      "name": "CyberRealistic Negative",
+      "description": "<p><strong><em><span style=\"color:rgb(250, 176, 5)\">Want to buy me coffee? </span></em></strong><a target=\"_blank\" rel=\"ugc\" href=\"https://ko-fi.com/cyberdelia\"><strong><em><span style=\"color:rgb(250, 176, 5)\">(</span><u><span style=\"color:rgb(250, 176, 5)\">Buy a cup</span></u><span style=\"color:rgb(250, 176, 5)\">)</span></em></strong></a></p><p><strong>This Negative Embedding (TI) can assist you in achieving a more realistic portrayal when prompting.</strong><br /><br /><strong><span style=\"color:rgb(230, 73, 128)\">NEW: CyberRealistic Negative Anime for Anime/Semi-Realistic Checkpoints like </span></strong><a target=\"_blank\" rel=\"ugc\" href=\"https://civitai.com/models/216056?modelVersionId=243482\"><strong><u><span style=\"color:rgb(230, 73, 128)\">CyberRealistic 2.5D Style</span></u></strong></a></p><h2 id=\"heading-47\"><br />How to use</h2><p>Download the file and place it in your embeddings folder. If you're using A1111 Webui, the folder path would be <strong>stable-diffusion-webui/embeddings</strong> (refer to the documentation to find the correct location for embeddings for other programs).</p><p>Once the file is in the designated folder, utilize the embedding by entering its name into the \"negative prompt\" box instead of the usual prompt. The default names are <strong><u>CyberRealistic_Negative</u></strong>, or <strong><u>CyberRealistic_Negative_Anime</u></strong>, depending on the version you downloaded.</p>",
+      "allowNoCredit": true,
+      "allowCommercialUse": ["Image", "RentCivit", "Rent", "Sell"],
+      "allowDerivatives": true,
+      "allowDifferentLicense": true,
+      "type": "TextualInversion",
+      "minor": false,
+      "poi": false,
+      "nsfw": false,
+      "nsfwLevel": 15,
+      "cosmetic": null,
+      "stats": {
+        "downloadCount": 80794,
+        "favoriteCount": 0,
+        "thumbsUpCount": 4593,
+        "thumbsDownCount": 7,
+        "commentCount": 24,
+        "ratingCount": 0,
+        "rating": 0,
+        "tippedAmountCount": 112
+      },
+      "creator": {
+        "username": "Cyberdelia",
+        "image": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/67778471-8dfe-4456-075a-e181f217c100/width=96/Cyberdelia.jpeg"
+      },
+      "tags": [
+        "anime",
+        "photorealistic",
+        "negative embedding",
+        "style",
+        "photorealism",
+        "realistic"
+      ],
+      "modelVersions": [
+        {
+          "id": 82745,
+          "index": 0,
+          "name": "v1.0",
+          "baseModel": "SD 1.5",
+          "baseModelType": "Standard",
+          "publishedAt": "2023-05-27T13:27:58.368Z",
+          "availability": "Public",
+          "nsfwLevel": 15,
+          "description": "<p>First version</p>",
+          "trainedWords": ["CyberRealistic_Negative"],
+          "stats": {
+            "downloadCount": 77461,
+            "ratingCount": 2061,
+            "rating": 4.98,
+            "thumbsUpCount": 3679,
+            "thumbsDownCount": 7
+          },
+          "files": [
+            {
+              "id": 56620,
+              "sizeKB": 193.029296875,
+              "name": "CyberRealistic_Negative-neg.pt",
+              "type": "Negative",
+              "pickleScanResult": "Success",
+              "pickleScanMessage": "No Pickle imports",
+              "virusScanResult": "Success",
+              "virusScanMessage": null,
+              "scannedAt": "2023-05-27T13:31:30.128Z",
+              "metadata": {
+                "format": "Other",
+                "size": null,
+                "fp": null
+              },
+              "hashes": {
+                "AutoV2": "65F3EA567C",
+                "SHA256": "65F3EA567C04C22F92024C5B55CBECA580BC330C4290AEB647EBD86273B3FFB8",
+                "CRC32": "ADA1714C",
+                "BLAKE3": "31F453CB45E5F3D75E29F1B879AF9C6FFA43E42D3FA4F50EE2482980F48FBACA"
+              },
+              "downloadUrl": "https://civitai.com/api/download/models/82745",
+              "primary": true
+            }
+          ],
+          "images": [
+            {
+              "id": 2017134,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/1464dd0c-0079-437e-9fb6-923c95fc9974/width=450/2017134.jpeg",
+              "nsfwLevel": 1,
+              "width": 1472,
+              "height": 2224,
+              "hash": "U38g,5_4.T0000jFt7%M00x]ITe.RO8_s9s.",
+              "type": "image"
+            },
+            {
+              "id": 2716690,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/9e9c2f33-d04d-47f1-b84a-a5269740755c/width=450/2716690.jpeg",
+              "nsfwLevel": 4,
+              "width": 1734,
+              "height": 2600,
+              "hash": "UWMivQSNOs-:_2R*t,t8*0Rj={jv%#$$Rjt7",
+              "type": "image"
+            },
+            {
+              "id": 2017135,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/7bc93a68-2eae-4492-8e21-a8b24f438272/width=450/2017135.jpeg",
+              "nsfwLevel": 1,
+              "width": 1472,
+              "height": 2224,
+              "hash": "UKEx^dXTKP~WkW.7SOkW56xZ-UIU-pNG%Mt6",
+              "type": "image"
+            },
+            {
+              "id": 931691,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/5dc94d4d-e256-4366-a974-677c98c3caa8/width=450/931691.jpeg",
+              "nsfwLevel": 4,
+              "width": 2048,
+              "height": 3072,
+              "hash": "UGIW}.9a0zxF~pt7niM|0L-:RjM{9Zofn%sm",
+              "type": "image"
+            },
+            {
+              "id": 931690,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/4066c3fc-8972-47ee-ae30-a22aa68234fb/width=450/931690.jpeg",
+              "nsfwLevel": 2,
+              "width": 2048,
+              "height": 3072,
+              "hash": "U9JtboOs%$0000DNPVM|00%2R5_NPAtSHr^+",
+              "type": "image"
+            },
+            {
+              "id": 931800,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/970c17fe-f2ad-431d-bcaf-c2e0f2a8d32a/width=450/931800.jpeg",
+              "nsfwLevel": 4,
+              "width": 2048,
+              "height": 3072,
+              "hash": "UMK,snyD0KMx0L~V%gofE2jH-oNx%gNx$fM{",
+              "type": "image"
+            },
+            {
+              "id": 944727,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/4aa2bcb1-1d9f-45d3-833b-3a2514d8760a/width=450/944727.jpeg",
+              "nsfwLevel": 1,
+              "width": 2048,
+              "height": 3072,
+              "hash": "UCJZ;^0g0~?b5500IUR51J?c~q9aD$RO9F%1",
+              "type": "image"
+            },
+            {
+              "id": 944798,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/346780b3-062a-4613-8779-700dd0c69e67/width=450/944798.jpeg",
+              "nsfwLevel": 1,
+              "width": 2048,
+              "height": 3072,
+              "hash": "UCIqJ#00loI;s*%#.7McEN?u$*t7%#NGx]tR",
+              "type": "image"
+            },
+            {
+              "id": 944678,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/f85fc935-5073-42ea-9281-49d559d96f23/width=450/944678.jpeg",
+              "nsfwLevel": 8,
+              "width": 2048,
+              "height": 3072,
+              "hash": "UDH1-%_N0etlK[R#E0M_0coa-oM_.6%MNGIo",
+              "type": "image"
+            },
+            {
+              "id": 1004406,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/b49623aa-e990-4e97-b3b9-0c944326abe9/width=450/1004406.jpeg",
+              "nsfwLevel": 1,
+              "width": 1024,
+              "height": 1536,
+              "hash": "UTIqy2^k.m56vzMxWUIoyERj%Maeo~M{s:Rj",
+              "type": "image"
+            },
+            {
+              "id": 4351284,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/8792a858-fccd-4a77-9ab3-ec174908f51a/width=450/4351284.jpeg",
+              "nsfwLevel": 8,
+              "width": 1600,
+              "height": 2400,
+              "hash": "U6AcuQ-o4n-:ofs-~V^+00%L~p9abv?HE10K",
+              "type": "image"
+            }
+          ],
+          "downloadUrl": "https://civitai.com/api/download/models/82745"
+        },
+        {
+          "id": 244417,
+          "index": 1,
+          "name": "Anime v1.0",
+          "baseModel": "SD 1.5",
+          "baseModelType": null,
+          "publishedAt": "2023-11-30T11:16:15.299Z",
+          "availability": "Public",
+          "nsfwLevel": 7,
+          "description": "<p>Negative for Anime checkpoints</p>",
+          "trainedWords": ["CyberRealistic_Negative_Anime"],
+          "stats": {
+            "downloadCount": 3333,
+            "ratingCount": 334,
+            "rating": 5,
+            "thumbsUpCount": 980,
+            "thumbsDownCount": 0
+          },
+          "files": [
+            {
+              "id": 189194,
+              "sizeKB": 214.0439453125,
+              "name": "CyberRealistic_Negative_Anime-neg.pt",
+              "type": "Negative",
+              "pickleScanResult": "Success",
+              "pickleScanMessage": "No Pickle imports",
+              "virusScanResult": "Success",
+              "virusScanMessage": null,
+              "scannedAt": "2023-11-30T09:35:32.790Z",
+              "metadata": {
+                "format": "Other",
+                "size": null,
+                "fp": null
+              },
+              "hashes": {
+                "AutoV2": "0D967611CC",
+                "SHA256": "0D967611CCFD52F523175C161FEF983A7223E0967EC58DD4A029D6ACD5310B7B",
+                "CRC32": "F00C6EAA",
+                "BLAKE3": "3D20210CA84D71D175B51121B446807C6A7DFA757699454EC8127E25790FC01D"
+              },
+              "downloadUrl": "https://civitai.com/api/download/models/244417",
+              "primary": true
+            }
+          ],
+          "images": [
+            {
+              "id": 4047881,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/25836eb8-d100-41de-b822-f3aba2d85565/width=450/4047881.jpeg",
+              "nsfwLevel": 1,
+              "width": 1533,
+              "height": 2300,
+              "hash": "U79%@vt,004:~Vf,IV9FDNMx?bW?rpxa-pNI",
+              "type": "image"
+            },
+            {
+              "id": 4049423,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/5bb1916b-8708-4208-989a-59e7b0220149/width=450/4049423.jpeg",
+              "nsfwLevel": 4,
+              "width": 1533,
+              "height": 2300,
+              "hash": "UAHBG6nO_M00?b00yX4:00D$9G%1oJ?b4n%M",
+              "type": "image"
+            },
+            {
+              "id": 4049869,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/2cec0089-5ee6-45cd-9ead-513187a04a77/width=450/4049869.jpeg",
+              "nsfwLevel": 1,
+              "width": 1533,
+              "height": 2300,
+              "hash": "UPHnTv57EK={~VNG-:NGtRM{xuRj%#IUIVWX",
+              "type": "image"
+            },
+            {
+              "id": 4047462,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/751f020d-fcd6-44c2-8d2a-399f3df9f69e/width=450/4047462.jpeg",
+              "nsfwLevel": 2,
+              "width": 1533,
+              "height": 2300,
+              "hash": "UCAw3R~o5k4;^i-:JUEMR4VYnit8X2ngrXeU",
+              "type": "image"
+            },
+            {
+              "id": 4051331,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/d2762191-6026-4197-a962-2a20ff4878b0/width=450/4051331.jpeg",
+              "nsfwLevel": 4,
+              "width": 1533,
+              "height": 2300,
+              "hash": "UpLE1v$$?^yX%gRiozafbvRjsoof%2xuM{o}",
+              "type": "image"
+            }
+          ],
+          "downloadUrl": "https://civitai.com/api/download/models/244417"
+        }
+      ]
+    },
+    {
+      "id": 119032,
+      "name": "unaestheticXL | Negative TI",
+      "description": "<p>いろいろあるので好みのやつを使ってください</p><p>Of course, since there are various options, please use your preferred one.</p><p>強弱や組み合わせもありです</p><p>It can be strong or weak or a combination of the two.</p><p>モデルとの相性もあるのでコントラストがおかしい場合は違うTIを使用してください</p><p>Use a different ”TI” if the contrast is not right, as it may be compatible with the model</p><p></p><p>Support</p><p><a target=\"_blank\" rel=\"ugc\" href=\"https://ko-fi.com/aikimi\">https://ko-fi.com/aikimi</a></p><p>maybe</p><p>anime: _sky3.1 , v1.0, _hk1</p><p>semireal: v3.1 , _AYv1, 2v10</p><p>real: _Jug6 , v1.3,_Alb2</p><p></p><p></p>",
+      "allowNoCredit": true,
+      "allowCommercialUse": ["Image", "RentCivit", "Rent"],
+      "allowDerivatives": true,
+      "allowDifferentLicense": false,
+      "type": "TextualInversion",
+      "minor": false,
+      "poi": false,
+      "nsfw": false,
+      "nsfwLevel": 7,
+      "cosmetic": null,
+      "stats": {
+        "downloadCount": 110166,
+        "favoriteCount": 0,
+        "thumbsUpCount": 4426,
+        "thumbsDownCount": 3,
+        "commentCount": 40,
+        "ratingCount": 0,
+        "rating": 0,
+        "tippedAmountCount": 14115
+      },
+      "creator": {
+        "username": "Aikimi",
+        "image": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/e91b9f49-1d3b-4297-28e2-8512532fc500/width=96/Aikimi.jpeg"
+      },
+      "tags": ["style"],
+      "modelVersions": [
+        {
+          "id": 480651,
+          "index": 0,
+          "name": "_bp5",
+          "baseModel": "SDXL 1.0",
+          "baseModelType": null,
+          "publishedAt": "2024-05-02T06:20:28.062Z",
+          "availability": "Public",
+          "nsfwLevel": 3,
+          "description": null,
+          "trainedWords": ["unaestheticXL_bp5"],
+          "stats": {
+            "downloadCount": 7977,
+            "ratingCount": 0,
+            "rating": 0,
+            "thumbsUpCount": 496,
+            "thumbsDownCount": 1
+          },
+          "files": [
+            {
+              "id": 399055,
+              "sizeKB": 48.5546875,
+              "name": "unaestheticXL_bp5.safetensors",
+              "type": "Model",
+              "pickleScanResult": "Success",
+              "pickleScanMessage": "No Pickle imports",
+              "virusScanResult": "Success",
+              "virusScanMessage": null,
+              "scannedAt": "2024-05-02T06:21:23.391Z",
+              "metadata": {
+                "format": "SafeTensor",
+                "size": null,
+                "fp": null
+              },
+              "hashes": {
+                "AutoV2": "EA3AF29326",
+                "SHA256": "EA3AF293260966B2332D7639A1C6939061E66ECECAA2605CF34C7E551808BFA4",
+                "CRC32": "9864564A",
+                "BLAKE3": "B9690B83C36B301562F8622B1F9BC5EBE7BF5D3216640FD3C8AE9CCD6426A8B1",
+                "AutoV3": "B3BEECC11815"
+              },
+              "downloadUrl": "https://civitai.com/api/download/models/480651",
+              "primary": true
+            }
+          ],
+          "images": [
+            {
+              "id": 11311386,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/21a6471f-bfd4-43ee-9bfb-0680e01e6b20/width=450/11311386.jpeg",
+              "nsfwLevel": 2,
+              "width": 1792,
+              "height": 1310,
+              "hash": "UXLXMXWAj[RO_NWCWCNG%MbHoekC-;aeoeoe",
+              "type": "image"
+            },
+            {
+              "id": 11311490,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/9496ccc4-2975-4ab2-ab5c-0547c1b60299/width=450/11311490.jpeg",
+              "nsfwLevel": 1,
+              "width": 1792,
+              "height": 1310,
+              "hash": "UnJ7];t7kCNb~qbGoLj]x^aeaejExuayWVs:",
+              "type": "image"
+            },
+            {
+              "id": 11311467,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/c0a38d76-3dee-4902-9069-4750023d583c/width=450/11311467.jpeg",
+              "nsfwLevel": 1,
+              "width": 1792,
+              "height": 1310,
+              "hash": "UVN,_D%Maz-;~qRjj[M{t7ayj[WB-;offQt7",
+              "type": "image"
+            },
+            {
+              "id": 11311471,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/b1ff7330-0cbd-4971-bc53-b0bd8d0692cb/width=450/11311471.jpeg",
+              "nsfwLevel": 1,
+              "width": 1792,
+              "height": 1310,
+              "hash": "USIOLaa{oLEN?wjFWBV@.9WVW;n%~qbHs:t7",
+              "type": "image"
+            },
+            {
+              "id": 11311485,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/b0e4afdb-1b19-406c-907a-26889b1318a4/width=450/11311485.jpeg",
+              "nsfwLevel": 1,
+              "width": 1792,
+              "height": 1310,
+              "hash": "UTLWnfR-a}Ir_3fka#of?^off6s:_4a{j[kB",
+              "type": "image"
+            },
+            {
+              "id": 11311487,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/0fc985e0-bc93-4cb2-8851-a6df4ad4a2ae/width=450/11311487.jpeg",
+              "nsfwLevel": 1,
+              "width": 1792,
+              "height": 1310,
+              "hash": "UPI4kgn+j[W=.TkCj?xZ_NWBbHR*?wkCa}j[",
+              "type": "image"
+            },
+            {
+              "id": 11311514,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/7dd74697-a0bf-4f9f-be1c-92d0140f6f9e/width=450/11311514.jpeg",
+              "nsfwLevel": 1,
+              "width": 1792,
+              "height": 1310,
+              "hash": "UULD=J-;xu?axqoyofR*?wayWBoM?vRjaeR*",
+              "type": "image"
+            }
+          ],
+          "downloadUrl": "https://civitai.com/api/download/models/480651"
+        },
+        {
+          "id": 363593,
+          "index": 1,
+          "name": "_Alb2",
+          "baseModel": "SDXL 1.0",
+          "baseModelType": null,
+          "publishedAt": "2024-02-27T06:37:20.270Z",
+          "availability": "Public",
+          "nsfwLevel": 3,
+          "description": "",
+          "trainedWords": ["unaestheticXL_Alb2"],
+          "stats": {
+            "downloadCount": 15417,
+            "ratingCount": 132,
+            "rating": 5,
+            "thumbsUpCount": 912,
+            "thumbsDownCount": 1
+          },
+          "files": [
+            {
+              "id": 290564,
+              "sizeKB": 48.5234375,
+              "name": "unaestheticXL_Alb2.safetensors",
+              "type": "Model",
+              "pickleScanResult": "Success",
+              "pickleScanMessage": "No Pickle imports",
+              "virusScanResult": "Success",
+              "virusScanMessage": null,
+              "scannedAt": "2024-02-27T06:30:55.642Z",
+              "metadata": {
+                "format": "SafeTensor",
+                "size": null,
+                "fp": null
+              },
+              "hashes": {
+                "AutoV2": "6C1C4CFA35",
+                "SHA256": "6C1C4CFA35E9813ABE5A3E0B490128CDB2680B1C33C7C802EEBC1114050E2E86",
+                "CRC32": "C166EBAC",
+                "BLAKE3": "9FB50FB830B485E17AF911D1FA8AF969D7EE800F1DC36A0CE929145A64A30A04",
+                "AutoV3": "4C6EA36605A9"
+              },
+              "downloadUrl": "https://civitai.com/api/download/models/363593",
+              "primary": true
+            }
+          ],
+          "images": [
+            {
+              "id": 7171790,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/34bf014d-5766-4e10-9b86-630c73b00b7d/width=450/7171790.jpeg",
+              "nsfwLevel": 2,
+              "width": 1792,
+              "height": 1299,
+              "hash": "UdJ*n}tRoKNe~qofoJWV-;aeayjF?Hs:WVt7",
+              "type": "image"
+            },
+            {
+              "id": 7171859,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/40fd0e69-c711-4824-8276-575961554af0/width=450/7171859.jpeg",
+              "nsfwLevel": 1,
+              "width": 1792,
+              "height": 1299,
+              "hash": "UTLW@VIXofIa%#xbs;$+-=oeWUWT?dWmayW-",
+              "type": "image"
+            },
+            {
+              "id": 7171888,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/c41b8e87-da04-41ee-bd43-e0644dc8e270/width=450/7171888.jpeg",
+              "nsfwLevel": 1,
+              "width": 2688,
+              "height": 1310,
+              "hash": "UUH_lURPsmRP~ps:R+s,_4WVRkW;_3ofWBoz",
+              "type": "image"
+            },
+            {
+              "id": 7171912,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/2a68819b-8b5d-40b5-a4ff-1391ba1f6292/width=450/7171912.jpeg",
+              "nsfwLevel": 1,
+              "width": 1792,
+              "height": 1299,
+              "hash": "URJ*q+tSt6=|?wofWVWVSRofWCW-~pRij[S1",
+              "type": "image"
+            },
+            {
+              "id": 7171976,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/5e3dbc26-c9a6-4fcb-b937-cf5e2764ac6f/width=450/7171976.jpeg",
+              "nsfwLevel": 1,
+              "width": 1792,
+              "height": 1299,
+              "hash": "UWDTbYbvayo0~pj@fkf8_2ofjtj[^*j[fQfP",
+              "type": "image"
+            }
+          ],
+          "downloadUrl": "https://civitai.com/api/download/models/363593"
+        },
+        {
+          "id": 302265,
+          "index": 2,
+          "name": "2v10",
+          "baseModel": "SDXL 1.0",
+          "baseModelType": null,
+          "publishedAt": "2024-01-17T12:44:43.797Z",
+          "availability": "Public",
+          "nsfwLevel": 3,
+          "description": null,
+          "trainedWords": ["unaestheticXL2v10"],
+          "stats": {
+            "downloadCount": 17937,
+            "ratingCount": 431,
+            "rating": 4.99,
+            "thumbsUpCount": 867,
+            "thumbsDownCount": 0
+          },
+          "files": [
+            {
+              "id": 238475,
+              "sizeKB": 32.515625,
+              "name": "unaestheticXL2v10.safetensors",
+              "type": "Model",
+              "pickleScanResult": "Success",
+              "pickleScanMessage": "No Pickle imports",
+              "virusScanResult": "Success",
+              "virusScanMessage": null,
+              "scannedAt": "2024-01-17T12:40:47.430Z",
+              "metadata": {
+                "format": "SafeTensor",
+                "size": null,
+                "fp": null
+              },
+              "hashes": {
+                "AutoV2": "C792360B80",
+                "SHA256": "C792360B80A1C10BFA7CEEEF3C971641379786289687948ADA61F1E7FCB4D2A2",
+                "CRC32": "D79DC814",
+                "BLAKE3": "28F31081B562D57B0367CD0411A42DAE7CB6DDA0B509978BCAA09EAD4B47B044",
+                "AutoV3": "8F6DECF408AA"
+              },
+              "downloadUrl": "https://civitai.com/api/download/models/302265",
+              "primary": true
+            }
+          ],
+          "images": [
+            {
+              "id": 5587960,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/1389bc6e-4b82-4cef-9dcd-06a3c900e706/width=450/5587960.jpeg",
+              "nsfwLevel": 2,
+              "width": 1760,
+              "height": 1480,
+              "hash": "UQLg^a$yoyxs_Nnin$xD?Ht7WBkC?bX8ofS$",
+              "type": "image"
+            },
+            {
+              "id": 5588030,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/3227930b-f05b-4477-8780-9a1556e066c8/width=450/5588030.jpeg",
+              "nsfwLevel": 1,
+              "width": 2304,
+              "height": 1937,
+              "hash": "UYIOnA%dfP-._NkWj?ozxxWCoeRk-paej@V?",
+              "type": "image"
+            },
+            {
+              "id": 5587961,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/f2f1c3f2-1cd0-4cb9-94c1-88be585ef259/width=450/5587961.jpeg",
+              "nsfwLevel": 1,
+              "width": 1760,
+              "height": 1480,
+              "hash": "UfH-=HxVjY-p_Na#WCkW?cayaft7?aoJoead",
+              "type": "image"
+            },
+            {
+              "id": 5587963,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/3d0b6fb4-6fbb-42ef-90c7-ed508dea5994/width=450/5587963.jpeg",
+              "nsfwLevel": 1,
+              "width": 1760,
+              "height": 1480,
+              "hash": "UPHxmOaJWB9F_3adoes8?^WBoLae~WxaWWxu",
+              "type": "image"
+            },
+            {
+              "id": 5587964,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/0aea9b18-831b-4982-b4cc-a89842092a39/width=450/5587964.jpeg",
+              "nsfwLevel": 1,
+              "width": 2640,
+              "height": 1480,
+              "hash": "UQHng6-o%KR+~qRkofj[.9R*W=t6?wWWkCj[",
+              "type": "image"
+            },
+            {
+              "id": 5587967,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/ab7e1858-7157-4481-b5e4-95c4bc09834c/width=450/5587967.jpeg",
+              "nsfwLevel": 1,
+              "width": 2688,
+              "height": 1299,
+              "hash": "USK^80xFaexa.Taej[jZ_NWBWXkC.TR*fkWX",
+              "type": "image"
+            },
+            {
+              "id": 5587987,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/7bc177fe-a351-48e5-b82a-40c7ebc93b82/width=450/5587987.jpeg",
+              "nsfwLevel": 1,
+              "width": 1760,
+              "height": 1480,
+              "hash": "UQIORvr;t7M{_4azWBkC~qogaxoz?ba}azV@",
+              "type": "image"
+            }
+          ],
+          "downloadUrl": "https://civitai.com/api/download/models/302265"
+        },
+        {
+          "id": 245812,
+          "index": 3,
+          "name": "_hk1",
+          "baseModel": "SDXL 1.0",
+          "baseModelType": null,
+          "publishedAt": "2023-12-01T13:36:53.448Z",
+          "availability": "Public",
+          "nsfwLevel": 3,
+          "description": "<p>maybe anime</p>",
+          "trainedWords": ["unaestheticXL_hk1"],
+          "stats": {
+            "downloadCount": 11833,
+            "ratingCount": 322,
+            "rating": 4.99,
+            "thumbsUpCount": 661,
+            "thumbsDownCount": 0
+          },
+          "files": [
+            {
+              "id": 190294,
+              "sizeKB": 32.515625,
+              "name": "unaestheticXL_hk1.safetensors",
+              "type": "Model",
+              "pickleScanResult": "Success",
+              "pickleScanMessage": "No Pickle imports",
+              "virusScanResult": "Success",
+              "virusScanMessage": null,
+              "scannedAt": "2023-12-01T13:35:41.829Z",
+              "metadata": {
+                "format": "SafeTensor",
+                "size": null,
+                "fp": null
+              },
+              "hashes": {
+                "AutoV2": "CA29D24A64",
+                "SHA256": "CA29D24A64C1801EFC82F8F4D05D98308E5B6C51C15D156FB61AC074F24F87CE",
+                "CRC32": "6548A9BE",
+                "BLAKE3": "4E63671A88D6E6B570001001E661CF567934B79B0EAB0218D20AAE36C3F43684",
+                "AutoV3": "63578AF5D493"
+              },
+              "downloadUrl": "https://civitai.com/api/download/models/245812",
+              "primary": true
+            }
+          ],
+          "images": [
+            {
+              "id": 4080867,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/3e2b660e-ad8a-49b0-a28f-5b6152fc0f4d/width=450/4080867.jpeg",
+              "nsfwLevel": 1,
+              "width": 2304,
+              "height": 1953,
+              "hash": "USM%QnNNR%-o~ot8WEbcpcX6WBW;_MoJs:nh",
+              "type": "image"
+            },
+            {
+              "id": 4080868,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/1ddd4444-d647-4d6a-b301-ccb45189a2b1/width=450/4080868.jpeg",
+              "nsfwLevel": 1,
+              "width": 2304,
+              "height": 1953,
+              "hash": "URHn{bI^ayR%_Nt6aykB_3t6WVj[?vofWBWB",
+              "type": "image"
+            },
+            {
+              "id": 4080879,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/fc465450-09d4-4719-87bd-02df077e160b/width=450/4080879.jpeg",
+              "nsfwLevel": 2,
+              "width": 2304,
+              "height": 1953,
+              "hash": "UOMjwC8{RPi^.TXnE2M|~pxZozog?Hxunht6",
+              "type": "image"
+            },
+            {
+              "id": 4080888,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/02f96379-08c0-4495-859a-c1a4c0168cc8/width=450/4080888.jpeg",
+              "nsfwLevel": 1,
+              "width": 2304,
+              "height": 1953,
+              "hash": "UNJaTW%3NGNd_Mt7aKVs.SShX8XS_NWVaxof",
+              "type": "image"
+            }
+          ],
+          "downloadUrl": "https://civitai.com/api/download/models/245812"
+        },
+        {
+          "id": 207934,
+          "index": 4,
+          "name": "_Jug6",
+          "baseModel": "SDXL 1.0",
+          "baseModelType": null,
+          "publishedAt": "2023-11-01T12:06:46.872Z",
+          "availability": "Public",
+          "nsfwLevel": 3,
+          "description": "<p>maybe real</p>",
+          "trainedWords": ["unaestheticXL_Jug6"],
+          "stats": {
+            "downloadCount": 9573,
+            "ratingCount": 230,
+            "rating": 4.97,
+            "thumbsUpCount": 398,
+            "thumbsDownCount": 1
+          },
+          "files": [
+            {
+              "id": 159516,
+              "sizeKB": 24.5234375,
+              "name": "unaestheticXL_Jug6.safetensors",
+              "type": "Model",
+              "pickleScanResult": "Success",
+              "pickleScanMessage": "No Pickle imports",
+              "virusScanResult": "Success",
+              "virusScanMessage": null,
+              "scannedAt": "2023-11-01T12:00:34.965Z",
+              "metadata": {
+                "format": "SafeTensor",
+                "size": null,
+                "fp": null
+              },
+              "hashes": {
+                "AutoV2": "ED78E5E8CE",
+                "SHA256": "ED78E5E8CE43574D791BC58A0AE675F9954BFDF76B49A6141EFF3591680F09F0",
+                "CRC32": "1C67EA03",
+                "BLAKE3": "210897F528617F90A6D25C6E7B57094120A213C5B4683DDAA3DA90E76C54A13C"
+              },
+              "downloadUrl": "https://civitai.com/api/download/models/207934",
+              "primary": true
+            }
+          ],
+          "images": [
+            {
+              "id": 3308760,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/86376953-8c46-480b-b1ab-773b05fbcf02/width=450/3308760.jpeg",
+              "nsfwLevel": 1,
+              "width": 2658,
+              "height": 2021,
+              "hash": "UuJkyBt8R+x]?wbGjFn~?boMW;R,x]kCa$WB",
+              "type": "image"
+            },
+            {
+              "id": 3308761,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/3c6438f6-8ead-4ad4-89ef-460bf34901d9/width=450/3308761.jpeg",
+              "nsfwLevel": 1,
+              "width": 4000,
+              "height": 2021,
+              "hash": "UoKKN2s;bba#~Vj[f8of-;j?oLoe-=jtbHbH",
+              "type": "image"
+            },
+            {
+              "id": 3308765,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/54bfcf55-4c08-4dcd-be5d-1096dd39acae/width=450/3308765.jpeg",
+              "nsfwLevel": 1,
+              "width": 4000,
+              "height": 2021,
+              "hash": "UWH.m2xvbaoz_4ayayfk^%axofoL?vflkCj[",
+              "type": "image"
+            },
+            {
+              "id": 3308766,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/7ca8b586-9942-4836-8690-2f6854dca7a7/width=450/3308766.jpeg",
+              "nsfwLevel": 1,
+              "width": 3672,
+              "height": 1855,
+              "hash": "UbHnpmr=ozs:~WRjWWay_3f6f6of?vj[j[WV",
+              "type": "image"
+            },
+            {
+              "id": 3308768,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/23e6a819-8419-4de3-9b11-4844a56e161a/width=450/3308768.jpeg",
+              "nsfwLevel": 1,
+              "width": 2304,
+              "height": 1162,
+              "hash": "UoH2sAWEWBWV?wjYj]f6^,oej]of.7j]ofbH",
+              "type": "image"
+            },
+            {
+              "id": 3308864,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/e9c7097c-8b96-4c46-80fd-96771e6903db/width=450/3308864.jpeg",
+              "nsfwLevel": 2,
+              "width": 4000,
+              "height": 2020,
+              "hash": "UhLXoa%1NLae?wofRkR-t7S5oLt7%1WBs:oJ",
+              "type": "image"
+            }
+          ],
+          "downloadUrl": "https://civitai.com/api/download/models/207934"
+        },
+        {
+          "id": 175819,
+          "index": 5,
+          "name": "_Sky3.1",
+          "baseModel": "SDXL 1.0",
+          "baseModelType": null,
+          "publishedAt": "2023-10-04T13:50:12.475Z",
+          "availability": "Public",
+          "nsfwLevel": 7,
+          "description": null,
+          "trainedWords": ["unaestheticXL_Sky3.1"],
+          "stats": {
+            "downloadCount": 13370,
+            "ratingCount": 262,
+            "rating": 4.99,
+            "thumbsUpCount": 470,
+            "thumbsDownCount": 0
+          },
+          "files": [
+            {
+              "id": 134255,
+              "sizeKB": 32.5234375,
+              "name": "unaestheticXL_Sky3.1.safetensors",
+              "type": "Model",
+              "pickleScanResult": "Success",
+              "pickleScanMessage": "No Pickle imports",
+              "virusScanResult": "Success",
+              "virusScanMessage": null,
+              "scannedAt": "2023-10-04T13:50:50.808Z",
+              "metadata": {
+                "format": "SafeTensor",
+                "size": null,
+                "fp": null
+              },
+              "hashes": {
+                "AutoV2": "A09AD810EA",
+                "SHA256": "A09AD810EA93C0C8ABEE3FA938A683AFD51D5BFA24083CEC1E06D8BA05F4B7F2",
+                "CRC32": "53A62FB3",
+                "BLAKE3": "4EE1B1575E9E67F117E07DD6A9CB6EBADB182BD1FD2DB516B08F4CAA19457FFD"
+              },
+              "downloadUrl": "https://civitai.com/api/download/models/175819",
+              "primary": true
+            }
+          ],
+          "images": [
+            {
+              "id": 2791446,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/967cd97e-b450-4055-b097-3f217652c0fe/width=450/2791446.jpeg",
+              "nsfwLevel": 2,
+              "width": 2584,
+              "height": 1964,
+              "hash": "UTIF*%xZXTE2~qWCs.sn=^bIn$Nu=|xtM|S2",
+              "type": "image"
+            },
+            {
+              "id": 2791447,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/5fe2cfc4-07ba-4bc1-8676-34ff0d3d4bc8/width=450/2791447.jpeg",
+              "nsfwLevel": 1,
+              "width": 3888,
+              "height": 1965,
+              "hash": "ULIg=nn$e-%1?wRkxDNH_Mt7S5of_NWBRkt6",
+              "type": "image"
+            },
+            {
+              "id": 2791448,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/dcc73038-aff3-4943-b625-748b37d0ad11/width=450/2791448.jpeg",
+              "nsfwLevel": 1,
+              "width": 3888,
+              "height": 1965,
+              "hash": "UXGSATbcoekD_Ns:WCof?IkCays:?bWCkCoL",
+              "type": "image"
+            },
+            {
+              "id": 2791451,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/a73d286b-cd95-47f9-956f-1b90372bbc63/width=450/2791451.jpeg",
+              "nsfwLevel": 1,
+              "width": 3888,
+              "height": 1965,
+              "hash": "UOLpXO9uwIRk?^s:jGo0?GozR.Sh?^s:aLWV",
+              "type": "image"
+            },
+            {
+              "id": 2791452,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/32eeaa65-5a74-4ac9-8e05-8a509128caf1/width=450/2791452.jpeg",
+              "nsfwLevel": 1,
+              "width": 3888,
+              "height": 1965,
+              "hash": "UNM6rKk8={t7_NNHXRi{yrxaW=WV.8R%V@Rj",
+              "type": "image"
+            },
+            {
+              "id": 2791453,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/7f46736b-3957-4038-a1bb-28a88a3d71f3/width=450/2791453.jpeg",
+              "nsfwLevel": 4,
+              "width": 3888,
+              "height": 1965,
+              "hash": "UZMHJo~qsjx]~WbbIojFt6kCWYjY?HWBWBj[",
+              "type": "image"
+            }
+          ],
+          "downloadUrl": "https://civitai.com/api/download/models/175819"
+        },
+        {
+          "id": 162146,
+          "index": 6,
+          "name": "_AYv1",
+          "baseModel": "SDXL 1.0",
+          "baseModelType": null,
+          "publishedAt": "2023-09-15T01:52:45.246Z",
+          "availability": "Public",
+          "nsfwLevel": 7,
+          "description": "<p>Stronger contrast</p>",
+          "trainedWords": ["unaestheticXL_AYv1"],
+          "stats": {
+            "downloadCount": 9702,
+            "ratingCount": 247,
+            "rating": 4.99,
+            "thumbsUpCount": 392,
+            "thumbsDownCount": 0
+          },
+          "files": [
+            {
+              "id": 122242,
+              "sizeKB": 32.5234375,
+              "name": "unaestheticXL_AYv1.safetensors",
+              "type": "Model",
+              "pickleScanResult": "Success",
+              "pickleScanMessage": "No Pickle imports",
+              "virusScanResult": "Success",
+              "virusScanMessage": null,
+              "scannedAt": "2023-09-15T01:50:36.028Z",
+              "metadata": {
+                "format": "SafeTensor",
+                "size": null,
+                "fp": null
+              },
+              "hashes": {
+                "AutoV2": "8A94B67251",
+                "SHA256": "8A94B6725117925997367D65328024077C301687BD9A95836793EB8C5209E29F",
+                "CRC32": "0DCAAE00",
+                "BLAKE3": "754B9FAA2F3584AA3526114A819982ACCF5ACE3BFAF07CC078B0E495FCA55975"
+              },
+              "downloadUrl": "https://civitai.com/api/download/models/162146",
+              "primary": true
+            }
+          ],
+          "images": [
+            {
+              "id": 2505462,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/4be4010a-1b57-40ae-913c-090e93de58f2/width=450/2505462.jpeg",
+              "nsfwLevel": 4,
+              "width": 2492,
+              "height": 1876,
+              "hash": "USIi5%I:WVIo~WRPaeMx?ca#WBn%^*ofayt7",
+              "type": "image"
+            },
+            {
+              "id": 2505472,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/62ab7aff-60ed-48be-a279-ffeb28c1d410/width=450/2505472.jpeg",
+              "nsfwLevel": 1,
+              "width": 2496,
+              "height": 2024,
+              "hash": "UTM6uSE2V@4._NoKWVRjyrs.f6xG%zt7kCoz",
+              "type": "image"
+            },
+            {
+              "id": 2505473,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/426ec8f6-4ac1-491e-85cb-3161a89e4809/width=450/2505473.jpeg",
+              "nsfwLevel": 2,
+              "width": 4320,
+              "height": 1298,
+              "hash": "UUIYRoMexbJ9yYSeW.n%~poyozkC*0WYoya}",
+              "type": "image"
+            },
+            {
+              "id": 2505475,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/5838435e-613a-4e10-a416-017de4e1f7fd/width=450/2505475.jpeg",
+              "nsfwLevel": 1,
+              "width": 7200,
+              "height": 2164,
+              "hash": "UVJafrM{xaS4~qRjt7oJx^WCWCj]x^WVayof",
+              "type": "image"
+            },
+            {
+              "id": 2505477,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/01be62d8-90b2-45e7-be7b-ad8a23a251fa/width=450/2505477.jpeg",
+              "nsfwLevel": 1,
+              "width": 7200,
+              "height": 2164,
+              "hash": "UeM74LbwW=jZ~qs:j[kBtlf+jYkC.8Rjs:WB",
+              "type": "image"
+            },
+            {
+              "id": 2505480,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/ad1c9cd8-1b51-4365-9129-da0849d317e3/width=450/2505480.jpeg",
+              "nsfwLevel": 1,
+              "width": 3744,
+              "height": 1959,
+              "hash": "UbJ8eGX9ozof~qaejZj[_3bHayoL%goLf8j[",
+              "type": "image"
+            },
+            {
+              "id": 2505482,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/d1cada71-4ad0-4541-bb24-b87221f8fd73/width=450/2505482.jpeg",
+              "nsfwLevel": 1,
+              "width": 1248,
+              "height": 1664,
+              "hash": "UIFFmeXmEL?b_Nx]I:%MIAxaozxvD*IURk%N",
+              "type": "image"
+            },
+            {
+              "id": 2505483,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/cd7a93bf-27a4-4d93-af0f-35cd98b9a5b6/width=450/2505483.jpeg",
+              "nsfwLevel": 1,
+              "width": 1248,
+              "height": 1664,
+              "hash": "U9EylK0z?tMe.TIoM{Di4UQ-00%L%4R6?Fo}",
+              "type": "image"
+            },
+            {
+              "id": 2505485,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/d5a0f411-bffa-4306-9975-4ca27a9dca02/width=450/2505485.jpeg",
+              "nsfwLevel": 2,
+              "width": 1248,
+              "height": 1664,
+              "hash": "ULEo.4~VV?R+%Mx]x^xaxuxaxuWBR,j@WAt7",
+              "type": "image"
+            },
+            {
+              "id": 2505486,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/77e55042-97ff-4346-bacf-2b9c9984d1a8/width=450/2505486.jpeg",
+              "nsfwLevel": 1,
+              "width": 1248,
+              "height": 1664,
+              "hash": "UCFFQx$J8_?w%hIU4.%N_3RPD%kW%fxCM{S$",
+              "type": "image"
+            }
+          ],
+          "downloadUrl": "https://civitai.com/api/download/models/162146"
+        },
+        {
+          "id": 149308,
+          "index": 7,
+          "name": "v3.1",
+          "baseModel": "SDXL 1.0",
+          "baseModelType": null,
+          "publishedAt": "2023-08-27T05:54:27.900Z",
+          "availability": "Public",
+          "nsfwLevel": 3,
+          "description": "<p>v1とv13の間の感じを目指しました</p><p>We aimed for a feeling between v1 and v13.</p>",
+          "trainedWords": ["unaestheticXLv31"],
+          "stats": {
+            "downloadCount": 11062,
+            "ratingCount": 366,
+            "rating": 5,
+            "thumbsUpCount": 420,
+            "thumbsDownCount": 0
+          },
+          "files": [
+            {
+              "id": 110890,
+              "sizeKB": 32.515625,
+              "name": "unaestheticXLv31.safetensors",
+              "type": "Model",
+              "pickleScanResult": "Success",
+              "pickleScanMessage": "No Pickle imports",
+              "virusScanResult": "Success",
+              "virusScanMessage": null,
+              "scannedAt": "2023-08-27T05:55:35.363Z",
+              "metadata": {
+                "format": "SafeTensor",
+                "size": null,
+                "fp": null
+              },
+              "hashes": {
+                "AutoV2": "75FA9A0423",
+                "SHA256": "75FA9A0423A19C56CCAAEA3B985B4999408B530585ECA3F6108685C0007E5B2E",
+                "CRC32": "E096D182",
+                "BLAKE3": "869B37862CFE12792336CE53D2CA33E0709CF75475F4A3EB9528D54380281A3A"
+              },
+              "downloadUrl": "https://civitai.com/api/download/models/149308",
+              "primary": true
+            }
+          ],
+          "images": [
+            {
+              "id": 2224166,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/3a06065c-7fb7-48eb-9305-00ceb2ac7eb8/width=450/2224166.jpeg",
+              "nsfwLevel": 1,
+              "width": 2512,
+              "height": 2088,
+              "hash": "UVKdPgtRsp-:_NbHWBRk%#V[W;M{_3WUs:WB",
+              "type": "image"
+            },
+            {
+              "id": 2224168,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/b8ae2389-efaa-456e-907e-0a7f30822c8a/width=450/2224168.jpeg",
+              "nsfwLevel": 1,
+              "width": 3888,
+              "height": 1940,
+              "hash": "UXJ86Oo}t8o~_Nt7fkt7.8fkoMjZ^*aef5oI",
+              "type": "image"
+            },
+            {
+              "id": 2224169,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/d038a1f4-4f6e-4fb0-b6b4-bd634acb581e/width=450/2224169.jpeg",
+              "nsfwLevel": 2,
+              "width": 3072,
+              "height": 1526,
+              "hash": "UFH{c+?wo#.7^ltlg4oz?vs;t6oe^+WBxtV[",
+              "type": "image"
+            },
+            {
+              "id": 2224171,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/c9fca345-99b7-4555-a721-bb34a9086821/width=450/2224171.jpeg",
+              "nsfwLevel": 1,
+              "width": 2592,
+              "height": 2092,
+              "hash": "UUJRv?xus:oL~XWVj]a#~Xk9ozkB?cjcjbRj",
+              "type": "image"
+            },
+            {
+              "id": 2224172,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/b08874e0-5b00-460d-aec7-557aeeaa929d/width=450/2224172.jpeg",
+              "nsfwLevel": 1,
+              "width": 2592,
+              "height": 2092,
+              "hash": "UaM$[K$*n%so?^Rjs:Io.SozWBoM?uWBkCof",
+              "type": "image"
+            },
+            {
+              "id": 2224173,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/5ea2b18a-5a91-4ad8-86b5-b487f1215ecf/width=450/2224173.jpeg",
+              "nsfwLevel": 2,
+              "width": 3072,
+              "height": 1526,
+              "hash": "UTHy2cl9%Mtm~VaeR*jF.Tt8bFt7?bbFf8af",
+              "type": "image"
+            },
+            {
+              "id": 2224180,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/5cfa728a-2800-40d3-8bd1-41c6c58e456d/width=450/2224180.jpeg",
+              "nsfwLevel": 1,
+              "width": 1296,
+              "height": 1728,
+              "hash": "U9Ex-GI;00~Vn#M|M{IV#Q%10goy$Jt7^,xZ",
+              "type": "image"
+            },
+            {
+              "id": 2224181,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/3657ff6e-ca8b-4883-b49e-8c0b3b18d9f4/width=450/2224181.jpeg",
+              "nsfwLevel": 1,
+              "width": 1296,
+              "height": 1728,
+              "hash": "UPI=Y[~p}-IBL4%NNLRjF$R:N|%1cFIVngWB",
+              "type": "image"
+            },
+            {
+              "id": 2224187,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/ecd9537c-81d9-41c1-ab68-142da7d7af65/width=450/2224187.jpeg",
+              "nsfwLevel": 1,
+              "width": 1296,
+              "height": 1728,
+              "hash": "UJI}Fp~q9ED$?cE29FnNyX_2M{M|X5T0XSNa",
+              "type": "image"
+            }
+          ],
+          "downloadUrl": "https://civitai.com/api/download/models/149308"
+        },
+        {
+          "id": 134424,
+          "index": 8,
+          "name": "v1.3",
+          "baseModel": "SDXL 1.0",
+          "baseModelType": "Standard",
+          "publishedAt": "2023-08-05T18:27:19.085Z",
+          "availability": "Public",
+          "nsfwLevel": 1,
+          "description": "<p>気分で使い分けてください</p><p>Use it according to your mood</p>",
+          "trainedWords": ["unaestheticXLv13"],
+          "stats": {
+            "downloadCount": 7915,
+            "ratingCount": 293,
+            "rating": 5,
+            "thumbsUpCount": 395,
+            "thumbsDownCount": 0
+          },
+          "files": [
+            {
+              "id": 98060,
+              "sizeKB": 32.1484375,
+              "name": "unaestheticXLv13.safetensors",
+              "type": "Model",
+              "pickleScanResult": "Success",
+              "pickleScanMessage": "No Pickle imports",
+              "virusScanResult": "Success",
+              "virusScanMessage": null,
+              "scannedAt": "2023-08-05T18:30:34.465Z",
+              "metadata": {
+                "format": "SafeTensor",
+                "size": null,
+                "fp": null
+              },
+              "hashes": {
+                "AutoV2": "81107B09C5",
+                "SHA256": "81107B09C54306C3FAB71ADC9165E40B4BAC806FE55927E51F943091208F675D",
+                "CRC32": "9F5DE2D1",
+                "BLAKE3": "AD2BCAAE0A958325A7922641E7927163CC7A78ABEE7EC0F2F825924465CE6A4B"
+              },
+              "downloadUrl": "https://civitai.com/api/download/models/134424",
+              "primary": true
+            }
+          ],
+          "images": [
+            {
+              "id": 1888699,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/2ad3a2a4-cfe0-4919-8cb4-bcac846e91bb/width=450/1888699.jpeg",
+              "nsfwLevel": 1,
+              "width": 2448,
+              "height": 1832,
+              "hash": "UYMscmxtay?G_MWYjbNepeR,WVWC.9ofjsoK",
+              "type": "image"
+            },
+            {
+              "id": 1888611,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/c469b860-ceb7-43dd-91c7-7d3f11ff60a3/width=450/1888611.jpeg",
+              "nsfwLevel": 1,
+              "width": 1224,
+              "height": 1632,
+              "hash": "UQPXw=~pyqb_?byDyWx[RQVtNGr?%}j=nOR+",
+              "type": "image"
+            },
+            {
+              "id": 1888612,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/435dd154-0ad2-4e46-9685-f9c66b1bb512/width=450/1888612.jpeg",
+              "nsfwLevel": 1,
+              "width": 1224,
+              "height": 1632,
+              "hash": "UCI;STOs7{IW,^H@00xuC7}[QTtR-WEL^P-o",
+              "type": "image"
+            },
+            {
+              "id": 1917995,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/7474954c-e122-4169-8fd3-b8e4b8294661/width=450/1917995.jpeg",
+              "nsfwLevel": 1,
+              "width": 3420,
+              "height": 2448,
+              "hash": "USLgkb_3~p_N.8Rkj]aK?HaeRjWV-;ayayj[",
+              "type": "image"
+            },
+            {
+              "id": 1888609,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/afa5e521-0705-47b3-8c76-4cf802877882/width=450/1888609.jpeg",
+              "nsfwLevel": 1,
+              "width": 1224,
+              "height": 1632,
+              "hash": "UQLpT{~UXc4:_0Sjk=jcEnX8S7s.%gxuaext",
+              "type": "image"
+            }
+          ],
+          "downloadUrl": "https://civitai.com/api/download/models/134424"
+        },
+        {
+          "id": 129199,
+          "index": 9,
+          "name": "v1.0",
+          "baseModel": "SDXL 1.0",
+          "baseModelType": "Standard",
+          "publishedAt": "2023-07-30T07:03:46.880Z",
+          "availability": "Public",
+          "nsfwLevel": 7,
+          "description": null,
+          "trainedWords": ["unaestheticXLv1"],
+          "stats": {
+            "downloadCount": 5380,
+            "ratingCount": 135,
+            "rating": 4.99,
+            "thumbsUpCount": 170,
+            "thumbsDownCount": 0
+          },
+          "files": [
+            {
+              "id": 93628,
+              "sizeKB": 32.1484375,
+              "name": "unaestheticXLv1.safetensors",
+              "type": "Model",
+              "pickleScanResult": "Success",
+              "pickleScanMessage": "No Pickle imports",
+              "virusScanResult": "Success",
+              "virusScanMessage": null,
+              "scannedAt": "2023-07-30T07:00:37.441Z",
+              "metadata": {
+                "format": "SafeTensor",
+                "size": null,
+                "fp": null
+              },
+              "hashes": {
+                "AutoV2": "1E9A2CE10D",
+                "SHA256": "1E9A2CE10DB180C68FFD60869BDE8542BA09A33D9211E897B38842297617534E",
+                "CRC32": "F94656F3",
+                "BLAKE3": "763F4B47C9070BE0E4C849769D6C2B389E5398B144F452BCB74B5FEB0EF69B58"
+              },
+              "downloadUrl": "https://civitai.com/api/download/models/129199",
+              "primary": true
+            }
+          ],
+          "images": [
+            {
+              "id": 1840584,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/e860f0be-0e33-4c76-a716-84d0c0be81f3/width=450/1840584.jpeg",
+              "nsfwLevel": 2,
+              "width": 1224,
+              "height": 1632,
+              "hash": "UFMGO]~p$_%f~B?bX.-:pJoJV[tS%#M{Vsae",
+              "type": "image"
+            },
+            {
+              "id": 1788093,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/e47b2b34-a542-4265-a7c1-8859d74183d5/width=450/1788093.jpeg",
+              "nsfwLevel": 1,
+              "width": 1728,
+              "height": 1306,
+              "hash": "UiGuq6xaoLt6~qofj[of%NWBayWB%gj[fQaz",
+              "type": "image"
+            },
+            {
+              "id": 1788094,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/fc1bd064-2b5f-4583-9ba9-cceefcf30ec9/width=450/1788094.jpeg",
+              "nsfwLevel": 1,
+              "width": 2592,
+              "height": 1306,
+              "hash": "UdOx:bX9R.t7?wjZaxkC?cj?j?bH.Sj[j[oL",
+              "type": "image"
+            },
+            {
+              "id": 1788095,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/e36f5a6a-ed72-4777-bec6-6f1809f46ffe/width=450/1788095.jpeg",
+              "nsfwLevel": 2,
+              "width": 1728,
+              "height": 1306,
+              "hash": "UbJHXIxva}t7~qj[j[ozpJWBaybH_Noea}jY",
+              "type": "image"
+            },
+            {
+              "id": 1788096,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/88cb44a9-a2c6-4dc0-b796-ffbe0327530a/width=450/1788096.jpeg",
+              "nsfwLevel": 1,
+              "width": 1728,
+              "height": 1306,
+              "hash": "UUK23QkCj[Rk~qoJj[oeNLt6j[xt_2R*WVRk",
+              "type": "image"
+            },
+            {
+              "id": 1788097,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/7344e4b2-96d1-4d75-9777-aed4287a5db4/width=450/1788097.jpeg",
+              "nsfwLevel": 2,
+              "width": 2592,
+              "height": 1306,
+              "hash": "UcLp%9xuozjZ_Na#WBj]k?jZaxof~qoLofjs",
+              "type": "image"
+            },
+            {
+              "id": 1788098,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/fc065b39-e3d0-46bc-b271-961e7f44dea5/width=450/1788098.jpeg",
+              "nsfwLevel": 1,
+              "width": 2592,
+              "height": 1306,
+              "hash": "UWLqa;kBoytQ?bofWBf8?cRkWBR*~qWBoLof",
+              "type": "image"
+            },
+            {
+              "id": 1788100,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/30d19dc8-a918-4659-8386-67888eceb860/width=450/1788100.jpeg",
+              "nsfwLevel": 1,
+              "width": 2592,
+              "height": 1306,
+              "hash": "UbOzGKkDt7j[-;j@WBj[~qofayt7%NRjj[ay",
+              "type": "image"
+            },
+            {
+              "id": 1840538,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/c594b078-8e49-4c0f-8c63-b0dbb889af0b/width=450/1840538.jpeg",
+              "nsfwLevel": 1,
+              "width": 1224,
+              "height": 1632,
+              "hash": "U7E_~#.902.T_3X:~q.8=soz9cE14nivnNi^",
+              "type": "image"
+            },
+            {
+              "id": 1840542,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/7494fcc9-a31d-4e3b-9090-c97901582560/width=450/1840542.jpeg",
+              "nsfwLevel": 2,
+              "width": 1224,
+              "height": 1632,
+              "hash": "U7F~UA4n.9cG4;?cIT00RNDi4m004.~W_3IU",
+              "type": "image"
+            },
+            {
+              "id": 1840543,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/7c1d9196-cfad-47a4-8a90-1fab46a71ba2/width=450/1840543.jpeg",
+              "nsfwLevel": 1,
+              "width": 1224,
+              "height": 1632,
+              "hash": "U7E_jjE34m4:}?nl.6M{01%0JC^+00xa^+of",
+              "type": "image"
+            },
+            {
+              "id": 1840539,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/3a0224b2-11c6-4824-90d4-adcea5691f8a/width=450/1840539.jpeg",
+              "nsfwLevel": 1,
+              "width": 1224,
+              "height": 1632,
+              "hash": "UKJtk]yD4.9u?wkXIVRP%#-oS5Ip~p%1xt%2",
+              "type": "image"
+            },
+            {
+              "id": 1840540,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/42dcc83d-413c-43a0-a0be-e4e78b968d28/width=450/1840540.jpeg",
+              "nsfwLevel": 1,
+              "width": 1224,
+              "height": 1632,
+              "hash": "UEEpAsR%Rsxb?]E1Ia$QD$nl8_s.IAo}$x$l",
+              "type": "image"
+            },
+            {
+              "id": 1840544,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/722193c2-6966-497c-998a-9bf836b1b7ad/width=450/1840544.jpeg",
+              "nsfwLevel": 2,
+              "width": 1224,
+              "height": 1632,
+              "hash": "UFMGO]~p$_%f~B?bX.-:pJoJV[tS%#M{Vsae",
+              "type": "image"
+            },
+            {
+              "id": 1840545,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/ef129271-828b-4912-a516-1d5b923052a3/width=450/1840545.jpeg",
+              "nsfwLevel": 2,
+              "width": 1224,
+              "height": 1632,
+              "hash": "UEGbF.IV00~BMxNb%2$e00%1bcS4E1xC^*I[",
+              "type": "image"
+            },
+            {
+              "id": 1840547,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/7d492de3-f45c-4f19-9a5e-bf57e1a2490a/width=450/1840547.jpeg",
+              "nsfwLevel": 1,
+              "width": 1224,
+              "height": 1632,
+              "hash": "UBFht_oz_14;~W9a%LI@?GxFIpMy0exWs:D*",
+              "type": "image"
+            },
+            {
+              "id": 1840550,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/01d84d49-8510-4e6f-aeb8-fb82e7a6fb74/width=450/1840550.jpeg",
+              "nsfwLevel": 4,
+              "width": 1224,
+              "height": 1632,
+              "hash": "UIK0{P4:Tc4oxts:-qWU?bxt%Mxv?w%MMxj]",
+              "type": "image"
+            },
+            {
+              "id": 1840546,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/f6b13adc-9d33-43a8-a829-b8e67316ed33/width=450/1840546.jpeg",
+              "nsfwLevel": 1,
+              "width": 1224,
+              "height": 1632,
+              "hash": "U5Hw*^9i00In0004lA5900xptnIW0h=?}@~V",
+              "type": "image"
+            },
+            {
+              "id": 1840556,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/14336d08-44ef-4ce8-b89d-7663c8c22f24/width=450/1840556.jpeg",
+              "nsfwLevel": 2,
+              "width": 1224,
+              "height": 1632,
+              "hash": "UCDl.qR-v}xu_Mbb~BNGxGNas:RQ57xanOM|",
+              "type": "image"
+            },
+            {
+              "id": 1840551,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/50297131-3903-4095-8b40-16b420c266cb/width=450/1840551.jpeg",
+              "nsfwLevel": 1,
+              "width": 1224,
+              "height": 1632,
+              "hash": "UAC~*iXnAcxF02Nx0g%1}QNHxVxu%hxuTKNG",
+              "type": "image"
+            }
+          ],
+          "downloadUrl": "https://civitai.com/api/download/models/129199"
+        }
+      ]
+    },
+    {
+      "id": 98259,
+      "name": "Detail ++",
+      "description": "<p><strong>Reminder:</strong><br /><strong>The older embeddings do not work on SDXL or Pony models, they give you errors on external image generators. Not sure what the internal generator does but I think it just ignores them if they throw errors. In the other direction, it works the same, no sd1.5 embeddings on SDXL or Pony and no SDXL/Pony embeddings on SD1.5...</strong></p><p></p><p>Set of TIs that gives me lots of detail in the skin and hair or even overall detail on the whole image. All but OverallDetail shifts the focus of the image to parts that get more detail now.</p><p>Check the comparison on the OverallDetails page but keep in mind that those are done without any other negative prompts or helpers unless stated.</p><p>The SkinDetail and SkinHairDetail sometimes have a side effect that shows scars or otherwise broken skin, that can be worked against with adding \"skin markings\" into the negative prompt.</p><p></p><p>The XL / Pony versions are tested with the XL Model Fenris (see the resources) and also my own model blend between a pony model and Fenris.</p>",
+      "allowNoCredit": true,
+      "allowCommercialUse": ["Image", "RentCivit", "Rent", "Sell"],
+      "allowDerivatives": true,
+      "allowDifferentLicense": true,
+      "type": "TextualInversion",
+      "minor": false,
+      "poi": false,
+      "nsfw": false,
+      "nsfwLevel": 15,
+      "cosmetic": null,
+      "stats": {
+        "downloadCount": 75433,
+        "favoriteCount": 0,
+        "thumbsUpCount": 4163,
+        "thumbsDownCount": 14,
+        "commentCount": 23,
+        "ratingCount": 0,
+        "rating": 0,
+        "tippedAmountCount": 218
+      },
+      "creator": {
+        "username": "Kaleidia",
+        "image": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/0f78742f-5a74-46b9-8e39-ab3b136b1c83/width=96/Kaleidia.jpeg"
+      },
+      "tags": [
+        "textual inversion",
+        "style",
+        "embedding",
+        "hair",
+        "detail",
+        "skin"
+      ],
+      "modelVersions": [
+        {
+          "id": 539032,
+          "index": 0,
+          "name": "Overall Detail XL",
+          "baseModel": "SDXL 1.0",
+          "baseModelType": null,
+          "publishedAt": "2024-05-30T15:33:42.805Z",
+          "availability": "Public",
+          "nsfwLevel": 15,
+          "description": "<p>Same as the other version but for SDXL and Pony, trigger word is OverallDetailXL</p>",
+          "trainedWords": ["OverallDetailXL"],
+          "stats": {
+            "downloadCount": 7437,
+            "ratingCount": 0,
+            "rating": 0,
+            "thumbsUpCount": 487,
+            "thumbsDownCount": 1
+          },
+          "files": [
+            {
+              "id": 455922,
+              "sizeKB": 16.1484375,
+              "name": "OverallDetailXL.safetensors",
+              "type": "Model",
+              "pickleScanResult": "Success",
+              "pickleScanMessage": "No Pickle imports",
+              "virusScanResult": "Success",
+              "virusScanMessage": null,
+              "scannedAt": "2024-05-30T15:35:43.695Z",
+              "metadata": {
+                "format": "SafeTensor",
+                "size": null,
+                "fp": null
+              },
+              "hashes": {
+                "AutoV2": "CAD765D41C",
+                "SHA256": "CAD765D41C8A1BF799DEAC753B62F1E735449B9F84FF00A115FD2F35A215FDF5",
+                "CRC32": "295D1C2B",
+                "BLAKE3": "2466DA209D526FAF7954B70099278352F6A3F370F7DD0C670866B23504164B97",
+                "AutoV3": "96E41947380E"
+              },
+              "downloadUrl": "https://civitai.com/api/download/models/539032",
+              "primary": true
+            }
+          ],
+          "images": [
+            {
+              "id": 14054888,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/20d69313-68bf-424b-bb76-5a0a993e8bf2/width=450/14054888.jpeg",
+              "nsfwLevel": 1,
+              "width": 768,
+              "height": 1344,
+              "hash": "UBD8]]4;bGs:~VM|WVfQSioJayj[s:WCayof",
+              "type": "image"
+            },
+            {
+              "id": 14054892,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/15c8d85e-b56a-42f3-a47a-51783c88299f/width=450/14054892.jpeg",
+              "nsfwLevel": 1,
+              "width": 768,
+              "height": 1344,
+              "hash": "U6A^RF%Lpb%M_NWU-pRkkEW.%2Rj%Lofj[j@",
+              "type": "image"
+            },
+            {
+              "id": 14054890,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/3d9bc6e6-2ecd-492d-b6fb-01642ae5f5b9/width=450/14054890.jpeg",
+              "nsfwLevel": 1,
+              "width": 768,
+              "height": 1344,
+              "hash": "U6A^ji}?#k?F~U%0njNd01E4SdRk9bWUs:NI",
+              "type": "image"
+            },
+            {
+              "id": 14055740,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/e2ee8ba3-9cbc-4f77-aa94-d6efacd030c4/width=450/14055740.jpeg",
+              "nsfwLevel": 1,
+              "width": 768,
+              "height": 1344,
+              "hash": "UFFX^:~VBp0KyY.8M|nhKjx]%2oJ%g-;%Moz",
+              "type": "image"
+            },
+            {
+              "id": 14055736,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/c7cc0434-7115-4c20-830e-c53942bea3af/width=450/14055736.jpeg",
+              "nsfwLevel": 1,
+              "width": 768,
+              "height": 1344,
+              "hash": "U9C$TK~q0L9bXkW?RlkCD%M_j?xGI.$*i{In",
+              "type": "image"
+            },
+            {
+              "id": 14055739,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/3eb24a86-8d2e-43f6-ac6b-9bfae25fa3a8/width=450/14055739.jpeg",
+              "nsfwLevel": 2,
+              "width": 768,
+              "height": 1344,
+              "hash": "U9DIj@s.57~BI?%LbY%24;tR?GIVNaagRjR*",
+              "type": "image"
+            },
+            {
+              "id": 14055737,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/b67d3697-701e-4dfd-aa2c-e78b56699d47/width=450/14055737.jpeg",
+              "nsfwLevel": 4,
+              "width": 768,
+              "height": 1344,
+              "hash": "UGGuUa%hp{0#TM%Msp-;TeShxus;9cD%V@s:",
+              "type": "image"
+            },
+            {
+              "id": 14033430,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/16085070-12bf-40c3-a1f9-182e4e86791c/width=450/14033430.jpeg",
+              "nsfwLevel": 4,
+              "width": 768,
+              "height": 1344,
+              "hash": "UIFi46ITyZ~Bpes+NHNH?vE2?HRkp0%M%2of",
+              "type": "image"
+            },
+            {
+              "id": 14033429,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/48e046ad-8d0d-43bf-878b-73868ced2615/width=450/14033429.jpeg",
+              "nsfwLevel": 4,
+              "width": 768,
+              "height": 1344,
+              "hash": "UFEoSvoI9axa_N9ZM{ayx^D%M{-o-;IUMxkC",
+              "type": "image"
+            },
+            {
+              "id": 14033432,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/0a1bcc98-de7d-4c2a-abe5-bb2eeeed4b2f/width=450/14033432.jpeg",
+              "nsfwLevel": 4,
+              "width": 768,
+              "height": 1344,
+              "hash": "UDD9Cq~V-:9aS$I;ofRkIps:%2t7kDj[Rkxa",
+              "type": "image"
+            },
+            {
+              "id": 14033431,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/a6e4d968-4e97-4ad4-8d2b-d5884cd3871c/width=450/14033431.jpeg",
+              "nsfwLevel": 8,
+              "width": 768,
+              "height": 1344,
+              "hash": "UCDvD*t6yD~WKR$$IpW;OtIU%1Io.8xtnh%M",
+              "type": "image"
+            },
+            {
+              "id": 14033377,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/7f2680c0-48de-41d9-bd5b-d77f50c80b25/width=450/14033377.jpeg",
+              "nsfwLevel": 4,
+              "width": 1344,
+              "height": 768,
+              "hash": "U8D+^|9F00.mEfx@wcoNwQ%yRiR6t2OYxYnO",
+              "type": "image"
+            },
+            {
+              "id": 14033408,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/e3ddecc5-28bc-4383-86ac-2b8b7f0b216c/width=450/14033408.jpeg",
+              "nsfwLevel": 4,
+              "width": 1344,
+              "height": 768,
+              "hash": "U5Gk5o~V00}lEM^ijZS2ozIo-VIp?a?HD%4o",
+              "type": "image"
+            },
+            {
+              "id": 14033376,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/18aec78e-c157-4f15-be79-24e71613588b/width=450/14033376.jpeg",
+              "nsfwLevel": 8,
+              "width": 1344,
+              "height": 768,
+              "hash": "UPF5%9-p9F_4yEtSbctlS$ozogbIxuj]aeoL",
+              "type": "image"
+            },
+            {
+              "id": 14033378,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/41b804df-fad2-4f6b-a2f6-c24923cadef3/width=450/14033378.jpeg",
+              "nsfwLevel": 8,
+              "width": 1344,
+              "height": 768,
+              "hash": "UJF5v;_30fRj57t8s:IUt7t8tR%2~Wxu9GRj",
+              "type": "image"
+            },
+            {
+              "id": 16518411,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/936e198c-811c-4deb-9706-1cddc8ae3016/width=450/16518411.jpeg",
+              "nsfwLevel": 1,
+              "width": 768,
+              "height": 1344,
+              "hash": "U9A]Nf570z}@%LspE1xuR-Nas:xZsRxaEMNG",
+              "type": "image"
+            },
+            {
+              "id": 16518410,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/e69d8adc-ec46-45b9-b91b-da895e38247c/width=450/16518410.jpeg",
+              "nsfwLevel": 1,
+              "width": 768,
+              "height": 1344,
+              "hash": "U8BMY-=_9[W.~A%24:j[bbozWENHI:NbIVM{",
+              "type": "image"
+            },
+            {
+              "id": 16518413,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/cbfc1ddf-491c-4aec-920b-0b88e3ee0f43/width=450/16518413.jpeg",
+              "nsfwLevel": 1,
+              "width": 768,
+              "height": 1344,
+              "hash": "U7AS_K570K~C%Ms.IUNHE*$fNHflXn$*i]NG",
+              "type": "image"
+            },
+            {
+              "id": 16518412,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/8c3fcc97-e6e4-41f3-919e-7fbf7535d209/width=450/16518412.jpeg",
+              "nsfwLevel": 1,
+              "width": 768,
+              "height": 1344,
+              "hash": "U6AJQTIn01~V%1jZ9YnhSjxun#NyM_ofRjE0",
+              "type": "image"
+            }
+          ],
+          "downloadUrl": "https://civitai.com/api/download/models/539032"
+        },
+        {
+          "id": 566402,
+          "index": 1,
+          "name": "Skin Detail PXL",
+          "baseModel": "SDXL 1.0",
+          "baseModelType": null,
+          "publishedAt": "2024-06-11T17:59:21.044Z",
+          "availability": "Public",
+          "nsfwLevel": 9,
+          "description": "<p>Skin detail for Pony and SDXL</p>",
+          "trainedWords": ["skindetailpxl"],
+          "stats": {
+            "downloadCount": 1039,
+            "ratingCount": 0,
+            "rating": 0,
+            "thumbsUpCount": 63,
+            "thumbsDownCount": 0
+          },
+          "files": [
+            {
+              "id": 482245,
+              "sizeKB": 112.1484375,
+              "name": "skindetailpxl.safetensors",
+              "type": "Model",
+              "pickleScanResult": "Success",
+              "pickleScanMessage": "No Pickle imports",
+              "virusScanResult": "Success",
+              "virusScanMessage": null,
+              "scannedAt": "2024-06-11T18:00:50.226Z",
+              "metadata": {
+                "format": "SafeTensor",
+                "size": null,
+                "fp": null
+              },
+              "hashes": {
+                "AutoV2": "5178F1BE4D",
+                "SHA256": "5178F1BE4D95552E8ADFE654BB0B84FE73383338498581184147F02109FDC73A",
+                "CRC32": "4555CBBE",
+                "BLAKE3": "7B66AD676C0B9A2E976616447B49B3E344D01DF4C938507DA0FF925AD368074E",
+                "AutoV3": "38E941A53AA6"
+              },
+              "downloadUrl": "https://civitai.com/api/download/models/566402",
+              "primary": true
+            }
+          ],
+          "images": [
+            {
+              "id": 15442083,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/8b011c3f-fc31-4057-8b54-7ee72fe74ee6/width=450/15442083.jpeg",
+              "nsfwLevel": 1,
+              "width": 768,
+              "height": 1344,
+              "hash": "UHIq7O019aNc~pE1M{E2IoWVafof%2E19a%L",
+              "type": "image"
+            },
+            {
+              "id": 15442084,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/0330db7e-c268-4cb8-9625-f28356729da9/width=450/15442084.jpeg",
+              "nsfwLevel": 1,
+              "width": 768,
+              "height": 1344,
+              "hash": "UHJt0V-:s.xZ?b%M%0RP9aoz4.Ip~CWB4:M|",
+              "type": "image"
+            },
+            {
+              "id": 15444200,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/4ae04869-475d-4c75-a85b-22c69536b196/width=450/15444200.jpeg",
+              "nsfwLevel": 8,
+              "width": 768,
+              "height": 1344,
+              "hash": "URKmFKIo9a%10fofxtxaNGNHxaIp~Vso%1NG",
+              "type": "image"
+            },
+            {
+              "id": 15444207,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/f27aa487-1755-4052-8942-a5c64772875d/width=450/15444207.jpeg",
+              "nsfwLevel": 1,
+              "width": 768,
+              "height": 1344,
+              "hash": "U6I:%j-o000L0M?GR5~A0K00^k?b00kWXm4:",
+              "type": "image"
+            },
+            {
+              "id": 15444510,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/99f6a7cf-d5a3-4657-8b82-0c429f579a65/width=450/15444510.jpeg",
+              "nsfwLevel": 1,
+              "width": 768,
+              "height": 1344,
+              "hash": "UFH^eV~B00n$?aWW4:Ip0eR*=|ay4:WBt7WV",
+              "type": "image"
+            },
+            {
+              "id": 15444826,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/fdeb5145-cbf9-47ef-a033-7f8bd38ac943/width=450/15444826.jpeg",
+              "nsfwLevel": 1,
+              "width": 768,
+              "height": 1344,
+              "hash": "UCH^ha~B010101jZ%1RkS#9a^j-o01Io%LRk",
+              "type": "image"
+            },
+            {
+              "id": 15444917,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/4f085d2d-db1e-4c82-aec6-2d96a2c21902/width=450/15444917.jpeg",
+              "nsfwLevel": 1,
+              "width": 768,
+              "height": 1344,
+              "hash": "UNHnKZ~VIVs.%Mxu%2xtNGxtf+t7^*t7IojY",
+              "type": "image"
+            },
+            {
+              "id": 15444950,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/fa9c5ff3-8767-4e13-8fb8-8683d5e40e7a/width=450/15444950.jpeg",
+              "nsfwLevel": 1,
+              "width": 768,
+              "height": 1344,
+              "hash": "UFEB{a0L0L~VJBxtWVt7xut7tRIp4:%2tRsm",
+              "type": "image"
+            },
+            {
+              "id": 15434547,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/0176f947-794c-45d5-af5a-75ede5c56816/width=450/15434547.jpeg",
+              "nsfwLevel": 1,
+              "width": 768,
+              "height": 1344,
+              "hash": "UDGazknh00-p~VIpE1oz56R*R*Ip-UWqR*Io",
+              "type": "image"
+            },
+            {
+              "id": 15435754,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/3daafec2-12d5-4744-932f-e2a913373cac/width=450/15435754.jpeg",
+              "nsfwLevel": 1,
+              "width": 768,
+              "height": 1344,
+              "hash": "U5EefF00Ab={_M00_2n3yDVY~WwHEM9Z~W8{",
+              "type": "image"
+            },
+            {
+              "id": 15435640,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/5279f952-d627-452e-9933-7ba02d52e538/width=450/15435640.jpeg",
+              "nsfwLevel": 1,
+              "width": 768,
+              "height": 1344,
+              "hash": "UCG[D[~B0#9ZSOkX4.xa9Z-;V@xu579F%fNG",
+              "type": "image"
+            },
+            {
+              "id": 15434561,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/c1405218-3f69-400e-bcce-d0473b220f1c/width=450/15434561.jpeg",
+              "nsfwLevel": 1,
+              "width": 768,
+              "height": 1344,
+              "hash": "U6ExhT0f00~VEMtQ4.E2^*of-pIo00t7?HnO",
+              "type": "image"
+            },
+            {
+              "id": 15435615,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/d6d97576-fe7c-4d97-8c3c-52c175ae9c98/width=450/15435615.jpeg",
+              "nsfwLevel": 8,
+              "width": 768,
+              "height": 1344,
+              "hash": "UBG87d9a0L^*%g~V9ZNG%fxtM|NGEMNG%2M{",
+              "type": "image"
+            },
+            {
+              "id": 15435685,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/77d2dd26-bf61-4724-bacd-447e945a394a/width=450/15435685.jpeg",
+              "nsfwLevel": 8,
+              "width": 768,
+              "height": 1344,
+              "hash": "UADIqC_30MNHK7~W?b9acFI@o#-p57NJ?b%L",
+              "type": "image"
+            }
+          ],
+          "downloadUrl": "https://civitai.com/api/download/models/566402"
+        },
+        {
+          "id": 566410,
+          "index": 2,
+          "name": "Hair Detail PXL",
+          "baseModel": "SDXL 1.0",
+          "baseModelType": null,
+          "publishedAt": "2024-06-11T18:11:50.710Z",
+          "availability": "Public",
+          "nsfwLevel": 13,
+          "description": "<p>Hair Detail for SDXL and Pony</p>",
+          "trainedWords": ["hairdetailpxl"],
+          "stats": {
+            "downloadCount": 877,
+            "ratingCount": 0,
+            "rating": 0,
+            "thumbsUpCount": 49,
+            "thumbsDownCount": 0
+          },
+          "files": [
+            {
+              "id": 482259,
+              "sizeKB": 64.1484375,
+              "name": "hairdetailpxl.safetensors",
+              "type": "Model",
+              "pickleScanResult": "Success",
+              "pickleScanMessage": "No Pickle imports",
+              "virusScanResult": "Success",
+              "virusScanMessage": null,
+              "scannedAt": "2024-06-11T18:10:55.096Z",
+              "metadata": {
+                "format": "SafeTensor",
+                "size": null,
+                "fp": null
+              },
+              "hashes": {
+                "AutoV2": "C376BE8D8F",
+                "SHA256": "C376BE8D8FD32F126CF7784FDDA4E7C0FAADF7DA03EF89B25DFD3112D338408D",
+                "CRC32": "94F7681E",
+                "BLAKE3": "33BCCB15430253649AE8C039029A1B39849CB58099A6653F8FA7AB2B2D42188A",
+                "AutoV3": "2C33012827E7"
+              },
+              "downloadUrl": "https://civitai.com/api/download/models/566410",
+              "primary": true
+            }
+          ],
+          "images": [
+            {
+              "id": 15435193,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/a6077f35-b698-4b35-aa0d-c30c9fea2d5c/width=450/15435193.jpeg",
+              "nsfwLevel": 8,
+              "width": 768,
+              "height": 1344,
+              "hash": "UFHUa-9GJB4n?w-p-o9G~p-;9GRjx]NGe-ni",
+              "type": "image"
+            },
+            {
+              "id": 15435407,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/f9ff063d-d98f-40c1-a2a2-6f6889690c2f/width=450/15435407.jpeg",
+              "nsfwLevel": 1,
+              "width": 768,
+              "height": 1344,
+              "hash": "UME.9A~B9aWBxukBRjs:W.xt%2xtE1WBxaWW",
+              "type": "image"
+            },
+            {
+              "id": 15435462,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/3e341fce-5582-42e6-b1ba-cc998a6b03ea/width=450/15435462.jpeg",
+              "nsfwLevel": 1,
+              "width": 768,
+              "height": 1344,
+              "hash": "UGF=5P~V0LRj%M-pRjRjNGbIogWB9aWB%LRk",
+              "type": "image"
+            },
+            {
+              "id": 15435556,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/db5017c1-372b-4b64-a3b7-664fa3b67d85/width=450/15435556.jpeg",
+              "nsfwLevel": 4,
+              "width": 768,
+              "height": 1344,
+              "hash": "U8EC8,Xo0K0000IA~Vkq5S~WIW$#?G9G4o?H",
+              "type": "image"
+            }
+          ],
+          "downloadUrl": "https://civitai.com/api/download/models/566410"
+        },
+        {
+          "id": 106020,
+          "index": 3,
+          "name": "Overall Detail (SD1.5)",
+          "baseModel": "SD 1.5",
+          "baseModelType": "Standard",
+          "publishedAt": "2023-06-28T17:29:52.951Z",
+          "availability": "Public",
+          "nsfwLevel": 2,
+          "description": "<p>Adds overall detail to the image, can add swirls and lace parts to clothing and as makeup or tattoos</p>",
+          "trainedWords": ["OverallDetail"],
+          "stats": {
+            "downloadCount": 27938,
+            "ratingCount": 411,
+            "rating": 4.87,
+            "thumbsUpCount": 2230,
+            "thumbsDownCount": 9
+          },
+          "files": [
+            {
+              "id": 74591,
+              "sizeKB": 15.955078125,
+              "name": "OverallDetail.pt",
+              "type": "Model",
+              "pickleScanResult": "Success",
+              "pickleScanMessage": "No Pickle imports",
+              "virusScanResult": "Success",
+              "virusScanMessage": null,
+              "scannedAt": "2023-06-28T17:30:53.125Z",
+              "metadata": {
+                "format": "PickleTensor",
+                "size": null,
+                "fp": null
+              },
+              "hashes": {
+                "AutoV2": "34DCA6DA73",
+                "SHA256": "34DCA6DA73885DB580F832023DDF48923D977D95167533EE145FE78E5646C6D4",
+                "CRC32": "65F83D8B",
+                "BLAKE3": "59D73C1BB471299FBD0A89325953C90A0E6E98AC4D775A63F44C21B4D30FFC0B"
+              },
+              "downloadUrl": "https://civitai.com/api/download/models/106020",
+              "primary": true
+            }
+          ],
+          "images": [
+            {
+              "id": 1324247,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/9954ffa7-a665-4c08-be3c-5d850cb36b38/width=450/1324247.jpeg",
+              "nsfwLevel": 2,
+              "width": 512,
+              "height": 768,
+              "hash": "ULD+0j~B5QR*xaxat6R+9uIpV@RkM|R*oeoL",
+              "type": "image"
+            },
+            {
+              "id": 1781023,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/cb77e8e5-73f8-4a18-b340-978d8af2db61/width=450/1781023.jpeg",
+              "nsfwLevel": 2,
+              "width": 4000,
+              "height": 2833,
+              "hash": "URI4w??v_N_NxuoKjsaz-pWBayaz%Mj[jZkC",
+              "type": "image"
+            }
+          ],
+          "downloadUrl": "https://civitai.com/api/download/models/106020"
+        },
+        {
+          "id": 105067,
+          "index": 4,
+          "name": "Skin and Hair Details",
+          "baseModel": "SD 1.5",
+          "baseModelType": "Standard",
+          "publishedAt": "2023-06-27T09:01:06.068Z",
+          "availability": "Public",
+          "nsfwLevel": 3,
+          "description": "<p>SD1.5 only</p>",
+          "trainedWords": ["SkinHairDetail"],
+          "stats": {
+            "downloadCount": 8139,
+            "ratingCount": 32,
+            "rating": 4.53,
+            "thumbsUpCount": 502,
+            "thumbsDownCount": 2
+          },
+          "files": [
+            {
+              "id": 73807,
+              "sizeKB": 66.955078125,
+              "name": "SkinHairDetail.pt",
+              "type": "Model",
+              "pickleScanResult": "Success",
+              "pickleScanMessage": "No Pickle imports",
+              "virusScanResult": "Success",
+              "virusScanMessage": null,
+              "scannedAt": "2023-06-27T11:42:14.317Z",
+              "metadata": {
+                "format": "PickleTensor",
+                "size": null,
+                "fp": null
+              },
+              "hashes": {
+                "AutoV2": "EDF710BF1E",
+                "SHA256": "EDF710BF1EA5E503DB6DC57E91CDFF78F35B7892191F5CE7A4FAB0AEBC09DE39",
+                "CRC32": "FE09E39F",
+                "BLAKE3": "F936921B77A0AE423067E482E5844693C6DC518AE5779A729AA8DF70CE4C2D69"
+              },
+              "downloadUrl": "https://civitai.com/api/download/models/105067",
+              "primary": true
+            }
+          ],
+          "images": [
+            {
+              "id": 1781501,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/e6bb1ba6-578e-4303-8303-e371983f9e86/width=450/1781501.jpeg",
+              "nsfwLevel": 2,
+              "width": 1920,
+              "height": 2394,
+              "hash": "UtJHR5~q?v?bxua}f6ayt7ayWBayxuayayj[",
+              "type": "image"
+            },
+            {
+              "id": 1306531,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/8094a645-6e7c-4bf4-bd6d-19dfcb5c40d1/width=450/1306531.jpeg",
+              "nsfwLevel": 1,
+              "width": 512,
+              "height": 768,
+              "hash": "UDEeoa~VpI57OtbIW=xa?G-oM{niS$IpxZay",
+              "type": "image"
+            },
+            {
+              "id": 1306530,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/b58ed6ae-0731-4852-886b-6e5441d0bd63/width=450/1306530.jpeg",
+              "nsfwLevel": 1,
+              "width": 512,
+              "height": 768,
+              "hash": "UOF=gj~q~Vj=-Tt7f+kWjE%Mxuxu9ZE1V@Rj",
+              "type": "image"
+            },
+            {
+              "id": 1306532,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/465ce59a-cc37-47cf-84e1-af96a22086c2/width=450/1306532.jpeg",
+              "nsfwLevel": 1,
+              "width": 512,
+              "height": 768,
+              "hash": "UaGa:,~W%MkXxuxutRt7oft6jZjZR+a}oLR*",
+              "type": "image"
+            },
+            {
+              "id": 1306533,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/bd548650-d555-4432-9f6e-d19630deb26f/width=450/1306533.jpeg",
+              "nsfwLevel": 1,
+              "width": 512,
+              "height": 768,
+              "hash": "UQH2Zh~q~qIUj[WBof%MM{%Mxu%MD%IURjM{",
+              "type": "image"
+            },
+            {
+              "id": 1306663,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/fee4e6c4-85ad-4955-8e85-cd9fee21e295/width=450/1306663.jpeg",
+              "nsfwLevel": 1,
+              "width": 512,
+              "height": 768,
+              "hash": "UAC$WJ~p0ME1Dj0L9Zt7Fx-:~B%10LM{$*R*",
+              "type": "image"
+            },
+            {
+              "id": 1306667,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/5794765a-9406-4a60-81df-35ae471972eb/width=450/1306667.jpeg",
+              "nsfwLevel": 1,
+              "width": 512,
+              "height": 768,
+              "hash": "UBDIam9Z01~V9uNHxZ%L%fs,VtW;9Zt7xaIp",
+              "type": "image"
+            }
+          ],
+          "downloadUrl": "https://civitai.com/api/download/models/105067"
+        },
+        {
+          "id": 105075,
+          "index": 5,
+          "name": "Skin Detail Negative",
+          "baseModel": "SD 1.5",
+          "baseModelType": "Standard",
+          "publishedAt": "2023-06-27T09:08:35.890Z",
+          "availability": "Public",
+          "nsfwLevel": 1,
+          "description": null,
+          "trainedWords": ["SkinDetailNeg"],
+          "stats": {
+            "downloadCount": 4731,
+            "ratingCount": 78,
+            "rating": 4.97,
+            "thumbsUpCount": 168,
+            "thumbsDownCount": 0
+          },
+          "files": [
+            {
+              "id": 73816,
+              "sizeKB": 24.955078125,
+              "name": "SkinDetailNeg-neg.pt",
+              "type": "Negative",
+              "pickleScanResult": "Success",
+              "pickleScanMessage": "No Pickle imports",
+              "virusScanResult": "Success",
+              "virusScanMessage": null,
+              "scannedAt": "2023-06-27T11:16:02.237Z",
+              "metadata": {
+                "format": "Other",
+                "size": null,
+                "fp": null
+              },
+              "hashes": {
+                "AutoV2": "5F5132A47F",
+                "SHA256": "5F5132A47F7EE6197ED01B9DA36DAAB84449BE9A42D1C32D774F6444C8FD2222",
+                "CRC32": "5D9EF060",
+                "BLAKE3": "83FF1BBCC5BF2888ACD17A7176EC36A16DE2F496A6F6C4E10D36F3359B86B5CC"
+              },
+              "downloadUrl": "https://civitai.com/api/download/models/105075",
+              "primary": true
+            }
+          ],
+          "images": [
+            {
+              "id": 1306620,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/7e1b238d-5cff-47fb-a1ac-a3e94a9e7d34/width=450/1306620.jpeg",
+              "nsfwLevel": 1,
+              "width": 512,
+              "height": 768,
+              "hash": "UDEeoa~VpI57OtbIW=xa?G-oM{niS$IpxZay",
+              "type": "image"
+            }
+          ],
+          "downloadUrl": "https://civitai.com/api/download/models/105075"
+        },
+        {
+          "id": 105072,
+          "index": 6,
+          "name": "Just Skin Detail",
+          "baseModel": "SD 1.5",
+          "baseModelType": "Standard",
+          "publishedAt": "2023-06-27T09:03:39.962Z",
+          "availability": "Public",
+          "nsfwLevel": 2,
+          "description": "<p>Just the skin detail part. Add \"skin markings\" to your negative if you get scars or strange artefacts on the skin.</p>",
+          "trainedWords": ["SkinDetail"],
+          "stats": {
+            "downloadCount": 4018,
+            "ratingCount": 14,
+            "rating": 4.64,
+            "thumbsUpCount": 94,
+            "thumbsDownCount": 0
+          },
+          "files": [
+            {
+              "id": 73812,
+              "sizeKB": 42.955078125,
+              "name": "SkinDetail.pt",
+              "type": "Model",
+              "pickleScanResult": "Success",
+              "pickleScanMessage": "No Pickle imports",
+              "virusScanResult": "Success",
+              "virusScanMessage": null,
+              "scannedAt": "2023-06-27T11:15:32.973Z",
+              "metadata": {
+                "format": "PickleTensor",
+                "size": null,
+                "fp": null
+              },
+              "hashes": {
+                "AutoV2": "3848D7747C",
+                "SHA256": "3848D7747C048E78BC0DAFFB3DC28DE39ED0C8959B395C4709D62C0E7FE5369F",
+                "CRC32": "C7018617",
+                "BLAKE3": "DC20BB474A4E593D06245DC3E7967F17B463BEF67CDDF60F147EDF890EB5D42E"
+              },
+              "downloadUrl": "https://civitai.com/api/download/models/105072",
+              "primary": true
+            }
+          ],
+          "images": [
+            {
+              "id": 1324106,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/35ae58dc-b7c9-4f18-b763-3bb39664bc13/width=450/1324106.jpeg",
+              "nsfwLevel": 2,
+              "width": 512,
+              "height": 768,
+              "hash": "U6Dbf=00xuAa~W4:EL-o00x[My%1I;-o-BxZ",
+              "type": "image"
+            },
+            {
+              "id": 1782089,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/0afb0fc4-4dd0-45fd-bc73-e5d2f5ac5dc8/width=450/1782089.jpeg",
+              "nsfwLevel": 2,
+              "width": 1920,
+              "height": 2394,
+              "hash": "UtJHR5~q?v?bxua}f6ayt7ayWBayxuayayj[",
+              "type": "image"
+            }
+          ],
+          "downloadUrl": "https://civitai.com/api/download/models/105072"
+        },
+        {
+          "id": 106002,
+          "index": 7,
+          "name": "Just Hair Detail",
+          "baseModel": "SD 1.5",
+          "baseModelType": "Standard",
+          "publishedAt": "2023-06-28T17:14:14.661Z",
+          "availability": "Public",
+          "nsfwLevel": 1,
+          "description": "<p>Just adds detail to the hair</p>",
+          "trainedWords": ["HairDetail"],
+          "stats": {
+            "downloadCount": 3358,
+            "ratingCount": 15,
+            "rating": 4.8,
+            "thumbsUpCount": 81,
+            "thumbsDownCount": 1
+          },
+          "files": [
+            {
+              "id": 74575,
+              "sizeKB": 9.955078125,
+              "name": "HairDetail.pt",
+              "type": "Model",
+              "pickleScanResult": "Success",
+              "pickleScanMessage": "No Pickle imports",
+              "virusScanResult": "Success",
+              "virusScanMessage": null,
+              "scannedAt": "2023-06-28T17:13:34.904Z",
+              "metadata": {
+                "format": "PickleTensor",
+                "size": null,
+                "fp": null
+              },
+              "hashes": {
+                "AutoV2": "CC42FB8CF9",
+                "SHA256": "CC42FB8CF919DB02B59DF27B979336597A2CF4ADBCB94281167C2ACFECFE4624",
+                "CRC32": "9CE20ED8",
+                "BLAKE3": "64C646779602903C80A4FE5E398ACF16CB4385FCB56CED072E98B20E52B753A9"
+              },
+              "downloadUrl": "https://civitai.com/api/download/models/106002",
+              "primary": true
+            }
+          ],
+          "images": [
+            {
+              "id": 1324050,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/b0f092e2-6a58-4557-a710-d2065e07971a/width=450/1324050.jpeg",
+              "nsfwLevel": 1,
+              "width": 512,
+              "height": 768,
+              "hash": "U9C$1L020f~C-pIpEL?G02^j$+Io4:t7^jE2",
+              "type": "image"
+            }
+          ],
+          "downloadUrl": "https://civitai.com/api/download/models/106002"
+        },
+        {
+          "id": 125020,
+          "index": 8,
+          "name": "Eye Detail",
+          "baseModel": "SD 1.5",
+          "baseModelType": "Standard",
+          "publishedAt": "2023-07-24T17:41:25.848Z",
+          "availability": "Public",
+          "nsfwLevel": 3,
+          "description": "<p>Adds more detail to the eye like a shine and spark, also whitens the eye ball a bit. Works independent of eye colors. Might reduce slight bleeding of eye color. Without any prompt on the eye, it produces unnatural glowing eyes, be aware.</p>",
+          "trainedWords": ["EyeDetail"],
+          "stats": {
+            "downloadCount": 4670,
+            "ratingCount": 26,
+            "rating": 4.85,
+            "thumbsUpCount": 198,
+            "thumbsDownCount": 1
+          },
+          "files": [
+            {
+              "id": 90263,
+              "sizeKB": 24.955078125,
+              "name": "EyeDetail.pt",
+              "type": "Model",
+              "pickleScanResult": "Success",
+              "pickleScanMessage": "No Pickle imports",
+              "virusScanResult": "Success",
+              "virusScanMessage": null,
+              "scannedAt": "2023-07-24T17:40:43.465Z",
+              "metadata": {
+                "format": "PickleTensor",
+                "size": null,
+                "fp": null
+              },
+              "hashes": {
+                "AutoV2": "C4458C9A3A",
+                "SHA256": "C4458C9A3A7EEAEE638117450AD04751D478B956FB39C59A9666E5E06840C1BF",
+                "CRC32": "386D2B14",
+                "BLAKE3": "94C9FF2F7B20340F8E979E27D5B1BD4918B551DD0E767C9498A59C4F4DAC2FF6"
+              },
+              "downloadUrl": "https://civitai.com/api/download/models/125020",
+              "primary": true
+            }
+          ],
+          "images": [
+            {
+              "id": 1705516,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/61bbeeef-8348-4311-aa36-95a35c92f157/width=450/1705516.jpeg",
+              "nsfwLevel": 1,
+              "width": 768,
+              "height": 1024,
+              "hash": "UaHw}o~WIoIV-pog9aM{X8bGs.RjIpRjM|Rk",
+              "type": "image"
+            },
+            {
+              "id": 1705515,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/450d6a77-a450-4fbc-9bee-554e4c7461fd/width=450/1705515.jpeg",
+              "nsfwLevel": 2,
+              "width": 768,
+              "height": 1024,
+              "hash": "U7Hw}n^+00E1D~My00Rk1NW;#8s:~qt74:WC",
+              "type": "image"
+            },
+            {
+              "id": 1705512,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/325a3fb2-4f60-49ea-8756-35c7f0874eb6/width=450/1705512.jpeg",
+              "nsfwLevel": 1,
+              "width": 768,
+              "height": 1024,
+              "hash": "UPIECM~V%M-o^+xaD%oI9ZRiR5M{NbR*xaof",
+              "type": "image"
+            },
+            {
+              "id": 1705513,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/535cc2ec-a4b3-4eed-a49a-45a00a454db4/width=450/1705513.jpeg",
+              "nsfwLevel": 2,
+              "width": 768,
+              "height": 1024,
+              "hash": "U8H1Vs~q0000~W^*0K-5019Z={-:R%NGMx-o",
+              "type": "image"
+            },
+            {
+              "id": 1705514,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/6678a312-67e7-4a09-b28d-34cc3b55e619/width=450/1705514.jpeg",
+              "nsfwLevel": 1,
+              "width": 768,
+              "height": 1024,
+              "hash": "UIIXNz~pxtD%-;%L0LRO9u%2aKxZ9ZIVjFWX",
+              "type": "image"
+            }
+          ],
+          "downloadUrl": "https://civitai.com/api/download/models/125020"
+        },
+        {
+          "id": 125032,
+          "index": 9,
+          "name": "Hand Negative",
+          "baseModel": "SD 1.5",
+          "baseModelType": "Standard",
+          "publishedAt": "2023-07-24T17:55:27.113Z",
+          "availability": "Public",
+          "nsfwLevel": 6,
+          "description": "<p>Some things for the negative prompt to make hands display less broken, as with all these TIs they just help the negative prompt and not replace the hands.</p>",
+          "trainedWords": ["HandNeg"],
+          "stats": {
+            "downloadCount": 3979,
+            "ratingCount": 658,
+            "rating": 5,
+            "thumbsUpCount": 1343,
+            "thumbsDownCount": 1
+          },
+          "files": [
+            {
+              "id": 90271,
+              "sizeKB": 114.955078125,
+              "name": "HandNeg-neg.pt",
+              "type": "Negative",
+              "pickleScanResult": "Success",
+              "pickleScanMessage": "No Pickle imports",
+              "virusScanResult": "Success",
+              "virusScanMessage": null,
+              "scannedAt": "2023-07-24T17:55:44.551Z",
+              "metadata": {
+                "format": "Other",
+                "size": null,
+                "fp": null
+              },
+              "hashes": {
+                "AutoV2": "19E4447B8F",
+                "SHA256": "19E4447B8FCCCD09D1027152A0E2C1E08C1E3AE9C2935B4F95B07EA9F29B489D",
+                "CRC32": "C9DABAC8",
+                "BLAKE3": "80C792059614AB05620732DC89C03D8D7E4BAC704EB4BCB56D8CD02673215716"
+              },
+              "downloadUrl": "https://civitai.com/api/download/models/125032",
+              "primary": true
+            }
+          ],
+          "images": [
+            {
+              "id": 1705655,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/33d36bfe-9d27-4143-b178-eeb27c6f0f09/width=450/1705655.jpeg",
+              "nsfwLevel": 4,
+              "width": 576,
+              "height": 1024,
+              "hash": "U8EUZ34;0L~Bw^NbNtRQ9b9]Ef={9tSh^jRQ",
+              "type": "image"
+            },
+            {
+              "id": 1705653,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/64979e49-02db-429c-bfdc-346346345e55/width=450/1705653.jpeg",
+              "nsfwLevel": 2,
+              "width": 576,
+              "height": 1024,
+              "hash": "UMI;O}~V4.i_tlx[IoRi%MRPMx%1xZs.i_ae",
+              "type": "image"
+            },
+            {
+              "id": 1705654,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/b0cfb477-ee79-43ca-b885-e61c057c9b10/width=450/1705654.jpeg",
+              "nsfwLevel": 4,
+              "width": 576,
+              "height": 1024,
+              "hash": "UCINBbR-00%L0L~BOXM|0fIUxu57KOs:IoR%",
+              "type": "image"
+            }
+          ],
+          "downloadUrl": "https://civitai.com/api/download/models/125032"
+        },
+        {
+          "id": 125014,
+          "index": 10,
+          "name": "Female Face Detail",
+          "baseModel": "SD 1.5",
+          "baseModelType": "Standard",
+          "publishedAt": "2023-07-24T17:34:34.536Z",
+          "availability": "Public",
+          "nsfwLevel": 7,
+          "description": "<p>Adds a bit of detail to the female face like blush and overall facial detail.</p>",
+          "trainedWords": ["fFaceDetail "],
+          "stats": {
+            "downloadCount": 5484,
+            "ratingCount": 23,
+            "rating": 4.78,
+            "thumbsUpCount": 378,
+            "thumbsDownCount": 0
+          },
+          "files": [
+            {
+              "id": 90257,
+              "sizeKB": 51.955078125,
+              "name": "fFaceDetail .pt",
+              "type": "Model",
+              "pickleScanResult": "Success",
+              "pickleScanMessage": "No Pickle imports",
+              "virusScanResult": "Success",
+              "virusScanMessage": null,
+              "scannedAt": "2023-07-24T17:35:40.249Z",
+              "metadata": {
+                "format": "PickleTensor",
+                "size": null,
+                "fp": null
+              },
+              "hashes": {
+                "AutoV2": "CAF6A4231E",
+                "SHA256": "CAF6A4231ECFC363FC720B82EEC9135B09204E8C99FE7CD718C699621404E01C",
+                "CRC32": "0E6107C7",
+                "BLAKE3": "B19D8B0F8E4AD82BC4CA28866A14CA402F60642B436950C885927C738624F9D1"
+              },
+              "downloadUrl": "https://civitai.com/api/download/models/125014",
+              "primary": true
+            }
+          ],
+          "images": [
+            {
+              "id": 1705435,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/5ebd8c46-e899-4d7d-bf56-02c3440f2417/width=450/1705435.jpeg",
+              "nsfwLevel": 1,
+              "width": 768,
+              "height": 1024,
+              "hash": "UCEUoj^jE1xF9uNH0fNH5RI:$*Rk9txZ~BxZ",
+              "type": "image"
+            },
+            {
+              "id": 1705434,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/591a87d1-5e9f-4df7-bcae-d75938a49f82/width=450/1705434.jpeg",
+              "nsfwLevel": 4,
+              "width": 768,
+              "height": 1024,
+              "hash": "U4H^no?G0J~U00E29vX800xu9I01-:%1^*V@",
+              "type": "image"
+            },
+            {
+              "id": 1705438,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/fd2baee0-237d-4db0-bc0e-07f24eca5ae6/width=450/1705438.jpeg",
+              "nsfwLevel": 2,
+              "width": 768,
+              "height": 1024,
+              "hash": "UAINa80001~V4:o|0f%fEkoeIVIpX4%1$*s,",
+              "type": "image"
+            },
+            {
+              "id": 1705436,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/d740ab84-a2a2-4963-a4a6-4b36c6b6334f/width=450/1705436.jpeg",
+              "nsfwLevel": 2,
+              "width": 768,
+              "height": 1024,
+              "hash": "UNINX7~V9ZE1IpNGE2E2NbaxIVsoWBoy-ot6",
+              "type": "image"
+            },
+            {
+              "id": 1705433,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/72689437-b3b3-4d1f-bf7b-5c794be01f1b/width=450/1705433.jpeg",
+              "nsfwLevel": 2,
+              "width": 768,
+              "height": 1024,
+              "hash": "ULH_3@~VE1%29at79tM|E2IVIUM{?aR*n%Rk",
+              "type": "image"
+            },
+            {
+              "id": 1705437,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/10122e16-5da8-4a0b-9a47-ef1fac7117bf/width=450/1705437.jpeg",
+              "nsfwLevel": 2,
+              "width": 768,
+              "height": 1024,
+              "hash": "UEHBe+?a00My?bt7IoRj~pbbxGV@Ndoe^*j[",
+              "type": "image"
+            }
+          ],
+          "downloadUrl": "https://civitai.com/api/download/models/125014"
+        },
+        {
+          "id": 125024,
+          "index": 11,
+          "name": "Female Hand Detail",
+          "baseModel": "SD 1.5",
+          "baseModelType": "Standard",
+          "publishedAt": "2023-07-24T17:50:11.338Z",
+          "availability": "Public",
+          "nsfwLevel": 6,
+          "description": "<p>Smoothes the hand a bit, makes it look more feminine. Adds painted nails. Sometimes the nails freak out, this is not the detailer but the models, most cannot display nails properly or have an issue with painted nails. Use with caution...</p>",
+          "trainedWords": ["fHandDetail"],
+          "stats": {
+            "downloadCount": 3763,
+            "ratingCount": 13,
+            "rating": 4.85,
+            "thumbsUpCount": 146,
+            "thumbsDownCount": 0
+          },
+          "files": [
+            {
+              "id": 90268,
+              "sizeKB": 45.955078125,
+              "name": "fHandDetail.pt",
+              "type": "Model",
+              "pickleScanResult": "Success",
+              "pickleScanMessage": "No Pickle imports",
+              "virusScanResult": "Success",
+              "virusScanMessage": null,
+              "scannedAt": "2023-07-24T17:51:03.278Z",
+              "metadata": {
+                "format": "PickleTensor",
+                "size": null,
+                "fp": null
+              },
+              "hashes": {
+                "AutoV2": "24A5B132A0",
+                "SHA256": "24A5B132A053AB1B905B2DCE6D18321DB45983178EB1F87529C1B02BCE6B023D",
+                "CRC32": "AE3846FB",
+                "BLAKE3": "1520F5DA16639BB1E814D7DAD9A14C08A4F3FF6F1A05851CA973055072F33F9C"
+              },
+              "downloadUrl": "https://civitai.com/api/download/models/125024",
+              "primary": true
+            }
+          ],
+          "images": [
+            {
+              "id": 1705620,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/4071b720-0c71-40e6-91c0-4da9cc050b5a/width=450/1705620.jpeg",
+              "nsfwLevel": 4,
+              "width": 576,
+              "height": 1024,
+              "hash": "UEIqZL%101xu*0Int7NG0LITIUM{4:9Gw]%L",
+              "type": "image"
+            },
+            {
+              "id": 1705622,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/976360f9-da15-45b1-9e7d-15a8ee6c4045/width=450/1705622.jpeg",
+              "nsfwLevel": 4,
+              "width": 576,
+              "height": 1024,
+              "hash": "U8IqJy000059Fy9GR4s;5RI@IU0f~pxa=|M{",
+              "type": "image"
+            },
+            {
+              "id": 1705619,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/80d632f6-0474-454e-966d-69cad07fd254/width=450/1705619.jpeg",
+              "nsfwLevel": 2,
+              "width": 576,
+              "height": 1024,
+              "hash": "UNJaJ_~q0e4.EftRRiIUJooLs8NG%1WBs.V@",
+              "type": "image"
+            }
+          ],
+          "downloadUrl": "https://civitai.com/api/download/models/125024"
+        }
+      ]
+    },
+    {
+      "id": 332646,
+      "name": "Pony PDXL Negative Embeddings",
+      "description": "<p><span style=\"color:rgb(130, 201, 30)\">No need to use score this, and score that. Just use the embeddings instead.</span></p><h3 id=\"be-sure-to-download-both-positive-and-negative-embeddings-and-use-both.-16ow6j0pc\"><span style=\"color:rgb(190, 75, 219)\">Be sure to download both positive and negative embeddings and use both.</span></h3><p>A set of quality enchancing embeddings for Pony SDXL, and other Pony-Adjacent models. You can mix and match any of the embeddings that you feel you need. They don't duplicate each other, so feel free to use as many together as needed.</p><p><strong><span style=\"color:rgb(64, 192, 87)\">High Quality V2:</span></strong><span style=\"color:rgb(64, 192, 87)\"> designed to give higher quality results and remove censoring.</span></p><p><strong><span style=\"color:rgb(64, 192, 87)\">XXX Rating:</span></strong><span style=\"color:rgb(64, 192, 87)\"> tells the Pony model of your choice to allow NSFW content.</span></p><p><strong><span style=\"color:rgb(64, 192, 87)\">PG Rating: </span></strong><span style=\"color:rgb(64, 192, 87)\">tells the Pony model of your choice to try and remove NSFW content for safe images.</span></p><p><strong><span style=\"color:rgb(64, 192, 87)\">Photo Real:</span></strong><span style=\"color:rgb(64, 192, 87)\"> tells the Pony model of your choice to use realistic or near realistic renders instead of cartoon or anime.</span></p><p><span style=\"color:rgb(230, 73, 128)\">Doesn't work with non-Pony models. Check your model.</span></p><p>Recommend using both positive and negative embeddings together at strength 1.0 to 2.0. If you can't use both, the Positive version should be take priority.</p>",
+      "allowNoCredit": true,
+      "allowCommercialUse": ["Image", "RentCivit"],
+      "allowDerivatives": false,
+      "allowDifferentLicense": true,
+      "type": "TextualInversion",
+      "minor": false,
+      "poi": false,
+      "nsfw": false,
+      "nsfwLevel": 7,
+      "cosmetic": null,
+      "stats": {
+        "downloadCount": 76612,
+        "favoriteCount": 0,
+        "thumbsUpCount": 4021,
+        "thumbsDownCount": 12,
+        "commentCount": 67,
+        "ratingCount": 0,
+        "rating": 0,
+        "tippedAmountCount": 1733
+      },
+      "creator": {
+        "username": "Zovya",
+        "image": "https://avatars.githubusercontent.com/u/110301217?v=4"
+      },
+      "tags": ["negative embedding", "tool", "quality up"],
+      "modelVersions": [
+        {
+          "id": 509253,
+          "index": 0,
+          "name": "High Quality V2",
+          "baseModel": "Pony",
+          "baseModelType": null,
+          "publishedAt": "2024-05-18T03:16:58.213Z",
+          "availability": "Public",
+          "nsfwLevel": 1,
+          "description": null,
+          "trainedWords": ["zPDXL2"],
+          "stats": {
+            "downloadCount": 19241,
+            "ratingCount": 0,
+            "rating": 0,
+            "thumbsUpCount": 1509,
+            "thumbsDownCount": 2
+          },
+          "files": [
+            {
+              "id": 430909,
+              "sizeKB": 240.1484375,
+              "name": "zPDXL2-neg.safetensors",
+              "type": "Negative",
+              "pickleScanResult": "Success",
+              "pickleScanMessage": "No Pickle imports",
+              "virusScanResult": "Success",
+              "virusScanMessage": null,
+              "scannedAt": "2024-05-18T03:21:21.733Z",
+              "metadata": {
+                "format": "Other",
+                "size": null,
+                "fp": null
+              },
+              "hashes": {
+                "AutoV2": "29DC1B9B1A",
+                "SHA256": "29DC1B9B1A2BBB10188F58062D2BE2EA95FE76B9549C1FA29597FFB947DFD4B4",
+                "CRC32": "F9811D92",
+                "BLAKE3": "589597E1BF5331D62E5CC9CD61D8CA91B9A9242FE2A3A64FEEF5CBFFBADA2326",
+                "AutoV3": "0C7BAC45D5C0"
+              },
+              "downloadUrl": "https://civitai.com/api/download/models/509253?type=Negative&format=Other"
+            },
+            {
+              "id": 426621,
+              "sizeKB": 336.1484375,
+              "name": "zPDXL2.safetensors",
+              "type": "Model",
+              "pickleScanResult": "Success",
+              "pickleScanMessage": "No Pickle imports",
+              "virusScanResult": "Success",
+              "virusScanMessage": null,
+              "scannedAt": "2024-05-16T00:55:37.160Z",
+              "metadata": {
+                "format": "SafeTensor",
+                "size": null,
+                "fp": null
+              },
+              "hashes": {
+                "AutoV2": "649C47827D",
+                "SHA256": "649C47827D599E2DDAB50769BD6880A3DE92B092FD6EDB2D7D1D387525920DCB",
+                "CRC32": "5310ABC6",
+                "BLAKE3": "21B53B96F8E8A1D512A33B5887591F6AF65E8D14A27D1B22D9B0263E93A7E58E",
+                "AutoV3": "3E7B0875E3E5"
+              },
+              "downloadUrl": "https://civitai.com/api/download/models/509253",
+              "primary": true
+            }
+          ],
+          "images": [
+            {
+              "id": 12596957,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/97bcc174-b1c3-4daf-b2c9-8c4cf2ca7808/width=450/12596957.jpeg",
+              "nsfwLevel": 1,
+              "width": 1152,
+              "height": 1728,
+              "hash": "UGD+}4?GQ,?G~pNI9FxDyDWWIUxZcFM{Q-tR",
+              "type": "image"
+            },
+            {
+              "id": 12596819,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/e5f723f4-ab96-49e1-a070-3ccb5bbe4ce0/width=450/12596819.jpeg",
+              "nsfwLevel": 1,
+              "width": 1152,
+              "height": 1728,
+              "hash": "UZFiDpIo.AxbbdW?NMo#R5NGRQWCoMaJaybc",
+              "type": "image"
+            },
+            {
+              "id": 12596822,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/6f309211-2d29-40ae-b2ce-221eb764a812/width=450/12596822.jpeg",
+              "nsfwLevel": 1,
+              "width": 1152,
+              "height": 1728,
+              "hash": "UCE.Lj9w01?Z?ZIVD+-:~RIq4p%M_2S4E4%L",
+              "type": "image"
+            },
+            {
+              "id": 12596821,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/194d07bd-b904-4965-bebe-b93349ad8ff3/width=450/12596821.jpeg",
+              "nsfwLevel": 1,
+              "width": 1152,
+              "height": 1728,
+              "hash": "UBE-{|-UrD$~}I-URkNI01t7J8E3KKJAxwxZ",
+              "type": "image"
+            },
+            {
+              "id": 12596820,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/578cba43-f4f6-4817-a20b-f48c7809d68d/width=450/12596820.jpeg",
+              "nsfwLevel": 1,
+              "width": 1152,
+              "height": 1728,
+              "hash": "UA6SQ[tSO*K7t:j?RMg59$ROUuxaQ*VXwIt7",
+              "type": "image"
+            }
+          ],
+          "downloadUrl": "https://civitai.com/api/download/models/509253"
+        },
+        {
+          "id": 482268,
+          "index": 1,
+          "name": "Photo Real",
+          "baseModel": "Pony",
+          "baseModelType": null,
+          "publishedAt": "2024-05-03T01:02:20.162Z",
+          "availability": "Public",
+          "nsfwLevel": 1,
+          "description": null,
+          "trainedWords": ["zPDXLrl"],
+          "stats": {
+            "downloadCount": 9514,
+            "ratingCount": 0,
+            "rating": 0,
+            "thumbsUpCount": 450,
+            "thumbsDownCount": 1
+          },
+          "files": [
+            {
+              "id": 400572,
+              "sizeKB": 73.0537109375,
+              "name": "zPDXLrl-neg.pt",
+              "type": "Negative",
+              "pickleScanResult": "Success",
+              "pickleScanMessage": "No Pickle imports",
+              "virusScanResult": "Success",
+              "virusScanMessage": null,
+              "scannedAt": "2024-05-03T01:00:52.716Z",
+              "metadata": {
+                "format": "Other",
+                "size": null,
+                "fp": null
+              },
+              "hashes": {
+                "AutoV2": "CC5B7CA272",
+                "SHA256": "CC5B7CA272EAFEDAB7A31BE3FC105F5142CED601BF780BA1F0FC532DBF00453B",
+                "CRC32": "EF78F611",
+                "BLAKE3": "F4E6C491D10206D8179B57AF9CB53858AF3BCFD75F35E163216F24697FCABFD9"
+              },
+              "downloadUrl": "https://civitai.com/api/download/models/482268?type=Negative&format=Other"
+            },
+            {
+              "id": 400571,
+              "sizeKB": 56.9755859375,
+              "name": "zPDXLrl.pt",
+              "type": "Model",
+              "pickleScanResult": "Success",
+              "pickleScanMessage": "No Pickle imports",
+              "virusScanResult": "Success",
+              "virusScanMessage": null,
+              "scannedAt": "2024-05-03T01:01:23.850Z",
+              "metadata": {
+                "format": "PickleTensor",
+                "size": null,
+                "fp": null
+              },
+              "hashes": {
+                "AutoV2": "ADF282AFB2",
+                "SHA256": "ADF282AFB238107532E5502495771F0E19B18CB5F7A23846EE96206ABEFE571B",
+                "CRC32": "A07E45B8",
+                "BLAKE3": "B211E4D3B7848F8FA17392EAC5DD7C2E718AD0E1FEFE7FFDEDC6A9A2D2F0954D"
+              },
+              "downloadUrl": "https://civitai.com/api/download/models/482268",
+              "primary": true
+            }
+          ],
+          "images": [
+            {
+              "id": 11384342,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/667cdd5e-33ab-422c-8307-524127e4d7a9/width=450/11384342.jpeg",
+              "nsfwLevel": 1,
+              "width": 1112,
+              "height": 1664,
+              "hash": "UFI43Kk956xZ0JSe-;r@b{kB-B$P{#S}rY$P",
+              "type": "image"
+            },
+            {
+              "id": 11384338,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/cb22e364-ce93-4cef-bcd9-4313cddba8cf/width=450/11384338.jpeg",
+              "nsfwLevel": 1,
+              "width": 1112,
+              "height": 1664,
+              "hash": "UND,f-%%8wRPJET1xFRP9Zafx^xvV?s-X8bw",
+              "type": "image"
+            },
+            {
+              "id": 11384344,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/3d840be2-ca02-4ff8-9888-aa53189d3cf4/width=450/11384344.jpeg",
+              "nsfwLevel": 1,
+              "width": 1112,
+              "height": 1664,
+              "hash": "UKIh1}~W004T^+RjM|IUK8o0M{Nt%MV@t8oz",
+              "type": "image"
+            },
+            {
+              "id": 11384345,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/ccfb90e3-a29e-4548-8e13-0f30398dd6ed/width=450/11384345.jpeg",
+              "nsfwLevel": 1,
+              "width": 768,
+              "height": 1152,
+              "hash": "USHVPI?b%N%g_4IUNGxv%haet6tR%g%2s:tR",
+              "type": "image"
+            },
+            {
+              "id": 11384340,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/3f2e53a2-7e17-4093-b8ae-447fc3647859/width=450/11384340.jpeg",
+              "nsfwLevel": 1,
+              "width": 768,
+              "height": 1152,
+              "hash": "UKIz@*?wS$=dvM$*x]xao#?HR*Ipx[I;s.n$",
+              "type": "image"
+            },
+            {
+              "id": 11384343,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/13525dd8-2d8b-4570-b095-d548e02e686c/width=450/11384343.jpeg",
+              "nsfwLevel": 1,
+              "width": 1112,
+              "height": 1664,
+              "hash": "U9Dkrp0z2anN0#w{icxZ00=|$fkW~BSN%MNH",
+              "type": "image"
+            }
+          ],
+          "downloadUrl": "https://civitai.com/api/download/models/482268"
+        },
+        {
+          "id": 380277,
+          "index": 2,
+          "name": "XXX Rating",
+          "baseModel": "Pony",
+          "baseModelType": null,
+          "publishedAt": "2024-03-08T01:54:07.607Z",
+          "availability": "Public",
+          "nsfwLevel": 4,
+          "description": null,
+          "trainedWords": ["zPDXLxxx"],
+          "stats": {
+            "downloadCount": 18472,
+            "ratingCount": 0,
+            "rating": 0,
+            "thumbsUpCount": 1255,
+            "thumbsDownCount": 4
+          },
+          "files": [
+            {
+              "id": 304994,
+              "sizeKB": 33.0419921875,
+              "name": "zPDXLxxx.pt",
+              "type": "Model",
+              "pickleScanResult": "Success",
+              "pickleScanMessage": "No Pickle imports",
+              "virusScanResult": "Success",
+              "virusScanMessage": null,
+              "scannedAt": "2024-03-08T01:50:51.478Z",
+              "metadata": {
+                "format": "PickleTensor",
+                "size": null,
+                "fp": null
+              },
+              "hashes": {
+                "AutoV2": "000E2B1616",
+                "SHA256": "000E2B1616E99B089FED906202F102686D57331C2503D4A1E36753B98622FA73",
+                "CRC32": "3B0D8E7D",
+                "BLAKE3": "B153A47E7FABB3BA1425C528803B18E6109992E41038EB721EA709E3B6DC7D28"
+              },
+              "downloadUrl": "https://civitai.com/api/download/models/380277",
+              "primary": true
+            },
+            {
+              "id": 304995,
+              "sizeKB": 33.0576171875,
+              "name": "zPDXLxxx-neg.pt",
+              "type": "Negative",
+              "pickleScanResult": "Success",
+              "pickleScanMessage": "No Pickle imports",
+              "virusScanResult": "Success",
+              "virusScanMessage": null,
+              "scannedAt": "2024-03-08T01:50:54.962Z",
+              "metadata": {
+                "format": "Other",
+                "size": null,
+                "fp": null
+              },
+              "hashes": {
+                "AutoV2": "C01180E3BC",
+                "SHA256": "C01180E3BCC5B645BDAD5AA9091D290417AC9CBC4BC48121FA911D19C5CAD7C2",
+                "CRC32": "696DB7B7",
+                "BLAKE3": "17CEBDE19F2A68D75606DB6D4E86180BE7386D2D0D7411B831BA0C058086D393"
+              },
+              "downloadUrl": "https://civitai.com/api/download/models/380277?type=Negative&format=Other"
+            }
+          ],
+          "images": [
+            {
+              "id": 7603310,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/1d7adf5d-ce34-476e-93e0-527d765faa8f/width=450/7603310.jpeg",
+              "nsfwLevel": 4,
+              "width": 1072,
+              "height": 1608,
+              "hash": "UJEo+19c_3xuPE%3ERr=^-4:s8wbAK9FS$IA",
+              "type": "image"
+            }
+          ],
+          "downloadUrl": "https://civitai.com/api/download/models/380277"
+        },
+        {
+          "id": 380285,
+          "index": 3,
+          "name": "PG Rating",
+          "baseModel": "Pony",
+          "baseModelType": null,
+          "publishedAt": "2024-03-08T01:56:45.469Z",
+          "availability": "Public",
+          "nsfwLevel": 1,
+          "description": null,
+          "trainedWords": ["zPDXLpg"],
+          "stats": {
+            "downloadCount": 5210,
+            "ratingCount": 0,
+            "rating": 0,
+            "thumbsUpCount": 275,
+            "thumbsDownCount": 0
+          },
+          "files": [
+            {
+              "id": 305005,
+              "sizeKB": 56.9755859375,
+              "name": "zPDXLpg.pt",
+              "type": "Model",
+              "pickleScanResult": "Success",
+              "pickleScanMessage": "No Pickle imports",
+              "virusScanResult": "Success",
+              "virusScanMessage": null,
+              "scannedAt": "2024-03-08T02:00:46.347Z",
+              "metadata": {
+                "format": "PickleTensor",
+                "size": null,
+                "fp": null
+              },
+              "hashes": {
+                "AutoV2": "7EF60EDA2D",
+                "SHA256": "7EF60EDA2D53693A56ADF982CF2F43890E3D292F8782C0981C5421002375E73D",
+                "CRC32": "C6B6617C",
+                "BLAKE3": "4CF1EAF71F527EE609EC1CC99787506E0393C140E8B6E8EDD99BEE47091FE4B4"
+              },
+              "downloadUrl": "https://civitai.com/api/download/models/380285",
+              "primary": true
+            },
+            {
+              "id": 305006,
+              "sizeKB": 121.0537109375,
+              "name": "zPDXLpg-neg.pt",
+              "type": "Negative",
+              "pickleScanResult": "Success",
+              "pickleScanMessage": "No Pickle imports",
+              "virusScanResult": "Success",
+              "virusScanMessage": null,
+              "scannedAt": "2024-03-08T02:00:51.522Z",
+              "metadata": {
+                "format": "Other",
+                "size": null,
+                "fp": null
+              },
+              "hashes": {
+                "AutoV2": "AE62180C86",
+                "SHA256": "AE62180C866B39C3C141C049471F9681EC37ABD0251ECA7A8F56F9DC0D174C87",
+                "CRC32": "F509FBD2",
+                "BLAKE3": "AD3FF56BDB9C0B1CB617B910C055BDE363C6B2592A461A19501DFCF7E23E6595"
+              },
+              "downloadUrl": "https://civitai.com/api/download/models/380285?type=Negative&format=Other"
+            }
+          ],
+          "images": [
+            {
+              "id": 7603417,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/bb3e1f28-83d7-4824-9eb1-877a809e8170/width=450/7603417.jpeg",
+              "nsfwLevel": 1,
+              "width": 1072,
+              "height": 1608,
+              "hash": "UDI4bN02.jIA^$9G%g575-v#t9K5-V9YPAkV",
+              "type": "image"
+            },
+            {
+              "id": 7603418,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/6668df84-363b-4dc2-8e2b-53da98f71cc4/width=450/7603418.jpeg",
+              "nsfwLevel": 1,
+              "width": 1072,
+              "height": 1608,
+              "hash": "UTIX?XMI%hAEt:JONe$kIAE2n4s7Mdadt1Vt",
+              "type": "image"
+            },
+            {
+              "id": 7603416,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/6106bb2f-4911-44dd-9a58-4f1759904029/width=450/7603416.jpeg",
+              "nsfwLevel": 1,
+              "width": 1072,
+              "height": 1608,
+              "hash": "UbIq*^xZI:tR_KofRkbF?XbcMznhEeW;ruaK",
+              "type": "image"
+            }
+          ],
+          "downloadUrl": "https://civitai.com/api/download/models/380285"
+        },
+        {
+          "id": 372656,
+          "index": 4,
+          "name": "High Quality",
+          "baseModel": "Pony",
+          "baseModelType": null,
+          "publishedAt": "2024-03-03T19:20:23.177Z",
+          "availability": "Public",
+          "nsfwLevel": 7,
+          "description": null,
+          "trainedWords": ["zPDXL"],
+          "stats": {
+            "downloadCount": 24175,
+            "ratingCount": 111,
+            "rating": 4.99,
+            "thumbsUpCount": 2349,
+            "thumbsDownCount": 6
+          },
+          "files": [
+            {
+              "id": 298494,
+              "sizeKB": 153.0458984375,
+              "name": "zPDXL-neg.pt",
+              "type": "Negative",
+              "pickleScanResult": "Success",
+              "pickleScanMessage": "No Pickle imports",
+              "virusScanResult": "Success",
+              "virusScanMessage": null,
+              "scannedAt": "2024-03-03T19:20:54.813Z",
+              "metadata": {
+                "format": "Other",
+                "size": null,
+                "fp": null
+              },
+              "hashes": {
+                "AutoV2": "31A5DA9018",
+                "SHA256": "31A5DA9018B9998DD52C9FE96A430961FA6AC978E14A96794C05401D8B4E7F9C",
+                "CRC32": "A1302E3F",
+                "BLAKE3": "BE0E58392A3A2438AC88A1BEFD161DB6C68A699E99FBD7DA5FF2C8C577C757EA"
+              },
+              "downloadUrl": "https://civitai.com/api/download/models/372656?type=Negative&format=Other"
+            },
+            {
+              "id": 298493,
+              "sizeKB": 136.8427734375,
+              "name": "zPDXL.pt",
+              "type": "Model",
+              "pickleScanResult": "Success",
+              "pickleScanMessage": "No Pickle imports",
+              "virusScanResult": "Success",
+              "virusScanMessage": null,
+              "scannedAt": "2024-03-03T19:20:49.945Z",
+              "metadata": {
+                "format": "PickleTensor",
+                "size": null,
+                "fp": null
+              },
+              "hashes": {
+                "AutoV2": "C1FCF5EEF4",
+                "SHA256": "C1FCF5EEF4149D82003EC2B7CC5080C8D80FB6BD9AC370B3EF7A26D8A688790D",
+                "CRC32": "25C7DC9C",
+                "BLAKE3": "D622CCD6014BFCBBEC0F7F888A907955EC4ACB240145B8E76FC8BBC434AB2BDC"
+              },
+              "downloadUrl": "https://civitai.com/api/download/models/372656",
+              "primary": true
+            }
+          ],
+          "images": [
+            {
+              "id": 7407484,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/1ce094ee-9738-4eaa-88aa-9fe3f9d0374d/width=450/7407484.jpeg",
+              "nsfwLevel": 2,
+              "width": 1072,
+              "height": 1608,
+              "hash": "UJGu:li_4T~prxfOJQRP%gM|NFxtT0s,Q-NG",
+              "type": "image"
+            },
+            {
+              "id": 7407488,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/acb81fab-d6c0-4620-b5d8-efa6f324aabc/width=450/7407488.jpeg",
+              "nsfwLevel": 1,
+              "width": 1072,
+              "height": 1608,
+              "hash": "UIDJr4?IxvNG%j%NNaIoJ-RjD$S$$*adnfXS",
+              "type": "image"
+            },
+            {
+              "id": 7407486,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/aa0aea2f-5920-49a3-b358-ce129cf6591f/width=450/7407486.jpeg",
+              "nsfwLevel": 4,
+              "width": 1072,
+              "height": 1608,
+              "hash": "UQIE*3OD%#m-pyE1ozRj9aMwR6o~$iiwniX9",
+              "type": "image"
+            },
+            {
+              "id": 7407487,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/d57390d4-38c5-48bb-bbb3-dc3be0e2ff18/width=450/7407487.jpeg",
+              "nsfwLevel": 1,
+              "width": 1072,
+              "height": 1608,
+              "hash": "ULFi6}X99FV@_Mx[M{MytlR*IVoLO@V@n4o|",
+              "type": "image"
+            },
+            {
+              "id": 7407489,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/9730bdf3-b1a8-4d6a-b412-24a013807abe/width=450/7407489.jpeg",
+              "nsfwLevel": 2,
+              "width": 1072,
+              "height": 1608,
+              "hash": "U8Gup]bK00%0Yis,9MNG=mIVEU%Ky?s:4TIV",
+              "type": "image"
+            },
+            {
+              "id": 7407483,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/d1152e18-5476-4a49-806e-6c8c4e332533/width=450/7407483.jpeg",
+              "nsfwLevel": 1,
+              "width": 1072,
+              "height": 1608,
+              "hash": "UJJje*0MIV%M_4R*r?XS03-mxZag0+skR+Vu",
+              "type": "image"
+            },
+            {
+              "id": 7407485,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/8de9856d-795b-40e8-a812-5b75236aba82/width=450/7407485.jpeg",
+              "nsfwLevel": 2,
+              "width": 1072,
+              "height": 1608,
+              "hash": "ULH21CK6oL-n_Lo#$jNG4;%eNuRQ5r%fWBM|",
+              "type": "image"
+            },
+            {
+              "id": 7407490,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/2964c2d4-292f-4ad4-8315-a7585293e6da/width=450/7407490.jpeg",
+              "nsfwLevel": 4,
+              "width": 1072,
+              "height": 1608,
+              "hash": "UQIOOqOD%#m-pyE1ozRj9aMwR6o~xFiwniX9",
+              "type": "image"
+            }
+          ],
+          "downloadUrl": "https://civitai.com/api/download/models/372656"
+        }
+      ]
+    },
+    {
+      "id": 50755,
+      "name": "Style Asian Less",
+      "description": "<p>This tool doesn't specifically race-swap asian to white-caucasian, it just removes asian so your prompts can be more effective with whatever other race or culture you're trying to portray. This is due mostly to heavy training that doesn't tag race or culture.</p><p></p><p><span style=\"color:rgb(253, 126, 20)\">Follow me to make sure you see new tools like this, or new </span><a target=\"_blank\" rel=\"ugc\" href=\"https://civitai.com/tag/zstyle\"><strong><span style=\"color:rgb(76, 110, 245)\">styles</span></strong></a><strong><span style=\"color:rgb(76, 110, 245)\">, </span></strong><a target=\"_blank\" rel=\"ugc\" href=\"https://civitai.com/tag/zpose\"><strong><span style=\"color:rgb(76, 110, 245)\">poses</span></strong></a><span style=\"color:rgb(76, 110, 245)\"> </span><span style=\"color:rgb(253, 126, 20)\">and</span><span style=\"color:rgb(76, 110, 245)\"> </span><a target=\"_blank\" rel=\"ugc\" href=\"https://civitai.com/tag/znobody\"><strong><span style=\"color:rgb(76, 110, 245)\">Nobodys</span></strong></a><span style=\"color:rgb(253, 126, 20)\"> when I post them. More Clutter series coming too. Things move fast on this site, it's easy to miss.</span><br /><br />Most of the recent, good, training has been using anime and models trained on asian people and it's culture. Nothing wrong with that, it's great that the community and fine-tunning continues to grow. But those models are mixed in with almost everything now (and because race or culture wasn't specifically tagged) sometimes it might be difficult to get results that don't have asian or anime influence. This embedding aims to assist with that. It can even change anime characters (though that wasn't the intended purpose).</p><p>I first created this when trying to make preview images for my <a target=\"_blank\" rel=\"ugc\" href=\"https://civitai.com/models/25749/south-of-the-border-style\">South of the Border</a> Style embedding. I was trying to get south american people and culture, but there was a lot of asian culture leaking into the generated images. This embedding fixed that. So it doesn't specifically race-swap asian to white-caucasian, it just removes asian so your prompts can be more effective with whatever other race or culture you're trying to portray.</p><p>How to use:<br />Use the negative prompt primarily, then use the positive prompts only if you need the additional help. There are 3 files to download.</p><ul><li><p><strong>Asian-Less2-Neg:</strong> Use this one, place in your negative prompt at strength of 1.0 (more updated embedding to account for more modern models)</p></li><li><p><strong>Asian-Less-Neg:</strong> Use this one, place in your negative prompt at strength of 1.0</p></li><li><p><strong>Asian-Less:</strong> Only use this in the positive prompt if you need the extra strength. On an asian-specific model for example.</p></li><li><p><strong>Asian-Less-Toon:</strong> Only use this in the positive prompt if you need to remove anime-like features in illustrations.</p></li></ul><p>Again, this isn't meant to race-swap, but to help get other race and/or cultures in your image generation without the influence of the asian image training. But like all models, the intended use and what you do with it are separate matters.</p><p></p><p><span style=\"color:rgb(64, 192, 87)\">Do you have requests? I've been putting in many more hours lately with this. That's my problem, not yours. But if you'd like to tip me, buy me a beer. Beer encourages me to ignore work and make AI models instead. Tip and make a request. I'll give it a shot if I can.</span><span style=\"color:rgb(193, 194, 197)\"> </span><a target=\"_blank\" rel=\"ugc\" href=\"https://ko-fi.com/zovya\"><u>Here at Ko-Fi</u></a></p>",
+      "allowNoCredit": false,
+      "allowCommercialUse": ["Image", "RentCivit"],
+      "allowDerivatives": true,
+      "allowDifferentLicense": false,
+      "type": "TextualInversion",
+      "minor": false,
+      "poi": false,
+      "nsfw": false,
+      "nsfwLevel": 1,
+      "cosmetic": null,
+      "stats": {
+        "downloadCount": 65273,
+        "favoriteCount": 0,
+        "thumbsUpCount": 3996,
+        "thumbsDownCount": 2,
+        "commentCount": 78,
+        "ratingCount": 0,
+        "rating": 0,
+        "tippedAmountCount": 273
+      },
+      "creator": {
+        "username": "Zovya",
+        "image": "https://avatars.githubusercontent.com/u/110301217?v=4"
+      },
+      "tags": ["negative embedding", "embedding", "tool"],
+      "modelVersions": [
+        {
+          "id": 268449,
+          "index": 0,
+          "name": "Negative V2",
+          "baseModel": "SD 1.5",
+          "baseModelType": null,
+          "publishedAt": "2023-12-20T02:12:01.003Z",
+          "availability": "Public",
+          "nsfwLevel": 1,
+          "description": null,
+          "trainedWords": ["Asian-Less2-Neg"],
+          "stats": {
+            "downloadCount": 10967,
+            "ratingCount": 272,
+            "rating": 4.98,
+            "thumbsUpCount": 852,
+            "thumbsDownCount": 1
+          },
+          "files": [
+            {
+              "id": 209362,
+              "sizeKB": 48.9404296875,
+              "name": "Asian-Less2-Neg.pt",
+              "type": "Model",
+              "pickleScanResult": "Success",
+              "pickleScanMessage": "No Pickle imports",
+              "virusScanResult": "Success",
+              "virusScanMessage": null,
+              "scannedAt": "2023-12-20T02:11:19.583Z",
+              "metadata": {
+                "format": "Other"
+              },
+              "hashes": {
+                "AutoV2": "6584E401AA",
+                "SHA256": "6584E401AA59A137DA7ED20FD29F9518E2B3248090A1CEB18A740E3B1B5E743C",
+                "CRC32": "D8F23496",
+                "BLAKE3": "E89331D9E401A120042C22E4ACFA8118CB2905748517BBAA0ADD52E1A9B75DC7"
+              },
+              "downloadUrl": "https://civitai.com/api/download/models/268449",
+              "primary": true
+            }
+          ],
+          "images": [
+            {
+              "id": 4728452,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/000b06b1-8249-4c21-9cc7-bed1ec9e8b6a/width=450/4728452.jpeg",
+              "nsfwLevel": 1,
+              "width": 1024,
+              "height": 1536,
+              "hash": "UAGbP6-oo2R+^PDh4.01.TIURk4o^jIpV@?H",
+              "type": "image"
+            },
+            {
+              "id": 4728450,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/404e6fa3-a10d-4f3b-a936-ca0a4de5496f/width=450/4728450.jpeg",
+              "nsfwLevel": 1,
+              "width": 1024,
+              "height": 1536,
+              "hash": "U3DmXO|;8{?c0ZK*xu-;0sx]IURj0P00IU00",
+              "type": "image"
+            },
+            {
+              "id": 4728451,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/a43fef20-2f4f-4d66-ae4a-3d37a870a374/width=450/4728451.jpeg",
+              "nsfwLevel": 1,
+              "width": 1024,
+              "height": 1536,
+              "hash": "U9Dc?u$ynh.9O_EMj[D%03xbR*-;AD-:IUIp",
+              "type": "image"
+            },
+            {
+              "id": 4728448,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/93d39ce2-976c-484a-a0b6-42ccff62ece8/width=450/4728448.jpeg",
+              "nsfwLevel": 1,
+              "width": 1024,
+              "height": 1536,
+              "hash": "U5ECzz-;9F?c0EIV%2Dj0FNIIotRyZ-;NFt8",
+              "type": "image"
+            },
+            {
+              "id": 4728449,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/eb7b53d9-cab7-4077-99c9-88dcdc35ae15/width=450/4728449.jpeg",
+              "nsfwLevel": 1,
+              "width": 1024,
+              "height": 1536,
+              "hash": "U9FrxD%LRj~q06IpWB010Ct7oy-:OHxtIU?b",
+              "type": "image"
+            },
+            {
+              "id": 4728453,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/01235f94-2473-41bb-90db-72c090c310fe/width=450/4728453.jpeg",
+              "nsfwLevel": 1,
+              "width": 1024,
+              "height": 1536,
+              "hash": "UAFPmI_2x]%L00D%R5V@15tmNbS$_4IBjFMy",
+              "type": "image"
+            },
+            {
+              "id": 4728454,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/a6d6200f-9196-4cec-9877-6b8b0b17448c/width=450/4728454.jpeg",
+              "nsfwLevel": 1,
+              "width": 1024,
+              "height": 1536,
+              "hash": "UFCjX[n#e.%g*JogkCV@0LRjRiNH00xuRkad",
+              "type": "image"
+            },
+            {
+              "id": 4728455,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/35e729bc-d4d2-4866-9b36-78fa8a1f94ea/width=450/4728455.jpeg",
+              "nsfwLevel": 1,
+              "width": 1024,
+              "height": 1536,
+              "hash": "UGF#ODv}D%D*{0RkogaeL~o#xu-:E2xuWBRj",
+              "type": "image"
+            },
+            {
+              "id": 4728456,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/3d99c204-7aa3-4d05-a8d6-2b6abf256781/width=450/4728456.jpeg",
+              "nsfwLevel": 1,
+              "width": 1024,
+              "height": 1536,
+              "hash": "UME_N=%2V@tR{yV[f7niIAR*WXWBIUV@oKV@",
+              "type": "image"
+            },
+            {
+              "id": 4728512,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/94dc5b72-ca67-42a9-998e-9de04d751e50/width=450/4728512.jpeg",
+              "nsfwLevel": 1,
+              "width": 1024,
+              "height": 1536,
+              "hash": "UJHBxcW9-:RP%0?HD%IU~WIo4nxtS2M|WBWB",
+              "type": "image"
+            },
+            {
+              "id": 4728510,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/7dc196b7-2bc7-4037-96c0-7e765404cfc1/width=450/4728510.jpeg",
+              "nsfwLevel": 1,
+              "width": 1024,
+              "height": 1536,
+              "hash": "UQHoI3IptPs.-;xuD%Io~pM_9G%L%gV@M_xu",
+              "type": "image"
+            },
+            {
+              "id": 4728511,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/8e90eb62-f132-4f2b-8cfe-9f72aed948a0/width=450/4728511.jpeg",
+              "nsfwLevel": 1,
+              "width": 1024,
+              "height": 1536,
+              "hash": "UIF}=#Mem,~V=|9FDj?H%0oyIpo#xuNakWx]",
+              "type": "image"
+            },
+            {
+              "id": 4728513,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/96e8d714-4968-4945-a9a9-a672ff6977c9/width=450/4728513.jpeg",
+              "nsfwLevel": 1,
+              "width": 1024,
+              "height": 1536,
+              "hash": "UFEyiAnhjF_3~q9F4n-;xXRj01WX-;RjM{%g",
+              "type": "image"
+            },
+            {
+              "id": 4753752,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/42702574-2412-400f-b9b0-a62de5ab5a6e/width=450/4753752.jpeg",
+              "nsfwLevel": 1,
+              "width": 1024,
+              "height": 1536,
+              "hash": "UGEeY[nh0y-p~Vt79Zt6E*xtRQE2kSogxZIV",
+              "type": "image"
+            }
+          ],
+          "downloadUrl": "https://civitai.com/api/download/models/268449"
+        },
+        {
+          "id": 57451,
+          "index": 1,
+          "name": "Negative",
+          "baseModel": "SD 1.5",
+          "baseModelType": "Standard",
+          "publishedAt": "2023-04-28T15:05:54.748Z",
+          "availability": "Public",
+          "nsfwLevel": 1,
+          "description": "<p>This is the main embedding, place this in your negative prompt at strength 1.</p>",
+          "trainedWords": ["Asian-Less-Neg"],
+          "stats": {
+            "downloadCount": 35405,
+            "ratingCount": 2321,
+            "rating": 4.99,
+            "thumbsUpCount": 3046,
+            "thumbsDownCount": 1
+          },
+          "files": [
+            {
+              "id": 40966,
+              "sizeKB": 15.86328125,
+              "name": "Asian-Less-Neg.pt",
+              "type": "Model",
+              "pickleScanResult": "Success",
+              "pickleScanMessage": "No Pickle imports",
+              "virusScanResult": "Success",
+              "virusScanMessage": null,
+              "scannedAt": "2023-04-28T15:05:40.599Z",
+              "metadata": {
+                "format": "Other"
+              },
+              "hashes": {
+                "AutoV2": "22D2F003E7",
+                "SHA256": "22D2F003E76F94DCF891B821A3F447F25C73B2E0542F089427B33FF344070A96",
+                "CRC32": "20986841",
+                "BLAKE3": "87BB972CFCE52DD744AB3DCC6A2CFD6EF218231018724486737E87C113A2CD9B"
+              },
+              "downloadUrl": "https://civitai.com/api/download/models/57451",
+              "primary": true
+            }
+          ],
+          "images": [
+            {
+              "id": 623896,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/67ebd62b-888b-433d-4409-96fc9ee5e800/width=450/623896.jpeg",
+              "nsfwLevel": 1,
+              "width": 1024,
+              "height": 2048,
+              "hash": "UDH.A$Qb00?V_N-U%gXUM}xtR.t6%M-.tRM}",
+              "type": "image"
+            },
+            {
+              "id": 623893,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/13896858-13a6-4eb0-a823-9920a8c5e400/width=450/623893.jpeg",
+              "nsfwLevel": 1,
+              "width": 1024,
+              "height": 1536,
+              "hash": "UWEM|1$*V@-UKSNaSNS58JkCn%WBt8ofayWC",
+              "type": "image"
+            },
+            {
+              "id": 623899,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/d9d02aca-ff93-458e-832b-e56f86823000/width=450/623899.jpeg",
+              "nsfwLevel": 1,
+              "width": 1024,
+              "height": 1536,
+              "hash": "UBF5j,S*Nfs+6XIpnhs;0G%0aKNe19%1IVNF",
+              "type": "image"
+            },
+            {
+              "id": 623894,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/275521bb-b07e-4a41-9977-00d3eb683400/width=450/623894.jpeg",
+              "nsfwLevel": 1,
+              "width": 1024,
+              "height": 1536,
+              "hash": "UEFsSK?]Rk.80fIoslbt00e9R*Q-xDRkozM}",
+              "type": "image"
+            },
+            {
+              "id": 623901,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/621b6252-b771-4694-c1da-e0d7c36cdb00/width=450/623901.jpeg",
+              "nsfwLevel": 1,
+              "width": 1024,
+              "height": 1536,
+              "hash": "USHUtbM{%gsm-=xuX9M{~ps;X9jr%MWXaeWU",
+              "type": "image"
+            },
+            {
+              "id": 623900,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/c7dcccf9-caa8-4aa3-50d8-ea69a8986800/width=450/623900.jpeg",
+              "nsfwLevel": 1,
+              "width": 1024,
+              "height": 1536,
+              "hash": "UJG*pF8_-n%2?vs-S$RP~Vs:S5WA?HR+M|Rk",
+              "type": "image"
+            },
+            {
+              "id": 623898,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/b8221df8-2b77-4ba1-c29a-575db48b5e00/width=450/623898.jpeg",
+              "nsfwLevel": 1,
+              "width": 1024,
+              "height": 1536,
+              "hash": "U6G84zO600w{}3Ob4ps8D%~CE3Io4=4,tAoI",
+              "type": "image"
+            },
+            {
+              "id": 623903,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/632ca2d0-237f-4c86-f130-017c09e2a700/width=450/623903.jpeg",
+              "nsfwLevel": 1,
+              "width": 1024,
+              "height": 1536,
+              "hash": "UNGakSoaDiR.}%ogE2WAs:s:IXaxM|R%NIad",
+              "type": "image"
+            },
+            {
+              "id": 623895,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/e4f3d0f4-e07a-423f-e140-f63fc4a40100/width=450/623895.jpeg",
+              "nsfwLevel": 1,
+              "width": 1024,
+              "height": 1536,
+              "hash": "UGF~5C~AH?Ek.nENK%e-C6Rk=_spEMxD=GNH",
+              "type": "image"
+            },
+            {
+              "id": 623897,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/f7a29f35-d4a3-4edc-4841-252a17e3eb00/width=450/623897.jpeg",
+              "nsfwLevel": 1,
+              "width": 1024,
+              "height": 1536,
+              "hash": "UIFrni~UD%EN_%RQEzNGL1W=-UWBELs:-BM|",
+              "type": "image"
+            },
+            {
+              "id": 623904,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/17630caa-bffb-4e60-e4d6-2b96df18b500/width=450/623904.jpeg",
+              "nsfwLevel": 1,
+              "width": 1024,
+              "height": 1536,
+              "hash": "URH{cX.SA1s**0yB.7R6M{ROV@D*VsjEt6Ip",
+              "type": "image"
+            },
+            {
+              "id": 623902,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/b71da887-aa1e-4d8c-d25d-0a19516eea00/width=450/623902.jpeg",
+              "nsfwLevel": 1,
+              "width": 1024,
+              "height": 1536,
+              "hash": "UUHVYA?uOtrq?]tk.6eTNFjEjYIWM|aeoJR*",
+              "type": "image"
+            }
+          ],
+          "downloadUrl": "https://civitai.com/api/download/models/57451"
+        },
+        {
+          "id": 55265,
+          "index": 2,
+          "name": "Normal",
+          "baseModel": "SD 1.5",
+          "baseModelType": "Standard",
+          "publishedAt": "2023-04-26T14:36:01.884Z",
+          "availability": "Public",
+          "nsfwLevel": 1,
+          "description": null,
+          "trainedWords": ["Asian-Less"],
+          "stats": {
+            "downloadCount": 10669,
+            "ratingCount": 18,
+            "rating": 4.83,
+            "thumbsUpCount": 40,
+            "thumbsDownCount": 0
+          },
+          "files": [
+            {
+              "id": 39762,
+              "sizeKB": 15.86328125,
+              "name": "Asian-Less.pt",
+              "type": "Model",
+              "pickleScanResult": "Success",
+              "pickleScanMessage": "No Pickle imports",
+              "virusScanResult": "Success",
+              "virusScanMessage": null,
+              "scannedAt": "2023-04-25T17:36:16.388Z",
+              "metadata": {
+                "format": "PickleTensor",
+                "size": null,
+                "fp": null
+              },
+              "hashes": {
+                "AutoV2": "965D8E05BA",
+                "SHA256": "965D8E05BAEB16776451587B57A14DECC421BF0220AFAF8631117168073325DD",
+                "CRC32": "9B2C614D",
+                "BLAKE3": "0C85423F8C5142390F10DAE17674FED90CA27EA888F1B1EE57F83D8D5E980850"
+              },
+              "downloadUrl": "https://civitai.com/api/download/models/55265",
+              "primary": true
+            }
+          ],
+          "images": [
+            {
+              "id": 597774,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/09f73011-9cbe-4fc9-14fb-dafd3e77e100/width=450/597774.jpeg",
+              "nsfwLevel": 1,
+              "width": 1024,
+              "height": 2048,
+              "hash": "UDH.A$Qa00?V_N-U%gXUM}xtR.t6%M-.tRM}",
+              "type": "image"
+            },
+            {
+              "id": 597793,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/1ab6d16a-012c-425e-2de3-8b53fe362200/width=450/597793.jpeg",
+              "nsfwLevel": 1,
+              "width": 1024,
+              "height": 1536,
+              "hash": "UWEM|1$*V@-UKSNaS4S58JkCn%WBt8ofayWC",
+              "type": "image"
+            },
+            {
+              "id": 597777,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/e3af3c94-c57f-420b-cd92-cb87fedb5200/width=450/597777.jpeg",
+              "nsfwLevel": 1,
+              "width": 1024,
+              "height": 1536,
+              "hash": "UBF5j,S*Nfs+6XIpnhs;0G%0aKNe19%1IVNF",
+              "type": "image"
+            },
+            {
+              "id": 597780,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/7c0a8c70-c9ea-4f1e-32b6-d6c7366cb500/width=450/597780.jpeg",
+              "nsfwLevel": 1,
+              "width": 1024,
+              "height": 1536,
+              "hash": "UEFsSK?]Rk.80fIoslbt00e9R*Q-xDRkozM}",
+              "type": "image"
+            },
+            {
+              "id": 597787,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/a08053f5-0c29-45b2-73ef-b9a524580700/width=450/597787.jpeg",
+              "nsfwLevel": 1,
+              "width": 1024,
+              "height": 1536,
+              "hash": "USHUtbM{%gsm-=xuX9M{~ps;X9jr%MWWaeWU",
+              "type": "image"
+            },
+            {
+              "id": 597782,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/a6a7b233-9cde-418f-b53a-bf1b7a957e00/width=450/597782.jpeg",
+              "nsfwLevel": 1,
+              "width": 1024,
+              "height": 1536,
+              "hash": "UJG*pF8_-n%2?vs-S$RP~Vs:S5V@?HR+M|Rk",
+              "type": "image"
+            },
+            {
+              "id": 597783,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/3344cd55-6b9b-4f09-f361-90d61b8b3800/width=450/597783.jpeg",
+              "nsfwLevel": 1,
+              "width": 1024,
+              "height": 1536,
+              "hash": "U6G84zO600w{}3Ob4ps8D%~CE3Io4=4,tAoI",
+              "type": "image"
+            },
+            {
+              "id": 597788,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/4f3cfe9f-7aad-49b4-330c-ec4beb97bf00/width=450/597788.jpeg",
+              "nsfwLevel": 1,
+              "width": 1024,
+              "height": 1536,
+              "hash": "UNGakSoaDiR.}%ogE2WAs:s:IXaxM|R%NIad",
+              "type": "image"
+            },
+            {
+              "id": 597784,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/c4f1ecba-fa26-44f8-95db-6676e10c4200/width=450/597784.jpeg",
+              "nsfwLevel": 1,
+              "width": 1024,
+              "height": 1536,
+              "hash": "UGF~5C~AH?Ek.nENK%e-C6Rk=_spEMxD=GNH",
+              "type": "image"
+            },
+            {
+              "id": 597778,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/bfdecf9e-2e66-4c80-7c24-4c2bb1079c00/width=450/597778.jpeg",
+              "nsfwLevel": 1,
+              "width": 1024,
+              "height": 1536,
+              "hash": "UIFrni~UD%EN_%RQEzNGL1W=-UWBELs:-BM|",
+              "type": "image"
+            },
+            {
+              "id": 597779,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/beb2496e-df66-4be2-7442-5fa9df4bdb00/width=450/597779.jpeg",
+              "nsfwLevel": 1,
+              "width": 1024,
+              "height": 1536,
+              "hash": "URH{cX.SA1s**0yB.7R6M{ROV@D*VsjEt6Ip",
+              "type": "image"
+            },
+            {
+              "id": 597781,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/1b631697-b449-4973-4d3b-385d2f1a6a00/width=450/597781.jpeg",
+              "nsfwLevel": 1,
+              "width": 1024,
+              "height": 1536,
+              "hash": "UUHVYA?uOtrq?]tk.6eTNFjEjYIWM|aeoJR*",
+              "type": "image"
+            }
+          ],
+          "downloadUrl": "https://civitai.com/api/download/models/55265"
+        },
+        {
+          "id": 55272,
+          "index": 3,
+          "name": "Toon",
+          "baseModel": "SD 1.5",
+          "baseModelType": "Standard",
+          "publishedAt": "2023-04-26T18:14:42.634Z",
+          "availability": "Public",
+          "nsfwLevel": 1,
+          "description": null,
+          "trainedWords": ["Asian-Less-Toon"],
+          "stats": {
+            "downloadCount": 8232,
+            "ratingCount": 167,
+            "rating": 5,
+            "thumbsUpCount": 179,
+            "thumbsDownCount": 0
+          },
+          "files": [
+            {
+              "id": 39763,
+              "sizeKB": 21.9404296875,
+              "name": "Asian-Less-Toon.pt",
+              "type": "Model",
+              "pickleScanResult": "Success",
+              "pickleScanMessage": "No Pickle imports",
+              "virusScanResult": "Success",
+              "virusScanMessage": null,
+              "scannedAt": "2023-04-25T17:36:05.656Z",
+              "metadata": {
+                "format": "PickleTensor",
+                "size": null,
+                "fp": null
+              },
+              "hashes": {
+                "AutoV2": "779EAC4F1D",
+                "SHA256": "779EAC4F1D05E74F646ECBE1ECFBC944F1CDF45007CED90B13566A5C1C70DE5B",
+                "CRC32": "60FB2F5F",
+                "BLAKE3": "7E2983F6693E210043D7CA88AE4849885472C44027AA638DDC43B2EFD2E276EC"
+              },
+              "downloadUrl": "https://civitai.com/api/download/models/55272",
+              "primary": true
+            }
+          ],
+          "images": [
+            {
+              "id": 597843,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/d14ff399-01fa-4f70-8f6b-4c5546a54900/width=450/597843.jpeg",
+              "nsfwLevel": 1,
+              "width": 1024,
+              "height": 1536,
+              "hash": "UBF5j,S*Nfs+6XIpnhs;0G%0aKNe19%1IVNF",
+              "type": "image"
+            }
+          ],
+          "downloadUrl": "https://civitai.com/api/download/models/55272"
+        }
+      ]
+    },
+    {
+      "id": 16807,
+      "name": "Useful Quality Embeddings",
+      "description": "<h1>介绍（中文）</h1><h2>基本信息</h2><p>该页面为推荐用于 AnimeIllustDiffusion [1] 模型的所有文本嵌入（Embedding）。您可以从版本描述查看该文本嵌入的信息。</p><h2>使用方法</h2><p>您应该将下载到的负面文本嵌入文件置入您 stable diffusion 目录下的 embeddings 文件夹内。之后，您只需要在填写负面提示词处输入 badv4 即可。</p><h2>评价参数</h2><p>每个文本嵌入将从以下参数描述其特性：</p><p><strong>正/负面文本嵌入</strong>：如果一个文本嵌入是正面文本嵌入，则您应该将它填写在正面提示词内发挥作用；反之，如果一个文本嵌入是负面文本嵌入，则您应该将它填写在负面提示词内发挥作用。</p><p><strong>作用范围</strong>：一个文本嵌入主要影响的画面内容。</p><p><strong>向量数</strong>：代表该文本嵌入占多少个词元。通常来说，您输入提示词中超过 75 个词元的部分会被忽略。因此，一个文本嵌入的向量数越少，您填入它之后剩余输入提示词的空间越多。</p><p><strong>向量强度</strong>：一个词元向量值的大小。向量强度越高，效果越强。普通词元的向量强度为[-0.05,0.05]。不可将用括号增强提示词等效于增强向量强度。</p><p></p><p></p><h1>Introduction (English)</h1><h2>Basic Information</h2><p>This page contains all the text embeddings recommended for use with the AnimeIllustDiffusion model [1]. You can view information about the text embeddings from the version description.</p><h2>Usage</h2><p>You should place the downloaded negative text embedding file in the embeddings folder of your Stable Diffusion directory. After that, you only need to enter \"badv4\" in the field for negative prompts.</p><h2>Evaluation Parameters</h2><p>Each text embedding is described by the following parameters:</p><p><strong>Positive/Negative Text Embedding</strong>: If a text embedding is a positive text embedding, it should be used in positive prompts. Conversely, if a text embedding is a negative text embedding, it should be used in negative prompts.</p><p><strong>Scope</strong>: The main content of the image that a text embedding will primarily affect.</p><p><strong>Vector Count</strong>: The number of token that the text embedding represents. Generally, the part of a prompt containing more than 75 tokens will be ignored. Therefore, the fewer the number of vectors in a text embedding, the more space you will have left to input the prompt.</p><p><strong>Vector Strength</strong>: The magnitude of a token's vector. The higher the vector strength, the stronger the effect. The vector strength of token is usually between [-0.05, 0.05]. Using parentheses to enhance prompts is not equivalent to increasing vector strength.</p><p></p><h1>引用 / References</h1><p>[1] AnimeIllustDiffusion Model Webpage: <a target=\"_blank\" rel=\"ugc\" href=\"https://civitai.com/models/16828/animeillustdiffusion\">https://civitai.com/models/16828/animeillustdiffusion</a></p>",
+      "allowNoCredit": true,
+      "allowCommercialUse": ["Image", "RentCivit", "Rent"],
+      "allowDerivatives": true,
+      "allowDifferentLicense": true,
+      "type": "TextualInversion",
+      "minor": false,
+      "poi": false,
+      "nsfw": false,
+      "nsfwLevel": 7,
+      "cosmetic": null,
+      "stats": {
+        "downloadCount": 65390,
+        "favoriteCount": 0,
+        "thumbsUpCount": 3853,
+        "thumbsDownCount": 1,
+        "commentCount": 26,
+        "ratingCount": 0,
+        "rating": 0,
+        "tippedAmountCount": 22
+      },
+      "creator": {
+        "username": "Euge_",
+        "image": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/f59d1991-04ab-4cce-387e-2e90e7603700/width=96/Euge_.jpeg"
+      },
+      "tags": ["anime", "textual inversion", "style"],
+      "modelVersions": [
+        {
+          "id": 111570,
+          "index": 0,
+          "name": "aid210",
+          "baseModel": "Other",
+          "baseModelType": "Standard",
+          "publishedAt": "2023-07-06T14:10:49.916Z",
+          "availability": "Public",
+          "nsfwLevel": 1,
+          "description": "<p>Anime Illust Diffusion v2.10 专属负面文本嵌入。但同样生效于其他模型。</p><p>与 aid291 相比，aid210 弱化了矫正效果，但对风格化更友好，不会过度损害底模自带的风格。它能够带来更柔和的光影和更厚的轮廓线条。如果您正在使用 AIDV2.10，我更推荐您使用 aid210。</p><p>作用范围：提高清晰度，消除伪影噪点，修正线条扭曲，轻微美颜</p><p>向量数：16</p><p>向量强度：0.05</p><p>缺点：对人体结构和手部的帮助较小</p><p>Anime Illust Diffusion v2.10 exclusive negative text embedding. But the same applies to other models.</p><p>Compared with aid291, aid210 weakens the correction effect, but is more friendly to stylization, and will not excessively damage the original style of its base model. It brings softer lighting and shadows and thicker contour lines (brushstrokes). If you are using AIDV2.10, I recommend you to use aid210.</p><p>Effect: Improve sharpness, eliminate artifact and noise, correct line distortion, and slightly beautify face.</p><p>Vector count: 16</p><p>Vector strength: 0.05</p><p>Disadvantage: Less helpful to anatomy and hands</p>",
+          "trainedWords": ["aid210"],
+          "stats": {
+            "downloadCount": 15993,
+            "ratingCount": 929,
+            "rating": 5,
+            "thumbsUpCount": 1672,
+            "thumbsDownCount": 0
+          },
+          "files": [
+            {
+              "id": 78987,
+              "sizeKB": 48.8486328125,
+              "name": "aid210.pt",
+              "type": "Model",
+              "pickleScanResult": "Success",
+              "pickleScanMessage": "No Pickle imports",
+              "virusScanResult": "Success",
+              "virusScanMessage": null,
+              "scannedAt": "2023-07-06T14:15:46.498Z",
+              "metadata": {
+                "format": "PickleTensor",
+                "size": null,
+                "fp": null
+              },
+              "hashes": {
+                "AutoV2": "AFA9C1D8E1",
+                "SHA256": "AFA9C1D8E13CBF5779505E81EC40E0AB62DAE18FE0844214564D5E49A5B1CD59",
+                "CRC32": "DB19E321",
+                "BLAKE3": "F8BA511EAABDB5C7DB614EA5BB813E659E082A0A97DE560B6AD6B32B265A58BD"
+              },
+              "downloadUrl": "https://civitai.com/api/download/models/111570",
+              "primary": true
+            }
+          ],
+          "images": [
+            {
+              "id": 1435375,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/b8433aac-bf82-40de-8565-62589ccd740a/width=450/1435375.jpeg",
+              "nsfwLevel": 1,
+              "width": 1152,
+              "height": 931,
+              "hash": "UXIF6,s?f+bu.AWBWVM{?at7ayxa^+WUn%j]",
+              "type": "image"
+            },
+            {
+              "id": 1435478,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/f55e1ed6-9d1f-4d8f-bc15-dba840edaf35/width=450/1435478.jpeg",
+              "nsfwLevel": 1,
+              "width": 2048,
+              "height": 825,
+              "hash": "UeK-LO$*ozbH_NX8oLtR^+jZR*s._NWVj[R*",
+              "type": "image"
+            }
+          ],
+          "downloadUrl": "https://civitai.com/api/download/models/111570"
+        },
+        {
+          "id": 91028,
+          "index": 1,
+          "name": "aid291",
+          "baseModel": "SD 1.5",
+          "baseModelType": "Standard",
+          "publishedAt": "2023-06-07T12:28:45.523Z",
+          "availability": "Public",
+          "nsfwLevel": 1,
+          "description": "<p>主观评价：aid291 是一个专用于 <strong>AnimeIllustDiffusionV2.91</strong> 的特制 <strong>负面文本嵌入</strong>，能够巨幅提高出图质量，比其他任何该系列的负面文本嵌入都要好。它它在其他模型上的表现 <strong>尚未测试过</strong>。当输入负面提示词时，请将要添加其他普通的负面 tag，放在 \"aid291\" tags 之前，以免弱效 tag 效用被覆盖。（例如，aid291, extra digits -&gt; extra digits, aid291）</p><p>作用范围：提高清晰度，消除伪影噪点，修正线条扭曲，添加细节，修正人体结构，改善手部细节，稳定构图，轻微美颜</p><p>向量数：39</p><p>向量强度：30% 0.5, 70% 0.35</p><p>缺点：（可能）会把不必要的物体引入</p><p>Subjective evaluation: aid291 is a specially crafted <strong>negative text embedding</strong> for <strong>AnimeIllustDiffusionV2.91</strong>. It hugely improves aid291 model's performance, better than any other negative text embeddings I have released so far. However, its performance on other models <strong>has not been tested</strong>, but worth trying. When inputting negative prompts, it's recommended to put other general tags before 'aid291' tag to prevent it weaken other tags before it. (e.g., aid291, extra digits -&gt; extra digits, aid291)</p><p>Effect: Improve sharpness, eliminate artifact and noise, correct line distortion, add details, correct human anatomy, improve hand structure, stabilize composition, and slightly beautify face.</p><p>Vector count: 39</p><p>Vector strength: 30% 0.5, 70% 0.35</p><p>Disadvantage: (May) Introduce unnecessary objects into</p>",
+          "trainedWords": ["aid291"],
+          "stats": {
+            "downloadCount": 7497,
+            "ratingCount": 487,
+            "rating": 4.99,
+            "thumbsUpCount": 560,
+            "thumbsDownCount": 1
+          },
+          "files": [
+            {
+              "id": 62659,
+              "sizeKB": 117.7890625,
+              "name": "aid291.pt",
+              "type": "Model",
+              "pickleScanResult": "Success",
+              "pickleScanMessage": "No Pickle imports",
+              "virusScanResult": "Success",
+              "virusScanMessage": null,
+              "scannedAt": "2023-06-07T12:31:07.283Z",
+              "metadata": {
+                "format": "PickleTensor",
+                "size": null,
+                "fp": null
+              },
+              "hashes": {
+                "AutoV2": "4D01744FD7",
+                "SHA256": "4D01744FD70C84A7E53D099684AE1754360EDA1AAC685D9AD37BA6D36CBE58B7",
+                "CRC32": "B30C168E",
+                "BLAKE3": "3C001A91E2A6B4B9821D8EC237015C1E08AD4FA0420361D6AAF9A84709098EB2"
+              },
+              "downloadUrl": "https://civitai.com/api/download/models/91028",
+              "primary": true
+            }
+          ],
+          "images": [
+            {
+              "id": 1061008,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/0f380d3c-a75c-422f-a8f5-75e639ea547d/width=450/1061008.jpeg",
+              "nsfwLevel": 1,
+              "width": 1280,
+              "height": 1003,
+              "hash": "UcMZI6%LS2-o_NofkCofY5WBo0NG_2ayays:",
+              "type": "image"
+            },
+            {
+              "id": 1060971,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/84c452d0-5279-4fb2-ae33-57e764e00bc6/width=450/1060971.jpeg",
+              "nsfwLevel": 1,
+              "width": 1280,
+              "height": 1003,
+              "hash": "UjJt@:R*WBIo~qayWCRkxuoMkCof-=oLays:",
+              "type": "image"
+            },
+            {
+              "id": 1060975,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/ec3f1d04-ecdc-4850-8ddd-57467501e754/width=450/1060975.jpeg",
+              "nsfwLevel": 1,
+              "width": 1280,
+              "height": 1003,
+              "hash": "UXOU}Xo[Rjxb}]NGWBRj%#ofoMt7t,n+ofoL",
+              "type": "image"
+            },
+            {
+              "id": 1060979,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/bc8ab6b7-0fcc-4603-a377-b745e40f3d8b/width=450/1060979.jpeg",
+              "nsfwLevel": 1,
+              "width": 1280,
+              "height": 1003,
+              "hash": "UzMZtHx]WVxa~qW;jZbHtSWBofWB%MWBWVjZ",
+              "type": "image"
+            }
+          ],
+          "downloadUrl": "https://civitai.com/api/download/models/91028"
+        },
+        {
+          "id": 81990,
+          "index": 2,
+          "name": "aid29",
+          "baseModel": "Other",
+          "baseModelType": "Standard",
+          "publishedAt": "2023-05-26T17:02:10.054Z",
+          "availability": "Public",
+          "nsfwLevel": 3,
+          "description": "<p>主观评价：aid29 是一个专用于 <strong>AnimeIllustDiffusionV2.9</strong> 的特制 <strong>负面文本嵌入</strong>。它在其他模型上的表现 <strong>尚未测试过</strong>。与 aid28 相比，aid29 更擅长绘制动态、灵活、拥有不错手部的图像，但占用的次元也更多。</p><p>e作用范围：画质、手、人体结构</p><p>向量数：50</p><p>向量强度：0.32</p><p>缺点：暂未发现</p><p>Subjective evaluation: aid29 is a specially crafted <strong>negative text embedding</strong> for <strong>AnimeIllustDiffusionV2.9</strong>. Its performance on other models <strong>has not been tested</strong>. Compared with aid28, aid29 is better at drawing dynamic, flexible images with decent hands, but also takes up more tokens (50).</p><p>Scope: image quality, hand and anatomy</p><p>Vector count: 50</p><p>Vector strength: 0.32</p><p>Disadvantage: currently none</p>",
+          "trainedWords": ["aid29"],
+          "stats": {
+            "downloadCount": 3778,
+            "ratingCount": 194,
+            "rating": 5,
+            "thumbsUpCount": 197,
+            "thumbsDownCount": 0
+          },
+          "files": [
+            {
+              "id": 56133,
+              "sizeKB": 150.7890625,
+              "name": "aid29.pt",
+              "type": "Model",
+              "pickleScanResult": "Success",
+              "pickleScanMessage": "No Pickle imports",
+              "virusScanResult": "Success",
+              "virusScanMessage": null,
+              "scannedAt": "2023-05-26T17:06:17.530Z",
+              "metadata": {
+                "format": "PickleTensor",
+                "size": null,
+                "fp": null
+              },
+              "hashes": {
+                "AutoV2": "7BB48F7B63",
+                "SHA256": "7BB48F7B6329D8D415FD2A05AF45522F26F781C5E86C7BB25F69EB25D10461B2",
+                "CRC32": "A45E0B43",
+                "BLAKE3": "1A1A2FD1150944CA4BB1509DC555B20778FDF3FD1F8A1A6DFC2C5BC3C58FEA26"
+              },
+              "downloadUrl": "https://civitai.com/api/download/models/81990",
+              "primary": true
+            }
+          ],
+          "images": [
+            {
+              "id": 921690,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/e514fe59-7a98-4745-8285-460b220ce5b6/width=450/921690.jpeg",
+              "nsfwLevel": 1,
+              "width": 1280,
+              "height": 1074,
+              "hash": "UQGScjITog9F~Uj[ofRj.8xbWC%M?vt7WBxu",
+              "type": "image"
+            },
+            {
+              "id": 921689,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/fe22a115-3e66-4226-a244-2c6f14cbaa00/width=450/921689.jpeg",
+              "nsfwLevel": 2,
+              "width": 1280,
+              "height": 1074,
+              "hash": "UZMQF%t8oyae?bjFaes:_Ns:bHt7.7S1jbNG",
+              "type": "image"
+            },
+            {
+              "id": 921688,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/aa8a4dab-ef0b-4191-a1a8-c546812f78c7/width=450/921688.jpeg",
+              "nsfwLevel": 1,
+              "width": 1280,
+              "height": 1074,
+              "hash": "UaKUZkxuRjxu~qt7ofofRjWBofof~qM{ayM{",
+              "type": "image"
+            }
+          ],
+          "downloadUrl": "https://civitai.com/api/download/models/81990"
+        },
+        {
+          "id": 49129,
+          "index": 3,
+          "name": "aid28",
+          "baseModel": "Other",
+          "baseModelType": "Standard",
+          "publishedAt": "2023-04-18T16:19:51.094Z",
+          "availability": "Public",
+          "nsfwLevel": 3,
+          "description": "<p>主观评价：aid28 是一个专用于 <strong>AnimeIllustDiffusionV2.8</strong> 的特制 <strong>负面文本嵌入</strong>。它在其他模型上的表现<strong>尚未测试过</strong>。</p><p>作用范围：画质和手</p><p>向量数：23</p><p>向量强度：0.3</p><p>缺点：暂无</p><p>Subjective evaluation: aid28 is a specially crafted <strong>negative text embedding</strong> for <strong>AnimeIllustDiffusionV2.8</strong>. Its performance on other models <strong>has not been tested</strong>.</p><p>Scope: image quality and hand</p><p>Vector count: 23</p><p>Vector strength: 0.3</p><p>Disadvantage: currently none</p>",
+          "trainedWords": ["aid28"],
+          "stats": {
+            "downloadCount": 5240,
+            "ratingCount": 128,
+            "rating": 4.99,
+            "thumbsUpCount": 132,
+            "thumbsDownCount": 0
+          },
+          "files": [
+            {
+              "id": 36191,
+              "sizeKB": 69.7861328125,
+              "name": "aid28.pt",
+              "type": "Model",
+              "pickleScanResult": "Success",
+              "pickleScanMessage": "No Pickle imports",
+              "virusScanResult": "Success",
+              "virusScanMessage": null,
+              "scannedAt": "2023-04-18T16:21:05.950Z",
+              "metadata": {
+                "format": "PickleTensor",
+                "size": null,
+                "fp": null
+              },
+              "hashes": {
+                "AutoV2": "859323FD02",
+                "SHA256": "859323FD02CE935DDA43A95BE4B8D2B3985092A63B236ADD90919209D9A9AD31",
+                "CRC32": "E454B9E9",
+                "BLAKE3": "42EFF24AD279B3FEFA37417CAC42A6F5E55B2AFE5C16A6C8DEF5D8FA359CC098"
+              },
+              "downloadUrl": "https://civitai.com/api/download/models/49129",
+              "primary": true
+            }
+          ],
+          "images": [
+            {
+              "id": 527846,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/63ec300d-b6f4-487d-b52d-a736f065fe00/width=450/527846.jpeg",
+              "nsfwLevel": 1,
+              "width": 1280,
+              "height": 1074,
+              "hash": "UYH21zNqV[s=_N$+Sx$*%eR+oMOA-:NGsoNa",
+              "type": "image"
+            },
+            {
+              "id": 527845,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/8100e6bf-eed2-4b11-50a2-02a1b4e7ea00/width=450/527845.jpeg",
+              "nsfwLevel": 2,
+              "width": 1280,
+              "height": 1074,
+              "hash": "UfMipFRjaeW=_NV@WBof.8WBkCWB%NoLj[t7",
+              "type": "image"
+            }
+          ],
+          "downloadUrl": "https://civitai.com/api/download/models/49129"
+        },
+        {
+          "id": 40158,
+          "index": 4,
+          "name": "aidv1",
+          "baseModel": "Other",
+          "baseModelType": "Standard",
+          "publishedAt": "2023-04-08T16:59:37.149Z",
+          "availability": "Public",
+          "nsfwLevel": 1,
+          "description": "<p>主观评价：aidv1 是一个专用于 <strong>AnimeIllustDiffusionV2.7</strong> 的特制 <strong>负面文本嵌入</strong>。它在其他模型上的表现<strong>尚未测试过</strong>。</p><p>作用范围：画质、构图、人体结构和手</p><p>向量数：72</p><p>向量强度：0.16</p><p>缺点：占用很多词元</p><p>Subjective evaluation: aidv1 is a specially crafted <strong>negative text embedding</strong> for <strong>AnimeIllustDiffusionV2.7</strong>. Its performance on other models <strong>has not been tested</strong>.</p><p>Scope: image quality, composition, human structure, and hand</p><p>Vector count: 72</p><p>Vector strength: 0.16</p><p>Disadvantage: It takes up many tokens</p>",
+          "trainedWords": ["aidv1"],
+          "stats": {
+            "downloadCount": 1902,
+            "ratingCount": 112,
+            "rating": 5,
+            "thumbsUpCount": 114,
+            "thumbsDownCount": 0
+          },
+          "files": [
+            {
+              "id": 31160,
+              "sizeKB": 216.7890625,
+              "name": "aidv1-neg.pt",
+              "type": "Negative",
+              "pickleScanResult": "Success",
+              "pickleScanMessage": "No Pickle imports",
+              "virusScanResult": "Success",
+              "virusScanMessage": null,
+              "scannedAt": "2023-04-08T17:06:34.954Z",
+              "metadata": {
+                "format": "Other",
+                "size": null,
+                "fp": null
+              },
+              "hashes": {
+                "AutoV2": "878B717BBF",
+                "SHA256": "878B717BBF8A13BC8CF15BD09BE1942F6215067FDEEB479638249F7A39B63DB7",
+                "CRC32": "A804855F",
+                "BLAKE3": "9420FB27CBF39AB6B162AC2851619671CD3D361E92C8657FCB0B371634D61476"
+              },
+              "downloadUrl": "https://civitai.com/api/download/models/40158",
+              "primary": true
+            }
+          ],
+          "images": [
+            {
+              "id": 444391,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/8eac9b6c-3af2-4ffb-599e-0c70303e3400/width=450/444391.jpeg",
+              "nsfwLevel": 1,
+              "width": 1280,
+              "height": 1920,
+              "hash": "UXLz{nH?ofo#D%tRt7MxNFM{oLt7~qocj]tR",
+              "type": "image"
+            }
+          ],
+          "downloadUrl": "https://civitai.com/api/download/models/40158"
+        },
+        {
+          "id": 36538,
+          "index": 5,
+          "name": "badv5",
+          "baseModel": "Other",
+          "baseModelType": "Standard",
+          "publishedAt": "2023-04-05T02:38:18.671Z",
+          "availability": "Public",
+          "nsfwLevel": 7,
+          "description": "<p>主观评价：<strong>负面文本嵌入</strong> badv5 是 badv3, badhandv4, bad-hand5 和 distirtionv1 的连接体。它的影响范围较广，能够改善手部细节，且对画风影响较小。<strong>我目前更推荐您使用它</strong>。</p><p>作用范围：画质、构图、人体结构和手</p><p>向量数：24</p><p>向量强度：0.5</p><p>缺点：非常轻微地添加厚涂画风和橙色色调</p><p>Subjective evaluation: <strong>Negative text embedding</strong> badv5 is a combination of badv3, badhandv4, bad-hand5, and distortionv1. It has a wide range of effects, can improve hand details, and has less impact on the overall style. Currently, I recommend using it.</p><p>Scope: image quality, composition, human structure, and hand</p><p>Vector count: 24</p><p>Vector strength: 0.5</p><p>Disadvantage: Slightly adds an impasto style and an orange tone.</p>",
+          "trainedWords": ["badv5"],
+          "stats": {
+            "downloadCount": 8615,
+            "ratingCount": 139,
+            "rating": 4.99,
+            "thumbsUpCount": 167,
+            "thumbsDownCount": 0
+          },
+          "files": [
+            {
+              "id": 29323,
+              "sizeKB": 72.931640625,
+              "name": "badv5.pt",
+              "type": "Model",
+              "pickleScanResult": "Success",
+              "pickleScanMessage": "No Pickle imports",
+              "virusScanResult": "Success",
+              "virusScanMessage": null,
+              "scannedAt": "2023-04-05T02:41:17.176Z",
+              "metadata": {
+                "format": "PickleTensor",
+                "size": null,
+                "fp": null
+              },
+              "hashes": {
+                "AutoV2": "0A3705F6D8",
+                "SHA256": "0A3705F6D8E9E49374FB5D8A95373EF494BAC14E341BBF731B0247B7606AAE3B",
+                "CRC32": "6500A2AF",
+                "BLAKE3": "A23C25805F02AC80A96B7963EE7B91D62FDD34EB60001A201FFA348D85CB24C0"
+              },
+              "downloadUrl": "https://civitai.com/api/download/models/36538",
+              "primary": true
+            }
+          ],
+          "images": [
+            {
+              "id": 428940,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/bf14d1b6-9262-4a1c-3331-e862882c8900/width=450/428940.jpeg",
+              "nsfwLevel": 1,
+              "width": 1280,
+              "height": 1003,
+              "hash": "URJ*SHn,Rjog~Vs:WBWB?vofayoL~qfkkBju",
+              "type": "image"
+            },
+            {
+              "id": 428939,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/3e56727b-1661-4678-6319-2a5cae1b1900/width=450/428939.jpeg",
+              "nsfwLevel": 2,
+              "width": 1280,
+              "height": 1003,
+              "hash": "UgKUTUofaztR~qofj[xuozt7ayxt_3ofj[WB",
+              "type": "image"
+            },
+            {
+              "id": 428941,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/02f0934d-585f-4dba-6c51-b1542e636000/width=450/428941.jpeg",
+              "nsfwLevel": 4,
+              "width": 1280,
+              "height": 1003,
+              "hash": "UYH-}mt7s:x]~qt7fkt7?vazWBs:-;azj[R*",
+              "type": "image"
+            }
+          ],
+          "downloadUrl": "https://civitai.com/api/download/models/36538"
+        },
+        {
+          "id": 30390,
+          "index": 6,
+          "name": "badv4",
+          "baseModel": "Other",
+          "baseModelType": "Standard",
+          "publishedAt": "2023-03-28T01:33:37.253Z",
+          "availability": "Public",
+          "nsfwLevel": 3,
+          "description": "<p>主观评价：相比于badv3，badv4能大大提高画质、构图、手部细节。通常情况下，一个badv4就能发挥出大量负面提示词的效果。</p><p>影响范围：画质、构图、人体结构和手</p><p>向量数：24</p><p>向量强度：0.7</p><p>缺点：会轻微添加厚涂风，并使画面轻微地变暖（橙色）</p><p>Subjective evaluation: Compared to badv3, badv4 can greatly improve image quality, composition, and hand details. In most cases, a single badv4 embedding can effectively represent a large number of negative prompts.</p><p>Effect area: quality, composition, anatomy, and hands.</p><p>Vector count: 24.</p><p>Vector strength: 0.7.</p><p>Disadvantages: A slight addition of impasto style and a slight warming (orange tint) of the tone.</p>",
+          "trainedWords": ["badv4"],
+          "stats": {
+            "downloadCount": 4756,
+            "ratingCount": 413,
+            "rating": 5,
+            "thumbsUpCount": 427,
+            "thumbsDownCount": 0
+          },
+          "files": [
+            {
+              "id": 25104,
+              "sizeKB": 72.7861328125,
+              "name": "badv4.pt",
+              "type": "Model",
+              "pickleScanResult": "Success",
+              "pickleScanMessage": "No Pickle imports",
+              "virusScanResult": "Success",
+              "virusScanMessage": null,
+              "scannedAt": "2023-03-28T01:36:25.212Z",
+              "metadata": {
+                "format": "PickleTensor",
+                "size": "full",
+                "fp": "fp16"
+              },
+              "hashes": {
+                "AutoV2": "FC4C4EE0F6",
+                "SHA256": "FC4C4EE0F65885201ABFC19601C97CA51D5DC4AA778E09C9A8FF800C78BCFABB",
+                "CRC32": "E022043C",
+                "BLAKE3": "DDED15B3F83A9E0B56A8FA597F562F4967545884818AD745DB44432DE3FDB3F7"
+              },
+              "downloadUrl": "https://civitai.com/api/download/models/30390",
+              "primary": true
+            }
+          ],
+          "images": [
+            {
+              "id": 345189,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/349070ca-b5cf-470f-0ce3-daee2fb4e600/width=450/345189.jpeg",
+              "nsfwLevel": 1,
+              "width": 1024,
+              "height": 858,
+              "hash": "UXIXms$Ns:xu_NWWWVSh-:oIjYs..8kCjsn$",
+              "type": "image"
+            },
+            {
+              "id": 345188,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/d220461a-3b9c-4fb7-44f3-38c5245f7e00/width=450/345188.jpeg",
+              "nsfwLevel": 1,
+              "width": 1024,
+              "height": 858,
+              "hash": "UaK0~U=^s.^i.ARke.Ip%#bGWVfP.8a#WVa}",
+              "type": "image"
+            },
+            {
+              "id": 345187,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/a33a2012-988d-463a-ee3c-4b895d18c000/width=450/345187.jpeg",
+              "nsfwLevel": 2,
+              "width": 1024,
+              "height": 858,
+              "hash": "UUF5puxZoLt7_4bHWBWB?cWVays:~qt7s:oL",
+              "type": "image"
+            },
+            {
+              "id": 345186,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/38a24440-b843-478b-5a85-dae813d18900/width=450/345186.jpeg",
+              "nsfwLevel": 2,
+              "width": 1024,
+              "height": 858,
+              "hash": "UNK^Qn-Uofb].TR+WVso?^ozWCWB?wM|WBfk",
+              "type": "image"
+            }
+          ],
+          "downloadUrl": "https://civitai.com/api/download/models/30390"
+        },
+        {
+          "id": 19837,
+          "index": 7,
+          "name": "badv3",
+          "baseModel": "Other",
+          "baseModelType": "Standard",
+          "publishedAt": "2023-03-07T13:33:20.741Z",
+          "availability": "Public",
+          "nsfwLevel": 3,
+          "description": "<p>主观评价：badv3 是较为<strong>基础</strong>的一款<strong>负面文本嵌入</strong>，其后的大多数负面文本嵌入都是基于它开发、融合或训练得到的。它适用于大部分情况。</p><p>影响范围：画质、构图和人体结构</p><p>向量数：8</p><p>向量强度：0.5</p><p>缺点：会导致画面轻微发绿</p><p>Subjective evaluation: badv3 is a <strong>basic negative text embedding</strong>, and most of the subsequent negative text embeddings are developed, merged or trained based on it. It is suitable for most situations.</p><p>Scope: image quality, composition, and human body structure</p><p>Vector count: 8</p><p>Vector strength: 0.5</p><p>Disadvantages: will cause the image to turn slightly green.</p>",
+          "trainedWords": ["badv3"],
+          "stats": {
+            "downloadCount": 3958,
+            "ratingCount": 244,
+            "rating": 5,
+            "thumbsUpCount": 248,
+            "thumbsDownCount": 0
+          },
+          "files": [
+            {
+              "id": 16552,
+              "sizeKB": 24.9169921875,
+              "name": "badv3.pt",
+              "type": "Model",
+              "pickleScanResult": "Success",
+              "pickleScanMessage": "No Pickle imports",
+              "virusScanResult": "Success",
+              "virusScanMessage": null,
+              "scannedAt": "2023-03-07T13:36:45.148Z",
+              "metadata": {
+                "format": "PickleTensor",
+                "size": "full",
+                "fp": "fp16"
+              },
+              "hashes": {
+                "AutoV2": "6319C89FAA",
+                "SHA256": "6319C89FAAE76CADD3B4B0D373CE6F3D425CE6C95710E05ED4ED18936B151168",
+                "CRC32": "23ABEB04",
+                "BLAKE3": "401DA9E8A52ABBD13CC7D7AD5C2C501DC2F071853FD6E5E08194F72E72242D06"
+              },
+              "downloadUrl": "https://civitai.com/api/download/models/19837",
+              "primary": true
+            }
+          ],
+          "images": [
+            {
+              "id": 208909,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/405ea05c-0e94-472b-4cf6-f5c247744a00/width=450/208909.jpeg",
+              "nsfwLevel": 2,
+              "width": 1280,
+              "height": 1176,
+              "hash": "UeL4KV%3bb?a.SNGjFM{~qjYaxt7?vWXflRj",
+              "type": "image"
+            },
+            {
+              "id": 208911,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/784fda46-7ae9-46e2-6dd2-cd4dec70d300/width=450/208911.jpeg",
+              "nsfwLevel": 1,
+              "width": 1024,
+              "height": 940,
+              "hash": "UgO:bIxvxut8~padV@ofu3bEbHae%hR.fRs:",
+              "type": "image"
+            },
+            {
+              "id": 208910,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/94b8c99e-a914-4d4c-34f5-3ab48a753300/width=450/208910.jpeg",
+              "nsfwLevel": 1,
+              "width": 1024,
+              "height": 940,
+              "hash": "UkLE+%o#fOR+_Nj?a}t6-oRkj?s:-Bn$aybH",
+              "type": "image"
+            }
+          ],
+          "downloadUrl": "https://civitai.com/api/download/models/19837"
+        },
+        {
+          "id": 53718,
+          "index": 8,
+          "name": "deformityv6",
+          "baseModel": "Other",
+          "baseModelType": "Standard",
+          "publishedAt": "2023-04-24T02:37:58.922Z",
+          "availability": "Public",
+          "nsfwLevel": 1,
+          "description": "<p>主观评价：deformityv6 是一个我早期制作的负面文本嵌入。它的效果不如本页面下的其他负面文本嵌入。它主要用于复现一些已知参数的图像。</p><p>作用范围：画质和不良解剖</p><p>向量数：2</p><p>向量强度：0.19</p><p>缺点：会轻微改变画风。</p><p>Subjective evaluation: deformityv6 is a negative text embedding I made earlier. It doesn't work as well as other negative text embeds under this page. It is mainly used to reproduce images with known parameters.</p><p>Scope: quality and anatomy</p><p>Vector count: 2</p><p>Vector strength: 0.19</p><p>Disadvantage: slightly change the image style</p>",
+          "trainedWords": ["deformityv6"],
+          "stats": {
+            "downloadCount": 13651,
+            "ratingCount": 406,
+            "rating": 4.99,
+            "thumbsUpCount": 482,
+            "thumbsDownCount": 0
+          },
+          "files": [
+            {
+              "id": 38981,
+              "sizeKB": 6.9794921875,
+              "name": "deformityv6.pt",
+              "type": "Model",
+              "pickleScanResult": "Success",
+              "pickleScanMessage": "No Pickle imports",
+              "virusScanResult": "Success",
+              "virusScanMessage": null,
+              "scannedAt": "2023-04-24T02:41:35.520Z",
+              "metadata": {
+                "format": "PickleTensor",
+                "size": null,
+                "fp": null
+              },
+              "hashes": {
+                "AutoV2": "8455EC9B3D",
+                "SHA256": "8455EC9B3D3127812AF89BDA72BFBB3574D1CD037694BD401A75460A6624E612",
+                "CRC32": "466C0D61",
+                "BLAKE3": "E9843C649B8738FA28553AEEF5E56DF9BEAD43339CF84C9A69424C03DE6489EB"
+              },
+              "downloadUrl": "https://civitai.com/api/download/models/53718",
+              "primary": true
+            }
+          ],
+          "images": [
+            {
+              "id": 581441,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/305a98a6-caf5-4a72-81e8-f5335e27ee00/width=450/581441.jpeg",
+              "nsfwLevel": 1,
+              "width": 1024,
+              "height": 940,
+              "hash": "UWNAuBR%jZM{^+V[ofRj.8xuRk%M_NbHofs:",
+              "type": "image"
+            },
+            {
+              "id": 581440,
+              "url": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/42496c27-8f54-48e5-f68d-103a4c408000/width=450/581440.jpeg",
+              "nsfwLevel": 1,
+              "width": 1024,
+              "height": 940,
+              "hash": "UiMQt^xuofWV~qayayoftRWBayj[_2ayj[Rj",
+              "type": "image"
+            }
+          ],
+          "downloadUrl": "https://civitai.com/api/download/models/53718"
+        }
+      ]
+    }
+  ],
+  "metadata": {
+    "nextCursor": "3674|35302|7625",
+    "nextPage": "https://civitai.com/api/v1/models?limit=20&nsfw=false&types=TextualInversion&cursor=3674%7C35302%7C7625"
+  }
+}

--- a/app/_hooks/useCivitai.tsx
+++ b/app/_hooks/useCivitai.tsx
@@ -9,7 +9,8 @@ import {
   getFavoriteEnhancements,
   getRecentlyUsedEnhancements
 } from '../_db/imageEnhancementModules'
-import LORAS from '../_components/AdvancedOptions/LoRAs/_LORAs.json'
+import LORASJson from '../_components/AdvancedOptions/LoRAs/_LORAs.json'
+import EmbeddingsJson from '../_components/AdvancedOptions/LoRAs/_Embeddings.json'
 import { Embedding } from '../_data-models/Civitai'
 
 const searchCache = new CacheMap({ limit: 30, expireMinutes: 20 })
@@ -148,11 +149,14 @@ export default function useCivitAi({
   const [totalItems, setTotalItems] = useState(-1) // Setting 0 here causes brief flash between loading finished and totalItems populated
   const [totalPages, setTotalPages] = useState(0)
 
-  const fetchRecentOrFavoriteLoras = async (type: 'favorite' | 'recent') => {
+  const fetchRecentOrFavoriteLoras = async (
+    searchType: 'favorite' | 'recent'
+  ) => {
+    const enhancmentType = type === 'LORA' ? 'lora' : 'ti'
     const results =
-      type === 'favorite'
-        ? await getFavoriteEnhancements('lora')
-        : await getRecentlyUsedEnhancements('lora')
+      searchType === 'favorite'
+        ? await getFavoriteEnhancements(enhancmentType)
+        : await getRecentlyUsedEnhancements(enhancmentType)
     const models = results.map((f) => f.model)
 
     setSearchResults(models as unknown as Embedding[])
@@ -197,9 +201,10 @@ export default function useCivitAi({
     } else if (searchType === 'recent') {
       fetchRecentOrFavoriteLoras('recent')
     } else if (searchType === 'search') {
-      setSearchResults(LORAS.items as unknown as Embedding[])
+      const defaultResults = type === 'LORA' ? LORASJson : EmbeddingsJson
+      setSearchResults(defaultResults.items as unknown as Embedding[])
     }
-  }, [searchType])
+  }, [searchType, type])
 
   useEffect(() => {
     // fetchCivitAiResults()

--- a/app/_hooks/useCivitai.tsx
+++ b/app/_hooks/useCivitai.tsx
@@ -204,7 +204,7 @@ export default function useCivitAi({
       const defaultResults = type === 'LORA' ? LORASJson : EmbeddingsJson
       setSearchResults(defaultResults.items as unknown as Embedding[])
     }
-  }, [searchType, type])
+  }, [fetchRecentOrFavoriteLoras, searchType, type])
 
   useEffect(() => {
     // fetchCivitAiResults()

--- a/app/_utils/arrayUtils.ts
+++ b/app/_utils/arrayUtils.ts
@@ -14,6 +14,24 @@ export const mergeArrays = (jsonData: JsonData): string[] => {
   return mergedArray
 }
 
+function isSavedEmbedding(
+  embedding: SavedEmbedding | SavedLora
+): embedding is SavedEmbedding {
+  return (
+    (embedding as SavedEmbedding)._civitAiType !== undefined &&
+    (embedding as SavedEmbedding)._civitAiType === 'TextualInversion'
+  )
+}
+
+function isSavedLora(
+  embedding: SavedEmbedding | SavedLora
+): embedding is SavedLora {
+  return (
+    (embedding as SavedLora)._civitAiType !== undefined &&
+    (embedding as SavedLora)._civitAiType === 'Lora'
+  )
+}
+
 export const flattenKeywords = (
   jsonData: SavedEmbedding[] | SavedLora[] = []
 ): string[] => {
@@ -21,9 +39,9 @@ export const flattenKeywords = (
     (acc: string[], embedding: SavedEmbedding | SavedLora) => {
       if (!embedding || !embedding.modelVersions) return acc
 
-      if (embedding._civitAiType === 'TextualInversion') {
+      if (isSavedEmbedding(embedding) && embedding.inject_ti === 'none') {
         acc = acc.concat(embedding.tags)
-      } else if (embedding.modelVersions.length > 0) {
+      } else if (isSavedLora(embedding) && embedding.modelVersions.length > 0) {
         // Flatten and concatenate the trainedWords of the first model version to the accumulator
         acc = acc.concat(embedding.modelVersions[0].trainedWords)
       }


### PR DESCRIPTION
Enhancements:

- Implements favorites and recents modals for TIs / embeddings
- Can now choose `inject_ti` location or custom location (ArtBot v1 did not handle this)
- Warning / reminder if using custom `inject_ti` and no ti tags are found within the prompt. 