### PR TITLE
LoRA related fixes: broken input fields, add sizes, page through CivitAI results

### DIFF
--- a/app/_api/civitai/models.ts
+++ b/app/_api/civitai/models.ts
@@ -1,0 +1,139 @@
+// civitaiService.ts
+
+import { CivitAiApiResponse } from '../../_types/CivitaiTypes'
+import { AppSettings } from '../../_data-models/AppSettings'
+import CacheMap from '../../_data-models/CacheMap'
+import { Embedding } from '@/app/_data-models/Civitai'
+
+const API_BASE_URL = 'https://civitai.com/api/v1'
+const SEARCH_CACHE_LIMIT = 30
+const SEARCH_CACHE_EXPIRE_MINUTES = 20
+const REQUEST_TIMEOUT_MS = 8000
+
+const searchCache = new CacheMap({
+  limit: SEARCH_CACHE_LIMIT,
+  expireMinutes: SEARCH_CACHE_EXPIRE_MINUTES
+})
+
+export type EnhancementType = 'LORA' | 'LoCon' | 'TextualInversion'
+
+export interface CivitAiMetadata {
+  nextCursor: string
+  nextPage: string
+  currentPage: number
+  pageSize: number
+}
+
+interface SearchParams {
+  input?: string
+  page?: number
+  limit?: number
+  type: EnhancementType
+  signal?: AbortSignal
+}
+
+const buildQuery = ({
+  input,
+  page = 1,
+  limit = 20,
+  type
+}: SearchParams): string => {
+  const userBaseModelFilters = AppSettings.get('civitAiBaseModelFilter')
+
+  // TODO: Figure out these questions
+  // do sd14 loras/tis work on sd15 models? sd0.9 stuff works with sd1.0 models...
+  // what about Turbo and LCM? 2.0 and 2.1? I'm just assuming 2.0 and 2.1 can be mixed, and 1.4 and 1.5 can be mixed, and lcm/turbo/not can be mixed. leave the rest to the user, maybe display that baseline somewhere.
+  // I dont think civitai lets you filter by model size, maybe you want to put that filter in the display code (allow 220mb loras only)
+  //  - except some workers have modified this. the colab worker has the limit removed, and my runpod is set to 750mb...
+
+  // Per this discussion on GitHub, this is an undocumented feature:
+  // https://github.com/orgs/civitai/discussions/733
+  // API response gives me the following valid values:
+  //  "'SD 1.4' | 'SD 1.5' | 'SD 1.5 LCM' | 'SD 2.0' | 'SD 2.0 768' | 'SD 2.1' | 'SD 2.1 768' | 'SD 2.1 Unclip' | 'SDXL 0.9' | 'SDXL 1.0' | 'SDXL 1.0 LCM' | 'SDXL Distilled' | 'SDXL Turbo' | 'SVD' | 'SVD XT' | 'Playground v2' | 'PixArt a' | 'Pony' | 'Other'"
+  let baseModelFilter
+
+  baseModelFilter = userBaseModelFilters.includes('SD 1.x')
+    ? ['1.4', '1.5', '1.5 LCM'].map((e) => '&baseModels=SD ' + e).join('')
+    : ''
+  baseModelFilter += userBaseModelFilters.includes('SD 2.x')
+    ? ['2.0', '2.0 768', '2.1', '2.1 768', '2.1 Unclip']
+        .map((e) => '&baseModels=SD ' + e)
+        .join('')
+    : ''
+  baseModelFilter += userBaseModelFilters.includes('SDXL')
+    ? ['0.9', '1.0', '1.0 LCM', 'Turbo']
+        .map((e) => '&baseModels=SDXL ' + e)
+        .join('')
+    : ''
+  baseModelFilter += userBaseModelFilters.includes('Pony')
+    ? '&baseModels=Pony'
+    : ''
+  baseModelFilter = baseModelFilter.replace(/ /g, '%20')
+
+  let searchTypes = 'types=LORA&types=LoCon'
+
+  if (type === 'TextualInversion') {
+    searchTypes = 'types=TextualInversion'
+  }
+
+  const query = input ? `&query=${input}` : ''
+  const searchKey = `limit=${limit}${query}&page=${page}&nsfw=${userBaseModelFilters.includes('NSFW')}${baseModelFilter}`
+  const searchParams = `${searchTypes}&sort=Highest%20Rated&${searchKey}`
+
+  return searchParams
+}
+
+export const getCivitaiSearchResults = async ({
+  input,
+  page = 1,
+  limit = 20,
+  type = 'LORA',
+  signal
+}: SearchParams): Promise<{
+  items: Embedding[]
+  metadata: CivitAiMetadata
+  error?: boolean
+}> => {
+  try {
+    const searchParams = buildQuery({ input, page, limit, type })
+
+    const cachedData = searchCache.get<CivitAiApiResponse>(searchParams)
+    if (cachedData) {
+      return {
+        items: cachedData.items || [],
+        metadata: cachedData.metadata || {}
+      }
+    }
+
+    const controller = new AbortController()
+    const timeoutId = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS)
+
+    // Use the provided signal if available, otherwise use our internal controller's signal
+    const fetchSignal = signal || controller.signal
+
+    const response = await fetch(`${API_BASE_URL}/models?${searchParams}`, {
+      signal: fetchSignal
+    })
+
+    clearTimeout(timeoutId)
+
+    if (!response.ok) {
+      throw new Error(`HTTP error! status: ${response.status}`)
+    }
+
+    const data: CivitAiApiResponse = await response.json()
+    searchCache.set(searchParams, data)
+
+    return {
+      items: data.items || [],
+      metadata: data.metadata || {}
+    }
+  } catch (error) {
+    if (error instanceof DOMException && error.name === 'AbortError') {
+      console.log('Request was aborted')
+      return { items: [], metadata: {} as CivitAiMetadata, error: true }
+    }
+    console.error('CivitAi Search Error - unable to fetch results:', error)
+    return { items: [], metadata: {} as CivitAiMetadata, error: true }
+  }
+}

--- a/app/_components/AdvancedOptions/LoRAs/AddLora.tsx
+++ b/app/_components/AdvancedOptions/LoRAs/AddLora.tsx
@@ -57,7 +57,7 @@ export default function AddLora() {
               NiceModal.show('modal', {
                 children: (
                   <Suspense>
-                    <LoraSearch onUseLoraClick={handleUseLoraClick} />,
+                    <LoraSearch onUseLoraClick={handleUseLoraClick} />
                   </Suspense>
                 ),
                 modalStyle: {

--- a/app/_components/AdvancedOptions/LoRAs/LoraDetails.tsx
+++ b/app/_components/AdvancedOptions/LoRAs/LoraDetails.tsx
@@ -4,6 +4,7 @@ import PageTitle from '../../PageTitle'
 import Carousel from '../../Carousel'
 import Button from '../../Button'
 import {
+  IconAlertTriangle,
   IconBox,
   IconDeviceFloppy,
   IconExternalLink,
@@ -29,6 +30,7 @@ import {
   SavedLora
 } from '@/app/_data-models/Civitai'
 import Link from 'next/link'
+import { AppConstants } from '@/app/_data-models/AppConstants'
 
 export default function LoraDetails({
   civitAiType = 'LORA',
@@ -128,6 +130,8 @@ export default function LoraDetails({
       value: version
     }
   })
+
+  console.log(`lora details`, details)
 
   return (
     <div>
@@ -270,7 +274,7 @@ export default function LoraDetails({
                 </div>
               </OptionLabel>
               {modelVersion?.description && (
-                <div className="w-full col">
+                <div className="w-full col gap-0">
                   <span className="row font-bold text-sm text-white gap-1">
                     Version details:
                   </span>
@@ -286,9 +290,47 @@ export default function LoraDetails({
                       fontWeight: 400,
                       gap: '8px',
                       maxWidth: '768px',
-                      padding: '8px'
+                      padding: '0 8px 8px 8px'
                     }}
                   />
+                </div>
+              )}
+              {modelVersion?.files?.length > 0 && (
+                <div className="w-full col gap-0">
+                  <span className="row font-bold text-sm text-white gap-1">
+                    Version size:
+                  </span>
+                  <span
+                    style={{
+                      fontSize: '14px'
+                    }}
+                  >
+                    {(modelVersion?.files[0].sizeKB / 1024).toFixed(2)} MB
+                  </span>
+                  {modelVersion?.files[0].sizeKB / 1024 >
+                    AppConstants.MAX_LORA_SIZE_MB && (
+                    <div
+                      className="col items-start gap-0 mt-2"
+                      style={{
+                        fontSize: '14px'
+                      }}
+                    >
+                      <div
+                        className="row items-start"
+                        style={{
+                          fontSize: '14px'
+                        }}
+                      >
+                        <IconAlertTriangle color="#db9200" />
+                        <strong>Warning:</strong>
+                      </div>
+                      <div>
+                        The selected version is larger than the AI Horde limit
+                        of 220 MB. Most GPU workers will not be able to utilize
+                        this {civitAiType === 'LORA' ? 'LoRA' : 'embedding'}.
+                      </div>
+                    </div>
+                  )}
                 </div>
               )}
             </Section>

--- a/app/_components/AdvancedOptions/LoRAs/LoraDetails.tsx
+++ b/app/_components/AdvancedOptions/LoRAs/LoraDetails.tsx
@@ -131,8 +131,6 @@ export default function LoraDetails({
     }
   })
 
-  console.log(`lora details`, details)
-
   return (
     <div>
       <div className="col w-full">

--- a/app/_components/AdvancedOptions/LoRAs/LoraImage.tsx
+++ b/app/_components/AdvancedOptions/LoRAs/LoraImage.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable @next/next/no-img-element */
-import React from 'react'
+import React, { useRef } from 'react'
 import styles from './loraSearch.module.css'
 import {
   Embedding,
@@ -10,6 +10,7 @@ import LoraDetails from './LoraDetails'
 import NiceModal from '@ebay/nice-modal-react'
 import { IconBox } from '@tabler/icons-react'
 import { AppSettings } from '@/app/_data-models/AppSettings'
+import useResizeObserver from '@/app/_hooks/useResizeObserver'
 
 interface LoraImageProps {
   civitAiType?: 'LORA' | 'TextualInversion'
@@ -26,16 +27,18 @@ interface LoraImageProps {
   }
 }
 
-const LoraImageV2 = ({
+const LoraImage = ({
   civitAiType = 'LORA',
   onUseLoraClick = () => {},
   image
 }: LoraImageProps) => {
+  const baseFilters = AppSettings.get('civitAiBaseModelFilter')
+  const containerRef = useRef<HTMLDivElement>(null)
+  const containerWidth = useResizeObserver(containerRef)
   if (!image) return null
 
-  const baseFilters = AppSettings.get('civitAiBaseModelFilter')
-  const aspectRatio = image.width / image.height
-  const paddingTop = `${(1 / aspectRatio) * 100}%`
+  // Maintain aspect ratio 320:400 -> 4:5
+  const height = (containerWidth / 4) * 5
 
   return (
     <div
@@ -52,12 +55,16 @@ const LoraImageV2 = ({
           id: 'LoraDetails'
         })
       }}
-      style={{ paddingTop }}
+      ref={containerRef}
+      style={{ width: '100%', height: `${height}px`, position: 'relative' }}
     >
       <img
         src={image.src}
         alt={image.name}
         style={{
+          width: '100%',
+          height: '100%',
+          objectFit: 'cover',
           filter:
             !baseFilters.includes('NSFW') && image.nsfwLevel >= 7
               ? 'blur(12px)'
@@ -114,4 +121,4 @@ const LoraImageV2 = ({
   )
 }
 
-export default LoraImageV2
+export default LoraImage

--- a/app/_components/AdvancedOptions/LoRAs/LoraImage.tsx
+++ b/app/_components/AdvancedOptions/LoRAs/LoraImage.tsx
@@ -56,7 +56,13 @@ const LoraImage = ({
         })
       }}
       ref={containerRef}
-      style={{ width: '100%', height: `${height}px`, position: 'relative' }}
+      style={{
+        width: '100%',
+        height: `${height}px`,
+        position: 'relative',
+        maxHeight: '400px',
+        maxWidth: '320px'
+      }}
     >
       <img
         src={image.src}

--- a/app/_components/AdvancedOptions/LoRAs/LoraSearch.tsx
+++ b/app/_components/AdvancedOptions/LoRAs/LoraSearch.tsx
@@ -2,6 +2,8 @@
 import NiceModal from '@ebay/nice-modal-react'
 import {
   IconArrowBarLeft,
+  // IconChevronLeft,
+  // IconChevronRight,
   IconDeviceFloppy,
   IconFilter,
   IconGrid3x3
@@ -30,9 +32,11 @@ export default function LoraSearch({
   searchType?: 'search' | 'favorite' | 'recent'
 }) {
   const {
+    // currentPage,
     fetchCivitAiResults,
     pendingSearch,
     searchResults,
+    // setCurrentPage,
     setPendingSearch
   } = useCivitAi({
     searchType,
@@ -62,6 +66,8 @@ export default function LoraSearch({
       }, 400)
     }
   }, [])
+
+  console.log('searchResults', searchResults)
 
   const transformedData = searchResults.map((embedding: Embedding) => {
     // TODO: Should probably find image with lowest NSFW rating.
@@ -216,6 +222,27 @@ export default function LoraSearch({
           ))}
         </MasonryLayout>
       </div>
+      {/* {(currentPage > 1 || hasNextPage) && (
+        <div className="w-full row justify-center gap-2">
+          <div
+            onClick={() => {
+              if (currentPage === 1) return
+              setCurrentPage(currentPage - 1)
+            }}
+          >
+            <IconChevronLeft />
+          </div>
+          <div>{currentPage}</div>
+          <div
+            onClick={() => {
+              if (!hasNextPage) return
+              setCurrentPage(currentPage + 1)
+            }}
+          >
+            <IconChevronRight />
+          </div>
+        </div>
+      )} */}
     </div>
   )
 }

--- a/app/_components/AdvancedOptions/LoRAs/LoraSearch.tsx
+++ b/app/_components/AdvancedOptions/LoRAs/LoraSearch.tsx
@@ -2,17 +2,16 @@
 import NiceModal from '@ebay/nice-modal-react'
 import {
   IconArrowBarLeft,
-  // IconChevronLeft,
-  // IconChevronRight,
+  IconChevronLeft,
+  IconChevronRight,
   IconDeviceFloppy,
   IconFilter,
   IconGrid3x3
 } from '@tabler/icons-react'
 
 import Button from '../../Button'
-import { useEffect, useMemo, useRef, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import useCivitAi from '@/app/_hooks/useCivitai'
-import { debounce } from '@/app/_utils/debounce'
 import LoraFilter from './LoraFilter'
 import LoraImage from './LoraImage'
 import {
@@ -21,6 +20,7 @@ import {
   SavedLora
 } from '@/app/_data-models/Civitai'
 import { MasonryLayout } from '../../Masonry'
+import clsx from 'clsx'
 
 export default function LoraSearch({
   civitAiType = 'LORA',
@@ -32,12 +32,15 @@ export default function LoraSearch({
   searchType?: 'search' | 'favorite' | 'recent'
 }) {
   const {
-    // currentPage,
-    fetchCivitAiResults,
+    currentPage,
+    debouncedSearchRequest,
+    // hasError,
     pendingSearch,
     searchResults,
-    // setCurrentPage,
-    setPendingSearch
+    goToNextPage,
+    goToPreviousPage,
+    hasNextPage,
+    hasPreviousPage
   } = useCivitAi({
     searchType,
     type: civitAiType
@@ -49,10 +52,10 @@ export default function LoraSearch({
   const [searchInput, setSearchInput] = useState('')
   const [showFilter, setShowFilter] = useState(false)
 
-  // Memoize the debounced function so it doesn't get recreated on every render
-  const debouncedSearchRequest = useMemo(() => {
-    return debounce(fetchCivitAiResults, 750)
-  }, [fetchCivitAiResults])
+  // // Memoize the debounced function so it doesn't get recreated on every render
+  // const debouncedSearchRequest = useMemo(() => {
+  //   return debounce(fetchCivitAiResults, 750)
+  // }, [fetchCivitAiResults])
 
   useEffect(() => {
     if (inputVersionId || !searchInput.trim()) return
@@ -130,7 +133,7 @@ export default function LoraSearch({
           placeholder={placeholder}
           onChange={(e) => {
             if (e.target.value.trim()) {
-              setPendingSearch(true)
+              debouncedSearchRequest(e.target.value.trim())
             }
 
             setSearchInput(e.target.value)
@@ -220,27 +223,32 @@ export default function LoraSearch({
           ))}
         </MasonryLayout>
       </div>
-      {/* {(currentPage > 1 || hasNextPage) && (
+      {(hasPreviousPage || hasNextPage) && (
         <div className="w-full row justify-center gap-2">
           <div
+            className={clsx(
+              'cursor-pointer',
+              hasPreviousPage && 'primary-color'
+            )}
             onClick={() => {
-              if (currentPage === 1) return
-              setCurrentPage(currentPage - 1)
+              if (!hasPreviousPage) return
+              goToPreviousPage()
             }}
           >
             <IconChevronLeft />
           </div>
           <div>{currentPage}</div>
           <div
+            className={clsx('cursor-pointer', hasNextPage && 'primary-color')}
             onClick={() => {
               if (!hasNextPage) return
-              setCurrentPage(currentPage + 1)
+              goToNextPage()
             }}
           >
             <IconChevronRight />
           </div>
         </div>
-      )} */}
+      )}
     </div>
   )
 }

--- a/app/_components/AdvancedOptions/LoRAs/LoraSearch.tsx
+++ b/app/_components/AdvancedOptions/LoRAs/LoraSearch.tsx
@@ -18,7 +18,7 @@ import {
   SavedEmbedding,
   SavedLora
 } from '@/app/_data-models/Civitai'
-import { MasonryItem, MasonryLayout } from '../../Masonry'
+import { MasonryLayout } from '../../Masonry'
 
 export default function LoraSearch({
   civitAiType = 'LORA',
@@ -38,6 +38,8 @@ export default function LoraSearch({
     searchType,
     type: civitAiType
   })
+
+  const modalRef = useRef<HTMLDivElement>(null)
   const inputRef = useRef<HTMLInputElement>(null)
   const [inputVersionId, setInputVersionId] = useState(false)
   const [searchInput, setSearchInput] = useState('')
@@ -102,7 +104,7 @@ export default function LoraSearch({
   }
 
   return (
-    <div className="col w-full h-full">
+    <div className="col w-full h-full" ref={modalRef}>
       <h2 className="row font-bold">
         {title} <span className="text-xs font-normal">(via CivitAI)</span>
       </h2>
@@ -199,15 +201,18 @@ export default function LoraSearch({
         </div>
       )}
       <div>
-        <MasonryLayout>
+        <MasonryLayout containerRef={modalRef}>
           {transformedData.map((image) => (
-            <MasonryItem key={`${image.key}`}>
+            <div
+              key={`${image.key}`}
+              style={{ width: '100%', marginBottom: '20px' }}
+            >
               <LoraImage
                 civitAiType={civitAiType}
                 onUseLoraClick={onUseLoraClick}
                 image={image}
               />
-            </MasonryItem>
+            </div>
           ))}
         </MasonryLayout>
       </div>

--- a/app/_components/AdvancedOptions/LoRAs/LoraSearch.tsx
+++ b/app/_components/AdvancedOptions/LoRAs/LoraSearch.tsx
@@ -67,13 +67,11 @@ export default function LoraSearch({
     }
   }, [])
 
-  console.log('searchResults', searchResults)
-
   const transformedData = searchResults.map((embedding: Embedding) => {
     // TODO: Should probably find image with lowest NSFW rating.
     // Extracting the first model version and its first image
-    const firstModelVersion = embedding.modelVersions[0]
-    const firstImage = firstModelVersion.images[0]
+    const firstModelVersion = embedding.modelVersions[0] || {}
+    const firstImage = firstModelVersion.images[0] || {}
 
     const photoData = {
       key: String(embedding.id), // Ensuring the key is a string

--- a/app/_components/AdvancedOptions/LoRAs/LoraSettingsCard.tsx
+++ b/app/_components/AdvancedOptions/LoRAs/LoraSettingsCard.tsx
@@ -15,6 +15,10 @@ interface UpdateSaveLoraParams {
   updates: Partial<SavedLora>
 }
 
+function roundToNearest005(value: number): number {
+  return Math.round(value * 20) / 20
+}
+
 // Function to update specified properties of a SaveLora instance in an array
 function updateSaveLoraProperty({
   loras,
@@ -50,8 +54,8 @@ function updateSaveLoraProperty({
 
 export default function LoraSettingsCard({ lora }: { lora: SavedLora }) {
   const { input, setInput } = useInput()
-  const [strength, setStrength] = useState(lora.strength)
-  const [clip, setClip] = useState(lora.clip)
+  const [strength, setStrength] = useState<string>(lora.strength.toString())
+  const [clip, setClip] = useState<string>(lora.clip.toString())
 
   const loraIndex = input.loras.findIndex(
     (l) => String(l.versionId) === String(lora.versionId)
@@ -65,21 +69,32 @@ export default function LoraSettingsCard({ lora }: { lora: SavedLora }) {
     setInput({ loras: updateLoras })
   }
 
-  const handleUpdateLora = (type: 'strength' | 'clip', value: number) => {
-    // Map through the loras array and update the specific Lora
-    const updateLoras = input.loras.map((l) => {
-      if (String(l.versionId) === String(lora.versionId)) {
-        // Return a new instance of SaveLora with the updated property
-        return new SavedLora({
-          ...l,
-          [type]: parseFloat(value.toFixed(2)) // Ensure the value is correctly formatted
-        })
-      }
-      return l // Return the unchanged Lora
-    })
+  const handleUpdateLora = (type: 'strength' | 'clip', value: string) => {
+    if (value === '') {
+      if (type === 'strength') setStrength('')
+      else setClip('')
+    } else {
+      const numericValue = parseFloat(value)
+      if (!isNaN(numericValue)) {
+        const roundedValue = roundToNearest005(numericValue)
+        const formattedValue = parseFloat(roundedValue.toFixed(2))
 
-    setStrength(value)
-    setInput({ loras: updateLoras })
+        const updateLoras = input.loras.map((l) => {
+          if (String(l.versionId) === String(lora.versionId)) {
+            return new SavedLora({
+              ...l,
+              [type]: formattedValue
+            })
+          }
+          return l
+        })
+
+        if (type === 'strength') setStrength(formattedValue.toString())
+        else setClip(formattedValue.toString())
+
+        setInput({ loras: updateLoras })
+      }
+    }
   }
 
   const currentVersion = lora.modelVersions.filter(
@@ -160,60 +175,37 @@ export default function LoraSettingsCard({ lora }: { lora: SavedLora }) {
             min={-5.0}
             max={5.0}
             onBlur={() => {
-              if (isNaN(strength)) {
-                setStrength(1.0)
+              if (strength === '' || isNaN(parseFloat(strength))) {
+                setStrength(lora.strength.toString())
               } else {
+                const roundedValue = roundToNearest005(parseFloat(strength))
+                const formattedValue = parseFloat(roundedValue.toFixed(2))
                 const updatedLoras = updateSaveLoraProperty({
                   loras: input.loras,
                   index: loraIndex,
-                  updates: { strength: parseFloat(Number(strength).toFixed(2)) }
+                  updates: { strength: formattedValue }
                 })
 
-                setStrength(parseFloat(Number(strength).toFixed(2)))
-                setInput({
-                  loras: updatedLoras
-                })
+                setStrength(formattedValue.toString())
+                setInput({ loras: updatedLoras })
               }
             }}
-            onChange={(num) => {
-              handleUpdateLora('strength', num as unknown as number)
+            onChange={(value) => {
+              handleUpdateLora('strength', value as string)
             }}
             onMinusClick={() => {
-              if (Number(strength) - 0.05 < -5.0) {
-                return
-              }
-              const updatedLoras = updateSaveLoraProperty({
-                loras: input.loras,
-                index: loraIndex,
-                updates: {
-                  strength: parseFloat(Number(strength - 0.05).toFixed(2))
-                }
-              })
-
-              setStrength(parseFloat(Number(strength - 0.05).toFixed(2)))
-              setInput({
-                loras: updatedLoras
-              })
+              const currentValue = parseFloat(strength) || 0
+              if (currentValue - 0.05 < -5.0) return
+              const newValue = roundToNearest005(currentValue - 0.05)
+              handleUpdateLora('strength', newValue.toString())
             }}
             onPlusClick={() => {
-              if (Number(strength) + 0.05 > 5.0) {
-                return
-              }
-
-              const updatedLoras = updateSaveLoraProperty({
-                loras: input.loras,
-                index: loraIndex,
-                updates: {
-                  strength: parseFloat(Number(strength + 0.05).toFixed(2))
-                }
-              })
-
-              setStrength(parseFloat(Number(strength + 0.05).toFixed(2)))
-              setInput({
-                loras: updatedLoras
-              })
+              const currentValue = parseFloat(strength) || 0
+              if (currentValue + 0.05 > 5.0) return
+              const newValue = roundToNearest005(currentValue + 0.05)
+              handleUpdateLora('strength', newValue.toString())
             }}
-            value={lora.strength}
+            value={strength as unknown as number}
           />
         </div>
       </OptionLabel>
@@ -228,63 +220,37 @@ export default function LoraSettingsCard({ lora }: { lora: SavedLora }) {
             min={-5.0}
             max={5.0}
             onBlur={() => {
-              if (isNaN(clip)) {
-                setClip(1.0)
+              if (clip === '' || isNaN(parseFloat(clip))) {
+                setClip(lora.clip.toString())
               } else {
+                const roundedValue = roundToNearest005(parseFloat(clip))
+                const formattedValue = parseFloat(roundedValue.toFixed(2))
                 const updatedLoras = updateSaveLoraProperty({
                   loras: input.loras,
                   index: loraIndex,
-                  updates: {
-                    clip: parseFloat(Number(clip).toFixed(2))
-                  }
+                  updates: { clip: formattedValue }
                 })
 
-                setClip(parseFloat(Number(clip).toFixed(2)))
-                setInput({
-                  loras: updatedLoras
-                })
+                setClip(formattedValue.toString())
+                setInput({ loras: updatedLoras })
               }
             }}
-            onChange={(num) => {
-              handleUpdateLora('clip', num as unknown as number)
+            onChange={(value) => {
+              handleUpdateLora('clip', value as string)
             }}
             onMinusClick={() => {
-              if (Number(clip) - 0.05 < -5.0) {
-                return
-              }
-
-              const updatedLoras = updateSaveLoraProperty({
-                loras: input.loras,
-                index: loraIndex,
-                updates: {
-                  clip: parseFloat(Number(clip - 0.05).toFixed(2))
-                }
-              })
-
-              setClip(parseFloat(Number(clip - 0.05).toFixed(2)))
-              setInput({
-                loras: updatedLoras
-              })
+              const currentValue = parseFloat(clip) || 0
+              if (currentValue - 0.05 < -5.0) return
+              const newValue = roundToNearest005(currentValue - 0.05)
+              handleUpdateLora('clip', newValue.toString())
             }}
             onPlusClick={() => {
-              if (Number(clip) + 0.05 > 5.0) {
-                return
-              }
-
-              const updatedLoras = updateSaveLoraProperty({
-                loras: input.loras,
-                index: loraIndex,
-                updates: {
-                  clip: parseFloat(Number(clip + 0.05).toFixed(2))
-                }
-              })
-
-              setClip(parseFloat(Number(clip + 0.05).toFixed(2)))
-              setInput({
-                loras: updatedLoras
-              })
+              const currentValue = parseFloat(clip) || 0
+              if (currentValue + 0.05 > 5.0) return
+              const newValue = roundToNearest005(currentValue + 0.05)
+              handleUpdateLora('clip', newValue.toString())
             }}
-            value={lora.clip}
+            value={clip as unknown as number}
           />
         </div>
       </OptionLabel>

--- a/app/_components/AdvancedOptions/LoRAs/LoraSettingsCard.tsx
+++ b/app/_components/AdvancedOptions/LoRAs/LoraSettingsCard.tsx
@@ -104,7 +104,7 @@ export default function LoraSettingsCard({ lora }: { lora: SavedLora }) {
   return (
     <div className="rounded bg-[#1d4d74] p-2 col">
       <div className="w-full row justify-between text-sm font-mono font-bold text-white">
-        {lora.isArtbotManualEntry ? (
+        {lora.isArtbotManualEntry && lora.id !== '247778' ? (
           <span>LoRA by Version ID: {lora.name}</span>
         ) : (
           <span>{lora.name}</span>

--- a/app/_components/AdvancedOptions/LoRAs/loraSearch.module.css
+++ b/app/_components/AdvancedOptions/LoRAs/loraSearch.module.css
@@ -1,4 +1,5 @@
 .image-item {
+  cursor: pointer;
   position: relative;
   width: 100%;
   padding-top: 100%;

--- a/app/_components/ImageDetails.tsx
+++ b/app/_components/ImageDetails.tsx
@@ -182,7 +182,7 @@ export default function ImageDetails({
                     </div>
                     <div className="row">
                       <strong>CLIP: </strong>
-                      {lora.strength}
+                      {lora.clip}
                     </div>
                   </div>
                 )

--- a/app/_components/Masonry/MasonryLayout.tsx
+++ b/app/_components/Masonry/MasonryLayout.tsx
@@ -1,16 +1,21 @@
 'use client'
 
-import { useWindowSize } from '@/app/_hooks/useWindowSize'
-import { ReactNode, ReactElement, Children } from 'react'
+import { useContainerWidth } from '@/app/_hooks/useContainerWidth'
+import { ReactNode, ReactElement, Children, useRef, RefObject } from 'react'
+
+interface MasonryLayoutProps {
+  children: ReactNode
+  gap?: number
+  containerRef?: RefObject<HTMLDivElement>
+}
 
 const MasonryLayout = ({
   children,
-  gap = 20
-}: {
-  children: ReactNode
-  gap?: number
-}) => {
-  const { width } = useWindowSize()
+  gap = 20,
+  containerRef
+}: MasonryLayoutProps) => {
+  const defaultRef = useRef<HTMLDivElement>(null)
+  const width = useContainerWidth(containerRef || defaultRef)
 
   if (!children || !width) return null
 
@@ -71,7 +76,11 @@ const MasonryLayout = ({
     )
   }
 
-  return <div style={{ display: 'flex' }}>{result}</div>
+  return (
+    <div style={{ display: 'flex' }} ref={containerRef || defaultRef}>
+      {result}
+    </div>
+  )
 }
 
 export default MasonryLayout

--- a/app/_data-models/AppConstants.ts
+++ b/app/_data-models/AppConstants.ts
@@ -18,4 +18,6 @@ export class AppConstants {
    * Maximum supported resolution for image requests to the AI Horde
    */
   static MAX_IMAGE_PIXELS = 4194304
+
+  static MAX_LORA_SIZE_MB = 220
 }

--- a/app/_data-models/PromptInput.test.ts
+++ b/app/_data-models/PromptInput.test.ts
@@ -7,7 +7,7 @@ describe('PromptInput', () => {
     const defaultPromptInput = new PromptInput()
 
     expect(defaultPromptInput.artbot_id).toBe('')
-    expect(defaultPromptInput.cfg_scale).toBe(5)
+    expect(defaultPromptInput.cfg_scale).toBe(2)
     expect(defaultPromptInput.clipskip).toBe(1)
     expect(defaultPromptInput.control_type).toBe('')
     expect(defaultPromptInput.denoising_strength).toBe(0.75)
@@ -21,7 +21,7 @@ describe('PromptInput', () => {
     expect(defaultPromptInput.imageType).toBe('')
     expect(defaultPromptInput.jobType).toBe(JobType.Text2Img)
     expect(defaultPromptInput.karras).toBe(true)
-    expect(defaultPromptInput.loras).toEqual([])
+    expect(defaultPromptInput.loras.length).toEqual(1)
     expect(defaultPromptInput.models).toEqual(['AlbedoBase XL (SDXL)'])
     expect(defaultPromptInput.negative).toBe('')
     expect(defaultPromptInput.numImages).toBe(1)
@@ -33,7 +33,7 @@ describe('PromptInput', () => {
     expect(defaultPromptInput.sampler).toBe('k_dpmpp_sde')
     expect(defaultPromptInput.seed).toBe('')
     expect(defaultPromptInput.source_processing).toBe(SourceProcessing.Prompt)
-    expect(defaultPromptInput.steps).toBe(20)
+    expect(defaultPromptInput.steps).toBe(8)
     expect(defaultPromptInput.tiling).toBe(false)
     expect(defaultPromptInput.tis).toEqual([])
     expect(defaultPromptInput.triggers).toEqual([])
@@ -60,7 +60,7 @@ describe('PromptInput', () => {
 
   it('should initialize with empty object', () => {
     const defaultPromptInput = new PromptInput({})
-    expect(defaultPromptInput.cfg_scale).toBe(5)
+    expect(defaultPromptInput.cfg_scale).toBe(2)
     expect(defaultPromptInput.height).toBe(1024)
     expect(defaultPromptInput.width).toBe(1024)
     expect(defaultPromptInput.jobType).toBe(JobType.Text2Img)
@@ -76,6 +76,5 @@ describe('PromptInput', () => {
     expect(defaultPromptInput.extra_texts).toEqual([
       { text: 'example', reference: 'ref' }
     ])
-    expect(defaultPromptInput.loras).toEqual([])
   })
 })

--- a/app/_data-models/PromptInput.ts
+++ b/app/_data-models/PromptInput.ts
@@ -11,7 +11,7 @@ class PromptInput {
   artbot_id: string = ''
 
   // Fields used for AI Horde image requests
-  cfg_scale: number = 5
+  cfg_scale: number = 2
   clipskip: number = 1
   control_type?: ControlTypes = '' as ControlTypes
   denoising_strength?: number | '' = 0.75
@@ -28,7 +28,18 @@ class PromptInput {
   imageType: string = ''
   jobType: JobType = JobType.Text2Img
   karras: boolean = true
-  loras: SavedLora[] = []
+  loras: SavedLora[] = [
+    new SavedLora({
+      id: '247778',
+      civitAiType: 'LORA',
+      versionId: '247778',
+      versionName: '',
+      isArtbotManualEntry: true,
+      name: 'SDXL | LCM TurboMix LoRA (SDE sampler)',
+      strength: 1,
+      clip: 1
+    })
+  ]
   models: Array<string> = ['AlbedoBase XL (SDXL)']
   modelDetails: {
     baseline: string
@@ -50,7 +61,7 @@ class PromptInput {
   sampler: string = 'k_dpmpp_sde'
   seed: string = ''
   source_processing?: SourceProcessing = SourceProcessing.Prompt
-  steps: number = 20
+  steps: number = 8
   tiling: boolean = false
   tis: SavedEmbedding[] = []
   transparent: boolean = false

--- a/app/_hooks/useCivitai.tsx
+++ b/app/_hooks/useCivitai.tsx
@@ -1,10 +1,5 @@
-// CivitAi API reference: https://github.com/civitai/civitai/wiki/REST-API-Reference
-
-import { useCallback, useEffect, useState } from 'react'
-import { AppSettings } from '../_data-models/AppSettings'
-import { debounce } from '../_utils/debounce'
-import CacheMap from '../_data-models/CacheMap'
-import { CivitAiApiResponse } from '../_types/CivitaiTypes'
+import { useState, useCallback, useRef, useEffect } from 'react'
+import { DebouncedFunction, debounce } from '../_utils/debounce'
 import {
   getFavoriteEnhancements,
   getRecentlyUsedEnhancements
@@ -12,153 +7,46 @@ import {
 import LORASJson from '../_components/AdvancedOptions/LoRAs/_LORAs.json'
 import EmbeddingsJson from '../_components/AdvancedOptions/LoRAs/_Embeddings.json'
 import { Embedding } from '../_data-models/Civitai'
+import {
+  EnhancementType,
+  getCivitaiSearchResults
+} from '../_api/civitai/models'
 
-const searchCache = new CacheMap({ limit: 30, expireMinutes: 20 })
-
-let pendingRequest = false
-const buildQuery = ({
-  input,
-  page = 1,
-  limit = 20,
-  type = 'LORA'
-}: {
-  input?: string
-  page?: number
-  limit?: number
-  type?: 'LoCon' | 'LORA' | 'TextualInversion'
-}) => {
-  const userBaseModelFilters = AppSettings.get('civitAiBaseModelFilter')
-
-  // TODO: Figure out these questions
-  // do sd14 loras/tis work on sd15 models? sd0.9 stuff works with sd1.0 models...
-  // what about Turbo and LCM? 2.0 and 2.1? I'm just assuming 2.0 and 2.1 can be mixed, and 1.4 and 1.5 can be mixed, and lcm/turbo/not can be mixed. leave the rest to the user, maybe display that baseline somewhere.
-  // I dont think civitai lets you filter by model size, maybe you want to put that filter in the display code (allow 220mb loras only)
-  //  - except some workers have modified this. the colab worker has the limit removed, and my runpod is set to 750mb...
-
-  // Per this discussion on GitHub, this is an undocumented feature:
-  // https://github.com/orgs/civitai/discussions/733
-  // API response gives me the following valid values:
-  //  "'SD 1.4' | 'SD 1.5' | 'SD 1.5 LCM' | 'SD 2.0' | 'SD 2.0 768' | 'SD 2.1' | 'SD 2.1 768' | 'SD 2.1 Unclip' | 'SDXL 0.9' | 'SDXL 1.0' | 'SDXL 1.0 LCM' | 'SDXL Distilled' | 'SDXL Turbo' | 'SVD' | 'SVD XT' | 'Playground v2' | 'PixArt a' | 'Pony' | 'Other'"
-  let baseModelFilter
-
-  baseModelFilter = userBaseModelFilters.includes('SD 1.x')
-    ? ['1.4', '1.5', '1.5 LCM'].map((e) => '&baseModels=SD ' + e).join('')
-    : ''
-  baseModelFilter += userBaseModelFilters.includes('SD 2.x')
-    ? ['2.0', '2.0 768', '2.1', '2.1 768', '2.1 Unclip']
-        .map((e) => '&baseModels=SD ' + e)
-        .join('')
-    : ''
-  baseModelFilter += userBaseModelFilters.includes('SDXL')
-    ? ['0.9', '1.0', '1.0 LCM', 'Turbo']
-        .map((e) => '&baseModels=SDXL ' + e)
-        .join('')
-    : ''
-  baseModelFilter += userBaseModelFilters.includes('Pony')
-    ? '&baseModels=Pony'
-    : ''
-  baseModelFilter = baseModelFilter.replace(/ /g, '%20')
-
-  let searchTypes = 'types=LORA&types=LoCon'
-
-  if (type === 'TextualInversion') {
-    searchTypes = 'types=TextualInversion'
-  }
-
-  const query = input ? `&query=${input}` : ''
-  const searchKey = `limit=${limit}${query}&page=${page}&nsfw=${userBaseModelFilters.includes('NSFW')}${baseModelFilter}`
-  const searchParams = `${searchTypes}&sort=Highest%20Rated&${searchKey}`
-
-  return searchParams
-}
-
-// Hacky implementation of a throttled search.
-const getCivitaiSearchResults = async ({
-  input,
-  page = 1,
-  limit = 20,
-  type = 'LORA'
-}: {
-  input?: string
-  page?: number
-  limit?: number
-  type?: 'LoCon' | 'LORA' | 'TextualInversion'
-}) => {
-  try {
-    if (pendingRequest) return false
-
-    pendingRequest = true
-
-    // Use AbortController to timeout long responses from CivitAI
-    const controller = new AbortController()
-    const signal = controller.signal
-
-    const searchParams = buildQuery({
-      input,
-      page,
-      limit,
-      type
-    })
-
-    if (searchCache.get(searchParams)) {
-      const data = searchCache.get<CivitAiApiResponse>(searchParams)
-      if (data) {
-        const { items = [], metadata = {} } = data
-        pendingRequest = false
-        return { items, metadata }
-      }
-    }
-
-    const timeout = setTimeout(() => {
-      controller.abort()
-      pendingRequest = false
-      console.error('CivitAi Search Error - Request timed out.')
-    }, 8000)
-
-    const response = await fetch(
-      `https://civitai.com/api/v1/models?${searchParams}`,
-      { signal }
-    )
-    clearTimeout(timeout)
-
-    const data = await response.json()
-    searchCache.set(searchParams, data)
-
-    const { items = [], metadata = {} } = data
-    pendingRequest = false
-    return { items, metadata }
-  } catch (error) {
-    console.error('CivitAi Search Error - unable to fetch results:', error)
-    pendingRequest = false
-    return { items: [], metadata: {}, error: true }
-  }
-}
+export type SearchType = 'search' | 'favorite' | 'recent'
 
 export default function useCivitAi({
   searchType = 'search',
-  type
+  type = 'LORA'
 }: {
-  searchType?: 'search' | 'favorite' | 'recent'
-  type: 'LORA' | 'TextualInversion'
+  searchType?: SearchType
+  type: EnhancementType
 }) {
   const [pendingSearch, setPendingSearch] = useState(false)
   const [searchResults, setSearchResults] = useState<Embedding[]>([])
-
   const [hasError, setHasError] = useState<string | boolean>(false)
   const [currentPage, setCurrentPage] = useState(1)
-  const [totalItems, setTotalItems] = useState(-1) // Setting 0 here causes brief flash between loading finished and totalItems populated
-  const [totalPages, setTotalPages] = useState(0)
+  // const [totalItems, setTotalItems] = useState(-1)
+  // const [totalPages, setTotalPages] = useState(0)
+
+  const abortControllerRef = useRef<AbortController | null>(null)
+  const debouncedSearchRef = useRef<DebouncedFunction<
+    typeof fetchCivitAiResults
+  > | null>(null)
 
   const fetchRecentOrFavoriteLoras = useCallback(
     async (searchType: 'favorite' | 'recent') => {
-      const enhancmentType = type === 'LORA' ? 'lora' : 'ti'
-      const results =
-        searchType === 'favorite'
-          ? await getFavoriteEnhancements(enhancmentType)
-          : await getRecentlyUsedEnhancements(enhancmentType)
-      const models = results.map((f) => f.model)
-
-      setSearchResults(models as unknown as Embedding[])
+      const enhancementType = type === 'LORA' ? 'lora' : 'ti'
+      try {
+        const results =
+          searchType === 'favorite'
+            ? await getFavoriteEnhancements(enhancementType)
+            : await getRecentlyUsedEnhancements(enhancementType)
+        const models = results.map((f) => f.model)
+        setSearchResults(models as unknown as Embedding[])
+      } catch (error) {
+        console.error('Error fetching recent or favorite LORAs:', error)
+        setHasError('Unable to load recent or favorite enhancements.')
+      }
     },
     [type]
   )
@@ -166,35 +54,61 @@ export default function useCivitAi({
   const fetchCivitAiResults = useCallback(
     async (input?: string) => {
       setPendingSearch(true)
-      const result = await getCivitaiSearchResults({
-        input,
-        page: 1,
-        type
-      })
+      setHasError(false)
 
-      // Happens due to _dev_ environment firing calls twice
-      if (result === false) return
-
-      const { items = [], metadata = {}, error } = result
-
-      if (error) {
-        setHasError(
-          'Unable to load data from CivitAI, please try again shortly.'
-        )
-        setPendingSearch(false)
-        return
+      if (abortControllerRef.current) {
+        abortControllerRef.current.abort()
       }
 
-      setSearchResults(items)
-      setTotalItems(metadata.totalItems)
-      setTotalPages(metadata.totalPages)
+      abortControllerRef.current = new AbortController()
 
-      setPendingSearch(false)
+      try {
+        const result = await getCivitaiSearchResults({
+          input,
+          page: 1,
+          type,
+          signal: abortControllerRef.current.signal
+        })
+
+        if (result.error) {
+          setHasError(
+            'Unable to load data from CivitAI, please try again shortly.'
+          )
+        } else {
+          setSearchResults(result.items)
+          // setTotalItems(result.metadata.totalItems)
+          // setTotalPages(result.metadata.totalPages)
+        }
+      } catch (error) {
+        if (error instanceof DOMException && error.name === 'AbortError') {
+          console.log('Request was aborted')
+        } else {
+          setHasError('An error occurred while fetching data.')
+          console.error('Error fetching CivitAI results:', error)
+        }
+      } finally {
+        setPendingSearch(false)
+      }
     },
     [type]
   )
 
-  const debouncedSearchRequest = debounce(fetchCivitAiResults, 500)
+  useEffect(() => {
+    debouncedSearchRef.current = debounce(fetchCivitAiResults, 500)
+
+    return () => {
+      if (debouncedSearchRef.current) {
+        debouncedSearchRef.current.cancel()
+      }
+    }
+  }, [fetchCivitAiResults])
+
+  // Expose a function to trigger the debounced search
+  const debouncedSearchRequest = useCallback((input?: string) => {
+    if (debouncedSearchRef.current) {
+      debouncedSearchRef.current(input)
+    }
+  }, [])
 
   useEffect(() => {
     if (searchType === 'favorite') {
@@ -208,9 +122,14 @@ export default function useCivitAi({
   }, [fetchRecentOrFavoriteLoras, searchType, type])
 
   useEffect(() => {
-    // fetchCivitAiResults()
-    // Ignore dependency array warning - we only want to fetch models once on initial load.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
+    return () => {
+      if (abortControllerRef.current) {
+        abortControllerRef.current.abort()
+      }
+      if (debouncedSearchRef.current) {
+        debouncedSearchRef.current.cancel()
+      }
+    }
   }, [])
 
   return {
@@ -221,8 +140,8 @@ export default function useCivitAi({
     pendingSearch,
     searchResults,
     setCurrentPage,
-    setPendingSearch,
-    totalItems,
-    totalPages
+    setPendingSearch
+    // totalItems,
+    // totalPages
   }
 }

--- a/app/_hooks/useContainerWidth.tsx
+++ b/app/_hooks/useContainerWidth.tsx
@@ -1,0 +1,25 @@
+// useContainerWidth.ts
+import { useState, useEffect, RefObject } from 'react'
+
+export const useContainerWidth = (containerRef: RefObject<HTMLDivElement>) => {
+  const [width, setWidth] = useState<number | null>(null)
+
+  useEffect(() => {
+    const handleResize = () => {
+      if (containerRef.current) {
+        setWidth(containerRef.current.offsetWidth)
+      } else {
+        setWidth(window.innerWidth)
+      }
+    }
+
+    handleResize()
+    window.addEventListener('resize', handleResize)
+
+    return () => {
+      window.removeEventListener('resize', handleResize)
+    }
+  }, [containerRef])
+
+  return width
+}

--- a/app/_hooks/useResizeObserver.tsx
+++ b/app/_hooks/useResizeObserver.tsx
@@ -1,0 +1,28 @@
+import { useEffect, useState, RefObject } from 'react'
+
+const useResizeObserver = (ref: RefObject<HTMLElement>) => {
+  const [width, setWidth] = useState(0)
+
+  useEffect(() => {
+    const observedElement = ref.current
+    const resizeObserver = new ResizeObserver((entries) => {
+      if (entries[0]) {
+        setWidth(entries[0].contentRect.width)
+      }
+    })
+
+    if (observedElement) {
+      resizeObserver.observe(observedElement)
+    }
+
+    return () => {
+      if (observedElement) {
+        resizeObserver.unobserve(observedElement)
+      }
+    }
+  }, [ref])
+
+  return width
+}
+
+export default useResizeObserver

--- a/app/_utils/debounce.ts
+++ b/app/_utils/debounce.ts
@@ -1,17 +1,28 @@
-export const debounce = (
-  // @ts-expect-error Any sort of args can be in the callback
-  func: (...args) => void,
-  wait: number = 250
-) => {
-  let timeout: number | undefined
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export interface DebouncedFunction<F extends (...args: any[]) => any> {
+  (...args: Parameters<F>): void
+  cancel: () => void
+}
 
-  return function executedFunction(...args: unknown[]) {
-    const later = () => {
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function debounce<F extends (...args: any[]) => any>(
+  func: F,
+  waitFor: number
+): DebouncedFunction<F> {
+  let timeout: ReturnType<typeof setTimeout> | null = null
+
+  const debounced = (...args: Parameters<F>) => {
+    if (timeout !== null) {
       clearTimeout(timeout)
-      func(...args)
     }
-
-    clearTimeout(timeout)
-    timeout = window.setTimeout(later, wait)
+    timeout = setTimeout(() => func(...args), waitFor)
   }
+
+  debounced.cancel = () => {
+    if (timeout !== null) {
+      clearTimeout(timeout)
+    }
+  }
+
+  return debounced
 }

--- a/app/create/_component/PromptStickyCreate.tsx
+++ b/app/create/_component/PromptStickyCreate.tsx
@@ -24,7 +24,7 @@ export default function PromptStickyCreate() {
       className={`transition-opacity duration-300 ${isSticky ? 'sticky top-0 opacity-100' : 'opacity-0'}`}
     >
       <div className="row w-full items-center">
-        <PromptActionPanel isSticky />
+        {isSticky && <PromptActionPanel isSticky />}
       </div>
     </div>
   )


### PR DESCRIPTION
## Fixes

- Unable to type in strength in LoRA and TI settings cards.
- You could sometimes click on the invisible sticky action prompt on the create page
- Refactor CivitAI hook and API call because it is just an absolute mess
- Handle issue where nsfwLevel (and other fields) may not exist in CivitAI response
- In image details, LoRA clip field was reading data from LoRA strength field.

## Enhancements

- Show LoRA size (and potential warning, if over 220MB) on LoRA details card.
- Update default settings to use LCM Turbo
- Ability to page through CivitAI API results.