### PR TITLE
feat: Enable worker allow / block lists and refactor ImageDetails panel

### DIFF
--- a/app/_api/horde/workers.ts
+++ b/app/_api/horde/workers.ts
@@ -1,0 +1,59 @@
+import { AppConstants } from '@/app/_data-models/AppConstants'
+import { clientHeader } from '@/app/_data-models/ClientHeader'
+import { HordeWorker } from '@/app/_types/HordeTypes'
+
+// Cache and timestamp initialization
+let workersCache: HordeWorker[] = []
+let lastFetchTime = 0
+
+export const fetchHordeWorkers = async () => {
+  const currentTime = new Date().getTime()
+
+  // Check if the last fetch was less than a minute ago
+  if (currentTime - lastFetchTime < 60000 && workersCache.length > 0) {
+    return workersCache // Return the cached data
+  }
+
+  try {
+    const res = await fetch(
+      `${AppConstants.AI_HORDE_PROD_URL}/api/v2/workers`,
+      {
+        cache: 'no-store',
+        headers: {
+          'Content-Type': 'application/json',
+          'Client-Agent': clientHeader()
+        },
+        method: 'GET'
+      }
+    )
+
+    const data = await res.json()
+
+    if (Array.isArray(data)) {
+      // Filter for image workers only:
+      const filtered = data.filter((worker) => worker.type === 'image')
+
+      // Update the cache and timestamp
+      workersCache = filtered
+      lastFetchTime = currentTime
+    } else {
+      if (workersCache.length > 0) {
+        return workersCache
+      }
+
+      return []
+    }
+  } catch (err) {
+    console.log(`Error: Unable to fetch worker details from AI Horde`)
+    console.log(err)
+
+    if (workersCache.length > 0) {
+      return workersCache
+    }
+
+    return []
+  }
+
+  // We should probably never get here, yeah?
+  return workersCache
+}

--- a/app/_components/Button/button.module.css
+++ b/app/_components/Button/button.module.css
@@ -42,6 +42,17 @@
   background-color: #f9595a;
 }
 
+.success {
+  background-color: #3F876B;
+  border-color: #3F876B;
+  font-weight: 700;
+  color: white;
+}
+
+.success:hover {
+  background-color: #3F876B;
+}
+
 .warning {
   background-color: #e6ae06;
   border-color: #e6ae06;

--- a/app/_components/Button/index.tsx
+++ b/app/_components/Button/index.tsx
@@ -5,7 +5,7 @@ import React, { CSSProperties, ReactNode, ElementType, forwardRef } from 'react'
 import styles from './button.module.css'
 
 // Extend this as needed
-type ButtonTheme = 'default' | 'danger' | 'warning'
+type ButtonTheme = 'default' | 'danger' | 'warning' | 'success'
 
 interface ButtonProps<T extends ElementType = 'button'> {
   as?: T

--- a/app/_components/ComboBox.tsx
+++ b/app/_components/ComboBox.tsx
@@ -15,7 +15,22 @@ function classNames(...classes: string[]) {
 }
 
 export interface SelectOption {
+  /**
+   * This is the "nice" display label for the option
+   */
   label: string
+
+  /**
+   * This is used to filter options. e.g., if you want to filer by a name and id, you can pass both values in here:
+   * {label: 'Nice Name', filterLabel: 'Nice Name abc123xyz}
+   */
+  filterLabel?: string
+
+  /**
+   * An optional component to format how the dropdown options are presented.
+   */
+  component?: React.ReactNode
+
   value: string | number
 }
 
@@ -66,6 +81,14 @@ export default function SelectCombo({
   })
 
   const filteredOptions = options.filter((option) => {
+    if (!option.label) return false
+
+    if (option.filterLabel) {
+      return option.filterLabel
+        .toLowerCase()
+        .includes(searchQuery.toLowerCase())
+    }
+
     return option.label.toLowerCase().includes(searchQuery.toLowerCase())
   })
 
@@ -154,7 +177,7 @@ export default function SelectCombo({
                         )
                       }
                     >
-                      {option.label}
+                      {option.component ? option.component : option.label}
                     </ComboboxOption>
                   )
                 })}

--- a/app/_components/ComboBox.tsx
+++ b/app/_components/ComboBox.tsx
@@ -35,10 +35,12 @@ export interface SelectOption {
 }
 
 export default function SelectCombo({
+  disabled = false,
   onChange = () => {},
   options,
   value
 }: {
+  disabled?: boolean
   onChange: (option: SelectOption) => void
   options: SelectOption[]
   value: SelectOption

--- a/app/_components/ComboBox.tsx
+++ b/app/_components/ComboBox.tsx
@@ -50,18 +50,6 @@ export default function SelectCombo({
   const [searchQuery, setSearchQuery] = useState('')
   const ref = useRef(null)
 
-  const [optionsPosition, setOptionsPosition] = useState({ top: 0, left: 0 })
-
-  useEffect(() => {
-    if (searchInputRef.current) {
-      const rect = searchInputRef.current.getBoundingClientRect()
-      setOptionsPosition({
-        top: rect.bottom + window.scrollY,
-        left: rect.left + window.scrollX
-      })
-    }
-  }, [optionsPanelOpen])
-
   useEffect(() => {
     setSearchInput(value.label)
   }, [value.label])
@@ -177,20 +165,21 @@ export default function SelectCombo({
             </div>
             {optionsPanelOpen && filteredOptions.length > 0 && (
               <Portal>
-                <ComboboxOptions
-                  static
-                  className="combobox-options absolute !z-[1000] mt-1 max-h-56 w-full overflow-auto rounded-md py-1 text-base shadow-lg ring-1 ring-opacity-5 focus:outline-none sm:text-sm bg-gray-50 border border-gray-300 text-gray-900 text-[16px] focus:ring-blue-500 focus:border-blue-500 block p-2 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white dark:focus:ring-blue-500 dark:focus:border-blue-500 mb-2"
+                <div
+                  className="absolute !z-[1000] w-full"
                   style={{
-                    position: 'fixed',
-                    top: `${optionsPosition.top + 12}px`,
-                    left: `${optionsPosition.left}px`,
-                    width: searchInputRef.current
-                      ? `${searchInputRef.current.offsetWidth}px`
-                      : 'auto'
+                    top: `${(searchInputRef.current as HTMLInputElement).getBoundingClientRect().bottom + window.scrollY + 8}px`,
+                    left: `${(searchInputRef.current as HTMLInputElement).getBoundingClientRect().left + window.scrollX - 8}px`,
+                    width:
+                      (searchInputRef.current as HTMLInputElement).offsetWidth +
+                      40
                   }}
                 >
-                  {filteredOptions.map((option, idx) => {
-                    return (
+                  <ComboboxOptions
+                    static
+                    className="combobox-options absolute !z-[1000] mt-1 max-h-56 w-full overflow-auto rounded-md py-1 text-base shadow-lg ring-1 ring-opacity-5 focus:outline-none sm:text-sm bg-gray-50 border border-gray-300 text-gray-900 text-[16px] focus:ring-blue-500 focus:border-blue-500 block p-2 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white dark:focus:ring-blue-500 dark:focus:border-blue-500 mb-2"
+                  >
+                    {filteredOptions.map((option, idx) => (
                       <ComboboxOption
                         key={`option-${option.value}-${idx}`}
                         value={option}
@@ -208,9 +197,9 @@ export default function SelectCombo({
                       >
                         {option.component ? option.component : option.label}
                       </ComboboxOption>
-                    )
-                  })}
-                </ComboboxOptions>
+                    ))}
+                  </ComboboxOptions>
+                </div>
               </Portal>
             )}
           </>

--- a/app/_components/DropdownMenu/index.tsx
+++ b/app/_components/DropdownMenu/index.tsx
@@ -1,21 +1,29 @@
-import { Menu, MenuButton, MenuDirection } from '@szhsin/react-menu'
+import React from 'react'
+import { Menu, MenuButton, MenuProps } from '@szhsin/react-menu'
 import '@szhsin/react-menu/dist/index.css'
 import '@szhsin/react-menu/dist/transitions/slide.css'
 
-export default function DropdownMenu(props: {
+type MenuButtonRenderProp = (
+  modifiers: Readonly<{ open: boolean }>
+) => React.ReactElement
+
+interface DropdownMenuProps extends Omit<MenuProps, 'menuButton'> {
   children: React.ReactNode
-  menuButton: React.ReactNode
-  direction?: MenuDirection
-  shift?: number
-}) {
+  menuButton: React.ReactNode | MenuButtonRenderProp
+}
+
+export default function DropdownMenu(props: DropdownMenuProps) {
   const { children, menuButton, ...rest } = props
+
+  const renderMenuButton = (modifiers: Readonly<{ open: boolean }>) => {
+    if (typeof menuButton === 'function') {
+      return menuButton(modifiers)
+    }
+    return <MenuButton>{menuButton}</MenuButton>
+  }
+
   return (
-    <Menu
-      arrow
-      menuButton={<MenuButton>{menuButton}</MenuButton>}
-      transition
-      {...rest}
-    >
+    <Menu arrow menuButton={renderMenuButton} transition {...rest}>
       {children}
     </Menu>
   )

--- a/app/_components/ImageView/ImageViewInfoContainer.tsx
+++ b/app/_components/ImageView/ImageViewInfoContainer.tsx
@@ -1,8 +1,7 @@
 import {
   IconPhotoUp,
   IconPlaylistAdd,
-  IconPlaylistX,
-  IconSettings
+  IconPlaylistX
 } from '@tabler/icons-react'
 import ImageViewActions from './imageViewActions'
 import styles from './imageView.module.css'
@@ -65,20 +64,8 @@ export default function ImageViewInfoContainer({
           </div>
         </div>
       )}
-      <div className="col gap-2 w-full">
-        <div className="row gap-2 text-sm font-bold">
-          <IconSettings stroke={1} />
-          Image details
-        </div>
-        <ImageDetails imageDetails={imageDetails as JobDetails} />
-      </div>
-      <div className="col gap-2 w-full mt-4">
-        <div className="row gap-2 text-sm font-bold">
-          <IconPhotoUp stroke={1} />
-          Source image
-        </div>
-        <ImageViewSourceImage imageDetails={imageDetails as JobDetails} />
-      </div>
+      <ImageDetails imageDetails={imageDetails as JobDetails} />
+      <ImageViewSourceImage imageDetails={imageDetails as JobDetails} />
     </div>
   )
 }

--- a/app/_components/ImageView/ImageViewSourceImage.tsx
+++ b/app/_components/ImageView/ImageViewSourceImage.tsx
@@ -3,6 +3,7 @@ import { getSourceImagesForArtbotJobFromDexie } from '@/app/_db/ImageFiles'
 import { JobDetails } from '@/app/_hooks/useImageDetails'
 import { useEffect, useState } from 'react'
 import ImageThumbnail from '../ImageThumbnail'
+import { IconPhotoUp } from '@tabler/icons-react'
 
 export default function ImageViewSourceImage({
   imageDetails
@@ -26,7 +27,11 @@ export default function ImageViewSourceImage({
   if (srcImages.length === 0) return null
 
   return (
-    <div>
+    <div className="col gap-2 w-full mt-4">
+      <div className="row gap-2 text-sm font-bold">
+        <IconPhotoUp stroke={1} />
+        Source image
+      </div>
       <ImageThumbnail image_id={srcImages[0]?.image_id} alt="Source Image" />
     </div>
   )

--- a/app/_components/ImageView_Pending/index.tsx
+++ b/app/_components/ImageView_Pending/index.tsx
@@ -16,7 +16,6 @@ import {
   IconPlaylistAdd,
   IconPlaylistX,
   IconRecycle,
-  IconSettings,
   IconTrash
 } from '@tabler/icons-react'
 import ImageDetails from '../ImageDetails'
@@ -34,6 +33,7 @@ import { updatePendingImage } from '@/app/_controllers/pendingJobController'
 import { deleteJobFromDexie } from '@/app/_db/jobTransactions'
 import { formatPendingPercentage } from '@/app/_utils/numberUtils'
 import { clientHeader } from '@/app/_data-models/ClientHeader'
+import { formatJobStatus } from '@/app/_utils/hordeUtils'
 
 interface PendingImageViewProps {
   artbot_id: string
@@ -58,25 +58,6 @@ const countErrorMessages = (
     message,
     count
   }))
-}
-
-function formatJobStatus(status: JobStatus) {
-  switch (status) {
-    case 'waiting':
-      return 'Waiting'
-    case 'queued':
-      return 'Queued'
-    case 'requested':
-      return 'Requested'
-    case 'processing':
-      return 'Processing'
-    case 'done':
-      return 'Done'
-    case 'error':
-      return 'Error'
-    default:
-      return status
-  }
 }
 
 export default function PendingImageView({ artbot_id }: PendingImageViewProps) {
@@ -225,21 +206,15 @@ export default function PendingImageView({ artbot_id }: PendingImageViewProps) {
           </div>
         </div>
       )}
-      <div className="col gap-2 w-full">
-        <div className="row gap-2 text-sm font-bold">
-          <IconSettings stroke={1} />
-          Image details
-        </div>
-        <ImageDetails
-          imageDetails={
-            {
-              jobDetails: jobDetails,
-              imageRequest: imageDetails,
-              imageFile: {}
-            } as JobDetails
-          }
-        />
-      </div>
+      <ImageDetails
+        imageDetails={
+          {
+            jobDetails: jobDetails,
+            imageRequest: imageDetails,
+            imageFile: {}
+          } as JobDetails
+        }
+      />
       <div className="row justify-end gap-2">
         <Button
           onClick={() => {

--- a/app/_components/Portal.tsx
+++ b/app/_components/Portal.tsx
@@ -1,0 +1,5 @@
+import { createPortal } from 'react-dom'
+
+export default function Portal({ children }: { children: React.ReactNode }) {
+  return createPortal(children, document.body)
+}

--- a/app/_data-models/AppConstants.ts
+++ b/app/_data-models/AppConstants.ts
@@ -1,6 +1,8 @@
 export class AppConstants {
   static AI_HORDE_ANON_KEY = '0000000000'
 
+  static AI_HORDE_PROD_URL = 'https://aihorde.net'
+
   /**
    * Maximum number of simulatenous jobs that can be running on the Horde.
    * Should be lower for anon users. Logged in users should be able to increase this in settings app.

--- a/app/_data-models/AppSettings.test.ts
+++ b/app/_data-models/AppSettings.test.ts
@@ -3,11 +3,23 @@ import { AppSettings, AppSettingsParams, rootSettingsKey } from './AppSettings'
 
 describe('AppSettings', () => {
   const initialSettings: AppSettingsParams = {
-    allowedWorkers: [{ value: 'worker1' }],
+    allowedWorkers: [
+      {
+        label: 'worker1',
+        timestamp: '2020-01-01 00:00:00',
+        value: 'abc-def'
+      }
+    ],
     allowNsfwImages: false,
     apiKey: 'testApiKey',
     autoDowngrade: true,
-    blockedWorkers: [{ value: 'worker2' }],
+    blockedWorkers: [
+      {
+        label: 'worker2',
+        timestamp: '2020-01-01 00:00:00',
+        value: 'xyz-123'
+      }
+    ],
     civitAiBaseModelFilter: ['SD 2.x'],
     negativePanelOpen: false,
     runInBackground: true,

--- a/app/_data-models/AppSettings.ts
+++ b/app/_data-models/AppSettings.ts
@@ -4,17 +4,17 @@
  * Save and load settings from browser's localStorage
  */
 
-import { CivitAiBaseModels } from '../_types/ArtbotTypes'
+import { CivitAiBaseModels, SelectedUserWorker } from '../_types/ArtbotTypes'
 import { AppConstants } from './AppConstants'
 
 export const rootSettingsKey = 'ArtBotSettings'
 
 export interface AppSettingsParams {
-  allowedWorkers: Array<{ value: string }>
+  allowedWorkers: SelectedUserWorker[]
   allowNsfwImages: boolean
   apiKey: string
   autoDowngrade: boolean
-  blockedWorkers: Array<{ value: string }>
+  blockedWorkers: SelectedUserWorker[]
   civitAiBaseModelFilter: CivitAiBaseModels[]
   negativePanelOpen: boolean
   runInBackground: boolean

--- a/app/_data-models/ImageParamsForHordeApi.ts
+++ b/app/_data-models/ImageParamsForHordeApi.ts
@@ -202,10 +202,9 @@ class ImageParamsForHordeApi implements HordeApiParamsBuilderInterface {
     }
 
     // If user has enabled forceSelectedWorker, override any other worker preference setting.
-    const worker = sessionStorage.getItem('forceSelectedWorker')
-    if (worker) {
-      const workerId = JSON.parse(worker).value
-      this.apiParams.workers = [workerId]
+    const forceWorkerId = sessionStorage.getItem('forceSelectedWorker')
+    if (forceWorkerId) {
+      this.apiParams.workers = [forceWorkerId]
       delete this.apiParams.worker_blacklist
       delete this.apiParams.slow_workers
 

--- a/app/_stores/UserStore.ts
+++ b/app/_stores/UserStore.ts
@@ -4,14 +4,22 @@ import { HordeUser } from '../_types/HordeTypes'
 interface UserStoreInterface {
   forceAllowedWorkers: boolean
   forceBlockedWorkers: boolean
+  forceSelectedWorker: boolean
   userDetails: HordeUser
 }
 
 export const UserStore = makeStore<UserStoreInterface>({
   forceAllowedWorkers: false,
   forceBlockedWorkers: false,
+  forceSelectedWorker: false,
   userDetails: {} as HordeUser
 })
+
+export const setForceSelectedWorker = (val: boolean) => {
+  UserStore.set(() => ({
+    forceSelectedWorker: val
+  }))
+}
 
 export const updateUser = (user: HordeUser) => {
   UserStore.set(() => ({ userDetails: user }))

--- a/app/_stores/UserStore.ts
+++ b/app/_stores/UserStore.ts
@@ -2,13 +2,27 @@ import { makeStore } from 'statery'
 import { HordeUser } from '../_types/HordeTypes'
 
 interface UserStoreInterface {
+  forceAllowedWorkers: boolean
+  forceBlockedWorkers: boolean
   userDetails: HordeUser
 }
 
 export const UserStore = makeStore<UserStoreInterface>({
+  forceAllowedWorkers: false,
+  forceBlockedWorkers: false,
   userDetails: {} as HordeUser
 })
 
 export const updateUser = (user: HordeUser) => {
   UserStore.set(() => ({ userDetails: user }))
+}
+
+export const updateWorkerUsagePreference = ({
+  forceAllowedWorkers,
+  forceBlockedWorkers
+}: {
+  forceAllowedWorkers: boolean
+  forceBlockedWorkers: boolean
+}) => {
+  UserStore.set(() => ({ forceAllowedWorkers, forceBlockedWorkers }))
 }

--- a/app/_types/ArtbotTypes.ts
+++ b/app/_types/ArtbotTypes.ts
@@ -111,6 +111,15 @@ export interface PromptsJobMap {
   prompt_id: number
 }
 
+/**
+ * Worker added to user's list of allowed or blocked workers
+ */
+export interface SelectedUserWorker {
+  label: string
+  timestamp: string
+  value: string
+}
+
 export interface Workflow {
   type: 'qr_code' | ''
   position: WorkflowPosition

--- a/app/_types/HordeTypes.ts
+++ b/app/_types/HordeTypes.ts
@@ -111,6 +111,34 @@ export interface HordeUser {
   }
 }
 
+export interface HordeWorker {
+  id: string
+  info: string
+  bridge_agent: string
+  kudos_details: { generated: number; uptime: number }
+  kudos_rewards: number
+  loading?: boolean
+  lora: boolean
+  img2img: boolean
+  maintenance_mode: boolean
+  max_pixels: number
+  models: string[]
+  name: string
+  nsfw: boolean
+  online: boolean
+  painting: boolean
+  performance: string
+  'post-processing': boolean
+  requests_fulfilled: number
+  team: {
+    id: string | null
+    name: string | null
+  }
+  threads: number
+  trusted: boolean
+  uptime: number
+}
+
 export interface ImageModelDetails {
   name: string
   baseline: string

--- a/app/_utils/hordeUtils.ts
+++ b/app/_utils/hordeUtils.ts
@@ -1,4 +1,5 @@
 import { SavedEmbedding } from '../_data-models/Civitai'
+import { JobStatus } from '../_types/ArtbotTypes'
 import { HordeTi } from '../_types/HordeTypes'
 
 export const castTiInject = (tis: SavedEmbedding[]): HordeTi[] => {
@@ -23,4 +24,23 @@ export const castTiInject = (tis: SavedEmbedding[]): HordeTi[] => {
   }
 
   return updatedTis
+}
+
+export const formatJobStatus = (status: JobStatus) => {
+  switch (status) {
+    case 'waiting':
+      return 'Waiting'
+    case 'queued':
+      return 'Queued'
+    case 'requested':
+      return 'Requested'
+    case 'processing':
+      return 'Processing'
+    case 'done':
+      return 'Done'
+    case 'error':
+      return 'Error'
+    default:
+      return status
+  }
 }

--- a/app/create/_component/ForceWorkerModal.tsx
+++ b/app/create/_component/ForceWorkerModal.tsx
@@ -1,0 +1,101 @@
+import { fetchHordeWorkers } from '@/app/_api/horde/workers'
+import Button from '@/app/_components/Button'
+import SelectCombo from '@/app/_components/ComboBox'
+import { setForceSelectedWorker } from '@/app/_stores/UserStore'
+import { HordeWorker } from '@/app/_types/HordeTypes'
+import NiceModal from '@ebay/nice-modal-react'
+import { IconArrowBarLeft, IconPlus } from '@tabler/icons-react'
+import { useEffect, useState } from 'react'
+
+export default function ForceWorkerModal() {
+  const [selectedWorker, setSelectedWorker] = useState<string>('')
+  const [workers, setWorkers] = useState<HordeWorker[]>([])
+
+  useEffect(() => {
+    async function fetchWorkers() {
+      const result = await fetchHordeWorkers()
+      setWorkers(result)
+    }
+
+    fetchWorkers()
+  }, [])
+
+  useEffect(() => {
+    const worker = sessionStorage.getItem('forceSelectedWorker')
+
+    console.log(`worker`, worker)
+
+    if (worker) {
+      setForceSelectedWorker(true)
+      setSelectedWorker(worker || '')
+    }
+  }, [])
+
+  const workerOptions = workers.map((worker) => {
+    return {
+      label: `${worker.name}`,
+      filterLabel: `${worker.name} ${worker.id}`,
+      component: (
+        <div className="col gap-0 mb-0">
+          <div>{worker.name}</div>
+          <div className="text-xs font-mono">{worker.id}</div>
+        </div>
+      ),
+      value: worker.id
+    }
+  })
+
+  return (
+    <div className="col w-full h-full">
+      <h2 className="row font-bold">Force Worker</h2>
+      <div className="col gap-2">
+        <div>
+          Temporarily send requests to a <strong>specific worker</strong>. This
+          will <strong>override</strong> any current worker preference options
+          that you may have set. Clearing this option will restore your previous
+          worker preferences.
+        </div>
+        <div>
+          This setting will affect any images that are queued up and awaiting to
+          be sent to the AI Horde.
+        </div>
+        <div className="w-full row">
+          <SelectCombo
+            onChange={(option) => {
+              if (!option) return
+              setSelectedWorker(option.value as string)
+            }}
+            options={workerOptions}
+            value={{
+              label: workers.filter((w) => w.id === selectedWorker)[0]?.name,
+              value: selectedWorker
+            }}
+          />
+          <Button
+            onClick={() => {
+              if (!selectedWorker) {
+                sessionStorage.setItem('forceSelectedWorker', '')
+              } else {
+                setForceSelectedWorker(true)
+                sessionStorage.setItem('forceSelectedWorker', selectedWorker)
+              }
+              NiceModal.remove('modal')
+            }}
+          >
+            <IconPlus />
+          </Button>
+          <Button
+            theme="danger"
+            onClick={() => {
+              setSelectedWorker('')
+              sessionStorage.setItem('forceSelectedWorker', '')
+              setForceSelectedWorker(false)
+            }}
+          >
+            <IconArrowBarLeft />
+          </Button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/app/create/_component/ForceWorkerModal.tsx
+++ b/app/create/_component/ForceWorkerModal.tsx
@@ -23,8 +23,6 @@ export default function ForceWorkerModal() {
   useEffect(() => {
     const worker = sessionStorage.getItem('forceSelectedWorker')
 
-    console.log(`worker`, worker)
-
     if (worker) {
       setForceSelectedWorker(true)
       setSelectedWorker(worker || '')

--- a/app/create/_component/PromptActionPanel.tsx
+++ b/app/create/_component/PromptActionPanel.tsx
@@ -8,8 +8,10 @@ import { deleteImageFileByArtbotIdTx } from '@/app/_db/ImageFiles'
 import { useInput } from '@/app/_providers/PromptInputProvider'
 import NiceModal from '@ebay/nice-modal-react'
 import {
+  IconDevicesPc,
   IconHourglass,
   IconInfoTriangle,
+  IconLock,
   IconSquarePlus,
   IconTrash
 } from '@tabler/icons-react'
@@ -17,6 +19,9 @@ import { useRouter } from 'next/navigation'
 import useCreateImageRequest from '../_hook/useCreateImageRequest'
 import clsx from 'clsx'
 import { AppConstants } from '@/app/_data-models/AppConstants'
+import ForceWorkerModal from './ForceWorkerModal'
+import { useStore } from 'statery'
+import { UserStore } from '@/app/_stores/UserStore'
 
 export default function PromptActionPanel({
   height = 36,
@@ -25,6 +30,7 @@ export default function PromptActionPanel({
   height?: number
   isSticky?: boolean
 }) {
+  const { forceSelectedWorker } = useStore(UserStore)
   const { kudos, setInput, setSourceImages } = useInput()
   const {
     emptyInput,
@@ -87,7 +93,6 @@ export default function PromptActionPanel({
             Reset?
           </span>
         </Button>
-
         <Button
           disabled={emptyInput || requestPending || hasCriticalError}
           onClick={handleCreateClick}
@@ -134,6 +139,25 @@ export default function PromptActionPanel({
             </span>
           </Button>
         )}
+        <Button
+          theme={forceSelectedWorker ? 'success' : 'default'}
+          onClick={() => {
+            NiceModal.show('modal', {
+              children: <ForceWorkerModal />,
+              modalClassName: 'max-w-[640px]'
+            })
+          }}
+          style={{
+            height: `${height}px`,
+            width: `40px`
+          }}
+        >
+          {forceSelectedWorker ? (
+            <IconLock stroke={1.5} />
+          ) : (
+            <IconDevicesPc stroke={1.5} />
+          )}
+        </Button>
       </div>
     </div>
   )

--- a/app/settings/_component/Apikey.tsx
+++ b/app/settings/_component/Apikey.tsx
@@ -53,56 +53,62 @@ export default function Apikey() {
   }
 
   return (
-    <div className="col md:row w-full items-end h-auto sm:h-[70px]">
-      <Input
-        label="API key"
-        onChange={(e) => setApikey(e.target.value)}
-        onKeyDown={handleKeyDown}
-        placeholder="Enter your API key"
-        type={!showKey ? 'password' : 'text'}
-        value={apikey}
-      />
-      <div className="row !h-full w-auto justify-end gap-1 items-end">
-        <Button
-          disabled={!apikey}
-          onClick={() => {
-            setApikey('')
-            AppSettings.set('apiKey', '')
-            toastController({
-              message: 'API key removed from ArtBot!'
-            })
-          }}
-          theme="danger"
-          title="Remove / reset API key"
-        >
-          <IconTrash />
-        </Button>
-        <Button
-          onClick={() => setShowKey(!showKey)}
-          title={!showKey ? 'Show API key' : 'Hide API key'}
-        >
-          {showKey ? <IconEyeOff /> : <IconEye />}
-        </Button>
-        <Button
-          onClick={() => {
-            if (apikey) {
-              navigator.clipboard.writeText(apikey)
+    <div className="col gap-2">
+      <div>
+        Leave blank for anonymous access. An API key gives higher priority
+        access to the AI Horde distributed cluster, resulting in quicker image
+        creation times.
+      </div>
+      <div className="col md:row w-full items-end h-auto">
+        <Input
+          onChange={(e) => setApikey(e.target.value)}
+          onKeyDown={handleKeyDown}
+          placeholder="Enter your API key"
+          type={!showKey ? 'password' : 'text'}
+          value={apikey}
+        />
+        <div className="row w-auto justify-end gap-1 items-end min-h-[42px]">
+          <Button
+            disabled={!apikey}
+            onClick={() => {
+              setApikey('')
+              AppSettings.set('apiKey', '')
               toastController({
-                message: 'API key copied to clipboard!'
+                message: 'API key removed from ArtBot!'
               })
-            }
-          }}
-          title="Copy API key"
-        >
-          <IconCopy />
-        </Button>
-        <Button
-          disabled={!apikey.trim()}
-          onClick={handleApiKeySave}
-          title="Save API key"
-        >
-          <IconDeviceFloppy />
-        </Button>
+            }}
+            theme="danger"
+            title="Remove / reset API key"
+          >
+            <IconTrash />
+          </Button>
+          <Button
+            onClick={() => setShowKey(!showKey)}
+            title={!showKey ? 'Show API key' : 'Hide API key'}
+          >
+            {showKey ? <IconEyeOff /> : <IconEye />}
+          </Button>
+          <Button
+            onClick={() => {
+              if (apikey) {
+                navigator.clipboard.writeText(apikey)
+                toastController({
+                  message: 'API key copied to clipboard!'
+                })
+              }
+            }}
+            title="Copy API key"
+          >
+            <IconCopy />
+          </Button>
+          <Button
+            disabled={!apikey.trim()}
+            onClick={handleApiKeySave}
+            title="Save API key"
+          >
+            <IconDeviceFloppy />
+          </Button>
+        </div>
       </div>
     </div>
   )

--- a/app/settings/_component/WorkerList.tsx
+++ b/app/settings/_component/WorkerList.tsx
@@ -168,7 +168,6 @@ export default function WorkerList({
         </div>
         <div className="w-full row">
           <SelectCombo
-            disabled={userWorkersList.length >= MAX_ENTRIES}
             onChange={(option) => {
               if (!option) return
               setSelectedWorker(option.value as string)

--- a/app/settings/_component/WorkerList.tsx
+++ b/app/settings/_component/WorkerList.tsx
@@ -1,0 +1,228 @@
+'use client'
+
+import { fetchHordeWorkers } from '@/app/_api/horde/workers'
+import Button from '@/app/_components/Button'
+import SelectCombo, { SelectOption } from '@/app/_components/ComboBox'
+import Section from '@/app/_components/Section'
+import Switch from '@/app/_components/Switch'
+import { AppSettings } from '@/app/_data-models/AppSettings'
+import { UserStore, updateWorkerUsagePreference } from '@/app/_stores/UserStore'
+import { SelectedUserWorker } from '@/app/_types/ArtbotTypes'
+import { HordeWorker } from '@/app/_types/HordeTypes'
+import { IconPlus, IconX } from '@tabler/icons-react'
+import { useEffect, useState } from 'react'
+import { useStore } from 'statery'
+
+const MAX_ENTRIES = 5
+
+const allowTip = `Add workers to send all image requests only to specific workers. Useful for debugging purposes or testing features available on particular workers. Maximum of 5 workers.`
+const blockTip = `Add worker IDs here to prevent sending image requests to that machine. Useful in instances where a worker is out of date, serving incorrect models, or a troll. Adding workers here will increase kudos costs by 10% due to unoptimal use of Horde resources. Max of 5.`
+
+export default function WorkerList({
+  type = 'block'
+}: {
+  type?: 'allow' | 'block'
+}) {
+  const { forceAllowedWorkers, forceBlockedWorkers } = useStore(UserStore)
+  const [selectedWorker, setSelectedWorker] = useState<string>('')
+  const [userWorkersList, setUserWorkersList] = useState<SelectedUserWorker[]>(
+    []
+  )
+  const [workers, setWorkers] = useState<HordeWorker[]>([])
+
+  const handleAddWorker = (workerObj: SelectOption) => {
+    const updatedWorkers = [...userWorkersList]
+    const exists = updatedWorkers.filter((obj) => obj.value === workerObj.value)
+
+    if (!exists || exists.length === 0) {
+      updatedWorkers.push({
+        label: workerObj.label as string,
+        value: workerObj.value as string,
+        timestamp: new Date().toLocaleString()
+      })
+
+      const appWorkersType =
+        type === 'allow' ? 'allowedWorkers' : 'blockedWorkers'
+
+      AppSettings.set(appWorkersType, updatedWorkers)
+      setUserWorkersList(updatedWorkers)
+    }
+  }
+
+  const removeWorkerFromList = (worker: SelectOption) => {
+    const updatedWorkers = userWorkersList.filter(
+      (obj) => obj.value !== worker.value
+    )
+
+    const appWorkersSetting =
+      type === 'allow' ? 'useAllowedWorkers' : 'useBlockedWorkers'
+    const appWorkersType =
+      type === 'allow' ? 'allowedWorkers' : 'blockedWorkers'
+
+    if (updatedWorkers.length === 0) {
+      setUserWorkersList([])
+      AppSettings.set(appWorkersSetting, false)
+    }
+
+    AppSettings.set(
+      appWorkersType,
+      updatedWorkers.length === 0 ? [] : updatedWorkers
+    )
+    setUserWorkersList(updatedWorkers)
+  }
+
+  useEffect(() => {
+    async function fetchWorkers() {
+      const result = await fetchHordeWorkers()
+      setWorkers(result)
+    }
+
+    fetchWorkers()
+  }, [])
+
+  useEffect(() => {
+    const appWorkersType =
+      type === 'allow' ? 'allowedWorkers' : 'blockedWorkers'
+
+    const list = AppSettings.get(appWorkersType) || []
+
+    const allowed = AppSettings.get('useAllowedWorkers')
+    const blocked = AppSettings.get('useBlockedWorkers')
+
+    updateWorkerUsagePreference({
+      forceAllowedWorkers: allowed,
+      forceBlockedWorkers: blocked
+    })
+
+    setUserWorkersList(list)
+  }, [type])
+
+  const workerOptions = workers.map((worker) => {
+    return {
+      label: `${worker.name}`,
+      filterLabel: `${worker.name} ${worker.id}`,
+      component: (
+        <div className="col gap-0 mb-0">
+          <div>{worker.name}</div>
+          <div className="text-xs font-mono">{worker.id}</div>
+        </div>
+      ),
+      value: worker.id
+    }
+  })
+
+  const sectionTitle = type === 'allow' ? 'Allowed Workers' : 'Blocked Workers'
+
+  return (
+    <Section
+      anchor={type === 'allow' ? 'allowed-workers' : 'blocked-workers'}
+      title={`${sectionTitle} (${userWorkersList.length} / ${MAX_ENTRIES})`}
+    >
+      <div className="col gap-2">
+        <div>
+          {type === 'allow' && allowTip}
+          {type === 'block' && blockTip}
+        </div>
+        <div>
+          <label className="row gap-2 text-white">
+            <strong>Use {type}ed workers?</strong>
+            <Switch
+              disabled={userWorkersList.length === 0}
+              checked={
+                type === 'allow' ? forceAllowedWorkers : forceBlockedWorkers
+              }
+              onChange={() => {
+                if (type === 'allow' && forceAllowedWorkers) {
+                  AppSettings.set('useAllowedWorkers', false)
+
+                  updateWorkerUsagePreference({
+                    forceAllowedWorkers: false,
+                    forceBlockedWorkers
+                  })
+                } else if (type === 'allow' && !forceAllowedWorkers) {
+                  AppSettings.set('useAllowedWorkers', true)
+                  AppSettings.set('useBlockedWorkers', false)
+                  updateWorkerUsagePreference({
+                    forceAllowedWorkers: true,
+                    forceBlockedWorkers: false
+                  })
+                }
+
+                if (type === 'block' && forceBlockedWorkers) {
+                  AppSettings.set('useBlockedWorkers', false)
+                  updateWorkerUsagePreference({
+                    forceAllowedWorkers,
+                    forceBlockedWorkers: false
+                  })
+                } else if (type === 'block' && !forceBlockedWorkers) {
+                  AppSettings.set('useAllowedWorkers', false)
+                  AppSettings.set('useBlockedWorkers', true)
+                  updateWorkerUsagePreference({
+                    forceAllowedWorkers: false,
+                    forceBlockedWorkers: true
+                  })
+                }
+              }}
+            />
+          </label>
+        </div>
+        <div className="w-full row">
+          <SelectCombo
+            disabled={userWorkersList.length >= MAX_ENTRIES}
+            onChange={(option) => {
+              if (!option) return
+              setSelectedWorker(option.value as string)
+            }}
+            options={workerOptions}
+            value={{
+              label: workers.filter((w) => w.id === selectedWorker)[0]?.name,
+              value: selectedWorker
+            }}
+          />
+          <Button
+            disabled={userWorkersList.length >= MAX_ENTRIES}
+            onClick={() => {
+              const option = {
+                label: workers.filter((w) => w.id === selectedWorker)[0]?.name,
+                value: selectedWorker
+              }
+
+              handleAddWorker(option)
+              setSelectedWorker('')
+            }}
+          >
+            <IconPlus />
+          </Button>
+        </div>
+        {userWorkersList.length > 0 && (
+          <div className="col gap-2">
+            {userWorkersList.map((worker) => (
+              <div
+                key={worker.value}
+                className="row w-full items-start justify-start gap-6"
+              >
+                <div className="pt-1">
+                  <Button
+                    onClick={() => removeWorkerFromList(worker)}
+                    theme="danger"
+                    style={{
+                      height: '32px',
+                      width: '32px'
+                    }}
+                  >
+                    <IconX />
+                  </Button>
+                </div>
+                <div className="col gap-0 font-mono">
+                  <div className="font-bold !text-md">{worker.label}</div>
+                  <div className="text-sm">{worker.timestamp}</div>
+                  <div className="text-sm">{worker.value}</div>
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+    </Section>
+  )
+}

--- a/app/settings/page.tsx
+++ b/app/settings/page.tsx
@@ -1,6 +1,8 @@
 import { Metadata } from 'next'
 import PageTitle from '../_components/PageTitle'
 import Apikey from './_component/Apikey'
+import Section from '../_components/Section'
+import WorkerList from './_component/WorkerList'
 
 export const metadata: Metadata = {
   title: 'Settings | ArtBot for Stable Diffusion'
@@ -8,9 +10,15 @@ export const metadata: Metadata = {
 
 export default async function SettingsPage() {
   return (
-    <>
+    <div className="col gap-2">
       <PageTitle>Settings</PageTitle>
-      <Apikey />
-    </>
+      <div className="col gap-4">
+        <Section anchor="api-key" title="AI Horde API key (optional)">
+          <Apikey />
+        </Section>
+        <WorkerList type="allow" />
+        <WorkerList type="block" />
+      </div>
+    </div>
   )
 }


### PR DESCRIPTION
## Enhancements

- Update ComboBox to support custom display options (used in new worker selection lists)
- Add support on settings page for setting allow / block lists for workers in a new re-usable component. (ArtBot v1 just did spaghetti all over this).
- Add support for render props to custom DropDownMenu component
- Add DropDownMenu component to ImageDetails view and add support for viewing job details (e.g., images requested vs images failed)