### PR TITLE
fix: remove default params

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -6,6 +6,7 @@
     "next/core-web-vitals",
     "prettier"
   ],
+  "ignorePatterns": ["__mocks__/*"],
   "parser": "@typescript-eslint/parser",
   "parserOptions": {
     "project": "./tsconfig.json"

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -18,6 +18,8 @@ jobs:
         fetch-depth: 0
     - name: Run playbook
       uses: dawidd6/action-ansible-playbook@v2
+      env:
+        ARTBOT_STATUS_API: ${{ secrets.ARTBOT_STATUS_API }}
       with:
         # Required, playbook filepath
         playbook: ansible/artbot_update.yml

--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,7 @@ yarn-debug.log*
 yarn-error.log*
 
 # local env files
+.env
 .env*.local
 
 # vercel

--- a/__mocks__/nanoid.js
+++ b/__mocks__/nanoid.js
@@ -1,0 +1,5 @@
+const object = {
+  nanoid: () => '123',
+}
+
+module.exports = object

--- a/app/_api/presets/index.tsx
+++ b/app/_api/presets/index.tsx
@@ -1,0 +1,57 @@
+// utils/fetchPresetData.ts
+import {
+  CategoryPreset,
+  StylePresetConfigurations,
+  StylePreviewConfigurations
+} from '@/app/_types/HordeTypes';
+
+export async function getPresetData(): Promise<{
+  success: boolean;
+  categories: CategoryPreset;
+  presets: StylePresetConfigurations;
+  previews: StylePreviewConfigurations;
+}> {
+  try {
+    const urls = [
+      'https://raw.githubusercontent.com/Haidra-Org/AI-Horde-Styles/main/categories.json',
+      'https://raw.githubusercontent.com/Haidra-Org/AI-Horde-Styles/main/styles.json',
+      'https://raw.githubusercontent.com/amiantos/AI-Horde-Styles-Previews/main/previews.json'
+    ];
+
+    const [categoriesRes, presetsRes, previewsRes] = await Promise.allSettled(
+      urls.map((url) => fetch(url))
+    );
+
+    const categories =
+      categoriesRes.status === 'fulfilled'
+        ? await categoriesRes.value.json()
+        : {};
+    const presets: StylePresetConfigurations =
+      presetsRes.status === 'fulfilled' ? await presetsRes.value.json() : {};
+    const previews: StylePreviewConfigurations =
+      previewsRes.status === 'fulfilled' ? await previewsRes.value.json() : {};
+
+    // Filter categories to include only those keys that exist in presets
+    const filteredCategories = Object.keys(categories).reduce((acc, key) => {
+      acc[key] = categories[key].filter(
+        (category: string) => category in presets
+      );
+      return acc;
+    }, {} as CategoryPreset);
+
+    return {
+      success: true,
+      categories: filteredCategories,
+      presets,
+      previews
+    };
+  } catch (err) {
+    console.error(err);
+    return {
+      success: false,
+      categories: {},
+      presets: {},
+      previews: {}
+    };
+  }
+}

--- a/app/_components/AdvancedOptions/ModelSelect/modelSelectComponent.test.tsx
+++ b/app/_components/AdvancedOptions/ModelSelect/modelSelectComponent.test.tsx
@@ -1,0 +1,102 @@
+import React from 'react'
+import { render, fireEvent } from '@testing-library/react'
+import ModelSelect from './modelSelectComponent'
+import { useInput } from '@/app/_providers/PromptInputProvider'
+import { useStore } from 'statery'
+import PromptInput from '@/app/_data-models/PromptInput'
+
+// Mock the necessary dependencies
+jest.mock('@/app/_providers/PromptInputProvider')
+jest.mock('statery')
+jest.mock('@/app/_data-models/PromptInput')
+
+jest.mock('../../ComboBox', () => ({
+  __esModule: true,
+  default: ({ onChange, options, value }: {
+    onChange: (option: { value: string }) => void,
+    options: Array<{ value: string, label: string }>,
+    value: { value: string, label: string }
+  }) => (
+    <select
+      data-testid="model-select"
+      onChange={(e) => onChange({ value: e.target.value })}
+      value={value.value}
+    >
+      {options.map((option) => (
+        <option key={option.value} value={option.value}>
+          {option.label}
+        </option>
+      ))}
+    </select>
+  ),
+}))
+
+describe('ModelSelect', () => {
+  const setInputMock = jest.fn()
+  let mockInput: any
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+
+    mockInput = {
+      models: ['Initial Model'],
+      clipskip: 1,
+      loras: [],
+      sampler: 'k_euler_a',
+      steps: '20',
+      cfg_scale: '7'
+    }
+
+      ; (useInput as jest.Mock).mockReturnValue({
+        input: mockInput,
+        setInput: setInputMock,
+      })
+
+      ; (useStore as jest.Mock).mockReturnValue({
+        availableModels: [
+          { name: 'Model 1', count: 5 },
+          { name: 'PonyXL', count: 3 },
+          { name: 'AlbedoBase XL (SDXL)', count: 2 },
+        ],
+        modelDetails: {
+          'Model 1': { baseline: 'base1', version: 'v1' },
+          'PonyXL': { baseline: 'base2', version: 'v2' },
+          'AlbedoBase XL (SDXL)': { baseline: 'base3', version: 'v3' },
+        },
+      })
+
+      ; (PromptInput.isDefaultPromptInput as jest.Mock).mockReturnValue(false)
+      ; (PromptInput.setNonTurboDefaultPromptInput as jest.Mock).mockImplementation((input) => input)
+      ; (PromptInput.setTurboDefaultPromptInput as jest.Mock).mockImplementation((input) => input)
+  })
+
+  it('updates input correctly when selecting a new model', () => {
+    const { getByTestId } = render(<ModelSelect />)
+    const select = getByTestId('model-select')
+
+    // Test selecting a regular model
+    fireEvent.change(select, { target: { value: 'Model 1' } })
+    expect(setInputMock).toHaveBeenCalledWith(expect.objectContaining({
+      models: ['Model 1'],
+      modelDetails: { baseline: 'base1', version: 'v1' },
+    }))
+
+    // Test selecting a Pony model
+    fireEvent.change(select, { target: { value: 'PonyXL' } })
+    expect(setInputMock).toHaveBeenCalledWith(expect.objectContaining({
+      models: ['PonyXL'],
+      modelDetails: { baseline: 'base2', version: 'v2' },
+      clipskip: 2,
+    }))
+
+    // Test selecting AlbedoBase XL (SDXL)
+    mockInput.models = ['Some Non-SDXL Model']
+      ; (PromptInput.isDefaultPromptInput as jest.Mock).mockReturnValue(true)
+    fireEvent.change(select, { target: { value: 'AlbedoBase XL (SDXL)' } })
+    expect(setInputMock).toHaveBeenCalledWith(expect.objectContaining({
+      models: ['AlbedoBase XL (SDXL)'],
+      modelDetails: { baseline: 'base3', version: 'v3' },
+    }))
+    expect(PromptInput.setTurboDefaultPromptInput).toHaveBeenCalled()
+  })
+})

--- a/app/_components/AdvancedOptions/ModelSelect/modelSelectComponent.test.tsx
+++ b/app/_components/AdvancedOptions/ModelSelect/modelSelectComponent.test.tsx
@@ -1,21 +1,25 @@
-import React from 'react'
-import { render, fireEvent } from '@testing-library/react'
-import ModelSelect from './modelSelectComponent'
-import { useInput } from '@/app/_providers/PromptInputProvider'
-import { useStore } from 'statery'
-import PromptInput from '@/app/_data-models/PromptInput'
+import React from 'react';
+import { render, fireEvent } from '@testing-library/react';
+import ModelSelect from './modelSelectComponent';
+import { useInput } from '@/app/_providers/PromptInputProvider';
+import { useStore } from 'statery';
+import PromptInput from '@/app/_data-models/PromptInput';
 
 // Mock the necessary dependencies
-jest.mock('@/app/_providers/PromptInputProvider')
-jest.mock('statery')
-jest.mock('@/app/_data-models/PromptInput')
+jest.mock('@/app/_providers/PromptInputProvider');
+jest.mock('statery');
+jest.mock('@/app/_data-models/PromptInput');
 
 jest.mock('../../ComboBox', () => ({
   __esModule: true,
-  default: ({ onChange, options, value }: {
-    onChange: (option: { value: string }) => void,
-    options: Array<{ value: string, label: string }>,
-    value: { value: string, label: string }
+  default: ({
+    onChange,
+    options,
+    value
+  }: {
+    onChange: (option: { value: string }) => void;
+    options: Array<{ value: string; label: string }>;
+    value: { value: string; label: string };
   }) => (
     <select
       data-testid="model-select"
@@ -28,75 +32,82 @@ jest.mock('../../ComboBox', () => ({
         </option>
       ))}
     </select>
-  ),
-}))
+  )
+}));
 
 describe('ModelSelect', () => {
-  const setInputMock = jest.fn()
-  let mockInput: any
+  const setInputMock = jest.fn();
+  let mockInput: Partial<PromptInput>;
 
   beforeEach(() => {
-    jest.clearAllMocks()
+    jest.clearAllMocks();
 
     mockInput = {
       models: ['Initial Model'],
       clipskip: 1,
       loras: [],
       sampler: 'k_euler_a',
-      steps: '20',
-      cfg_scale: '7'
-    }
-
-      ; (useInput as jest.Mock).mockReturnValue({
-        input: mockInput,
-        setInput: setInputMock,
-      })
-
-      ; (useStore as jest.Mock).mockReturnValue({
-        availableModels: [
-          { name: 'Model 1', count: 5 },
-          { name: 'PonyXL', count: 3 },
-          { name: 'AlbedoBase XL (SDXL)', count: 2 },
-        ],
-        modelDetails: {
-          'Model 1': { baseline: 'base1', version: 'v1' },
-          'PonyXL': { baseline: 'base2', version: 'v2' },
-          'AlbedoBase XL (SDXL)': { baseline: 'base3', version: 'v3' },
-        },
-      })
-
-      ; (PromptInput.isDefaultPromptInput as jest.Mock).mockReturnValue(false)
-      ; (PromptInput.setNonTurboDefaultPromptInput as jest.Mock).mockImplementation((input) => input)
-      ; (PromptInput.setTurboDefaultPromptInput as jest.Mock).mockImplementation((input) => input)
-  })
+      steps: 20,
+      cfg_scale: 7
+    };
+    (useInput as jest.Mock).mockReturnValue({
+      input: mockInput,
+      setInput: setInputMock
+    });
+    (useStore as jest.Mock).mockReturnValue({
+      availableModels: [
+        { name: 'Model 1', count: 5 },
+        { name: 'PonyXL', count: 3 },
+        { name: 'AlbedoBase XL (SDXL)', count: 2 }
+      ],
+      modelDetails: {
+        'Model 1': { baseline: 'base1', version: 'v1' },
+        PonyXL: { baseline: 'base2', version: 'v2' },
+        'AlbedoBase XL (SDXL)': { baseline: 'base3', version: 'v3' }
+      }
+    });
+    (PromptInput.isDefaultPromptInput as jest.Mock).mockReturnValue(false);
+    (PromptInput.setNonTurboDefaultPromptInput as jest.Mock).mockImplementation(
+      (input) => input
+    );
+    (PromptInput.setTurboDefaultPromptInput as jest.Mock).mockImplementation(
+      (input) => input
+    );
+  });
 
   it('updates input correctly when selecting a new model', () => {
-    const { getByTestId } = render(<ModelSelect />)
-    const select = getByTestId('model-select')
+    const { getByTestId } = render(<ModelSelect />);
+    const select = getByTestId('model-select');
 
     // Test selecting a regular model
-    fireEvent.change(select, { target: { value: 'Model 1' } })
-    expect(setInputMock).toHaveBeenCalledWith(expect.objectContaining({
-      models: ['Model 1'],
-      modelDetails: { baseline: 'base1', version: 'v1' },
-    }))
+    fireEvent.change(select, { target: { value: 'Model 1' } });
+    expect(setInputMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        models: ['Model 1'],
+        modelDetails: { baseline: 'base1', version: 'v1' }
+      })
+    );
 
     // Test selecting a Pony model
-    fireEvent.change(select, { target: { value: 'PonyXL' } })
-    expect(setInputMock).toHaveBeenCalledWith(expect.objectContaining({
-      models: ['PonyXL'],
-      modelDetails: { baseline: 'base2', version: 'v2' },
-      clipskip: 2,
-    }))
+    fireEvent.change(select, { target: { value: 'PonyXL' } });
+    expect(setInputMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        models: ['PonyXL'],
+        modelDetails: { baseline: 'base2', version: 'v2' },
+        clipskip: 2
+      })
+    );
 
     // Test selecting AlbedoBase XL (SDXL)
-    mockInput.models = ['Some Non-SDXL Model']
-      ; (PromptInput.isDefaultPromptInput as jest.Mock).mockReturnValue(true)
-    fireEvent.change(select, { target: { value: 'AlbedoBase XL (SDXL)' } })
-    expect(setInputMock).toHaveBeenCalledWith(expect.objectContaining({
-      models: ['AlbedoBase XL (SDXL)'],
-      modelDetails: { baseline: 'base3', version: 'v3' },
-    }))
-    expect(PromptInput.setTurboDefaultPromptInput).toHaveBeenCalled()
-  })
-})
+    mockInput.models = ['Some Non-SDXL Model'];
+    (PromptInput.isDefaultPromptInput as jest.Mock).mockReturnValue(true);
+    fireEvent.change(select, { target: { value: 'AlbedoBase XL (SDXL)' } });
+    expect(setInputMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        models: ['AlbedoBase XL (SDXL)'],
+        modelDetails: { baseline: 'base3', version: 'v3' }
+      })
+    );
+    expect(PromptInput.setTurboDefaultPromptInput).toHaveBeenCalled();
+  });
+});

--- a/app/_components/AdvancedOptions/ModelSelect/modelSelectComponent.test.tsx
+++ b/app/_components/AdvancedOptions/ModelSelect/modelSelectComponent.test.tsx
@@ -108,6 +108,8 @@ describe('ModelSelect', () => {
         modelDetails: { baseline: 'base3', version: 'v3' }
       })
     );
-    expect(PromptInput.setTurboDefaultPromptInput).toHaveBeenCalled();
+
+    // Temporarily change this to 0 for now as we've disabled updating default inputs.
+    expect(PromptInput.setTurboDefaultPromptInput).toHaveBeenCalledTimes(0);
   });
 });

--- a/app/_components/AdvancedOptions/ModelSelect/modelSelectComponent.tsx
+++ b/app/_components/AdvancedOptions/ModelSelect/modelSelectComponent.tsx
@@ -31,25 +31,25 @@ export default function ModelSelect() {
     };
 
     const isPonyModel = newModel.toLowerCase().indexOf('pony') >= 0;
-    const isAlbedoBaseXL = newModel === 'AlbedoBase XL (SDXL)';
+    // const isAlbedoBaseXL = newModel === 'AlbedoBase XL (SDXL)';
 
-    let newInput: Partial<typeof input> = {
+    const newInput: Partial<typeof input> = {
       models: [newModel],
       modelDetails: modelInfo
     };
 
-    if (PromptInput.isDefaultPromptInput(input) && !isAlbedoBaseXL) {
-      newInput = PromptInput.setNonTurboDefaultPromptInput({
-        ...input,
-        ...newInput,
-        clipskip: isPonyModel && input.clipskip < 2 ? 2 : input.clipskip
-      });
-    } else if (input.models[0] !== 'AlbedoBase XL (SDXL)' && isAlbedoBaseXL) {
-      newInput = PromptInput.setTurboDefaultPromptInput({
-        ...input,
-        ...newInput
-      });
-    }
+    // if (PromptInput.isDefaultPromptInput(input) && !isAlbedoBaseXL) {
+    //   newInput = PromptInput.setNonTurboDefaultPromptInput({
+    //     ...input,
+    //     ...newInput,
+    //     clipskip: isPonyModel && input.clipskip < 2 ? 2 : input.clipskip
+    //   });
+    // } else if (input.models[0] !== 'AlbedoBase XL (SDXL)' && isAlbedoBaseXL) {
+    //   newInput = PromptInput.setTurboDefaultPromptInput({
+    //     ...input,
+    //     ...newInput
+    //   });
+    // }
 
     if (isPonyModel && input.clipskip < 2) {
       newInput.clipskip = 2;

--- a/app/_components/AdvancedOptions/ModelSelect/modelSelectComponent.tsx
+++ b/app/_components/AdvancedOptions/ModelSelect/modelSelectComponent.tsx
@@ -9,7 +9,6 @@ import ModelModalWrapper from './modalWrapper';
 import { useStore } from 'statery';
 import { ModelStore } from '@/app/_stores/ModelStore';
 import SelectCombo from '../../ComboBox';
-import PromptInput from '@/app/_data-models/PromptInput';
 
 export default function ModelSelect() {
   const { availableModels, modelDetails } = useStore(ModelStore);

--- a/app/_components/AdvancedOptions/ModelSelect/modelSelectComponent.tsx
+++ b/app/_components/AdvancedOptions/ModelSelect/modelSelectComponent.tsx
@@ -1,59 +1,62 @@
-'use client'
+'use client';
 
-import NiceModal from '@ebay/nice-modal-react'
-import OptionLabel from '../OptionLabel'
-import { useInput } from '@/app/_providers/PromptInputProvider'
-import Button from '../../Button'
-import { IconListDetails, IconWand } from '@tabler/icons-react'
-import ModelModalWrapper from './modalWrapper'
-import { useStore } from 'statery'
-import { ModelStore } from '@/app/_stores/ModelStore'
-import SelectCombo from '../../ComboBox'
-import PromptInput from '@/app/_data-models/PromptInput'
+import NiceModal from '@ebay/nice-modal-react';
+import OptionLabel from '../OptionLabel';
+import { useInput } from '@/app/_providers/PromptInputProvider';
+import Button from '../../Button';
+import { IconListDetails, IconWand } from '@tabler/icons-react';
+import ModelModalWrapper from './modalWrapper';
+import { useStore } from 'statery';
+import { ModelStore } from '@/app/_stores/ModelStore';
+import SelectCombo from '../../ComboBox';
+import PromptInput from '@/app/_data-models/PromptInput';
 
 export default function ModelSelect() {
-  const { availableModels, modelDetails } = useStore(ModelStore)
-  const { input, setInput } = useInput()
+  const { availableModels, modelDetails } = useStore(ModelStore);
+  const { input, setInput } = useInput();
 
   const findModelCountByName = (name: string) => {
     // Find the model by name and return its count, or undefined if not found
-    const model = availableModels.find((model) => model.name === name)
-    return model?.count ? ` (${model.count})` : ''
-  }
+    const model = availableModels.find((model) => model.name === name);
+    return model?.count ? ` (${model.count})` : '';
+  };
 
   const handleModelChange = (option: { value: string }) => {
-    if (!option || !option.value) return
+    if (!option || !option.value) return;
 
-    const newModel = option.value as string
+    const newModel = option.value as string;
     const modelInfo = {
       baseline: modelDetails[newModel]?.baseline ?? '',
       version: modelDetails[newModel]?.version ?? ''
-    }
+    };
 
-    const isPonyModel = newModel.toLowerCase().indexOf('pony') >= 0
-    const isAlbedoBaseXL = newModel === 'AlbedoBase XL (SDXL)'
+    const isPonyModel = newModel.toLowerCase().indexOf('pony') >= 0;
+    const isAlbedoBaseXL = newModel === 'AlbedoBase XL (SDXL)';
 
     let newInput: Partial<typeof input> = {
       models: [newModel],
       modelDetails: modelInfo
-    }
+    };
 
     if (PromptInput.isDefaultPromptInput(input) && !isAlbedoBaseXL) {
       newInput = PromptInput.setNonTurboDefaultPromptInput({
         ...input,
         ...newInput,
         clipskip: isPonyModel && input.clipskip < 2 ? 2 : input.clipskip
-      })
+      });
     } else if (input.models[0] !== 'AlbedoBase XL (SDXL)' && isAlbedoBaseXL) {
-      newInput = PromptInput.setTurboDefaultPromptInput({ ...input, ...newInput })
+      newInput = PromptInput.setTurboDefaultPromptInput({
+        ...input,
+        ...newInput
+      });
     }
 
     if (isPonyModel && input.clipskip < 2) {
-      newInput.clipskip = 2
+      newInput.clipskip = 2;
     }
 
-    setInput(newInput)
-  }
+    setInput(newInput);
+  };
 
   return (
     <OptionLabel
@@ -84,10 +87,10 @@ export default function ModelSelect() {
 
             const randomModel =
               availableModels[
-              Math.floor(Math.random() * availableModels.length)
-              ]
+                Math.floor(Math.random() * availableModels.length)
+              ];
 
-            setInput({ models: [randomModel.name] })
+            setInput({ models: [randomModel.name] });
           }}
         >
           <IconWand />
@@ -99,19 +102,19 @@ export default function ModelSelect() {
                 <ModelModalWrapper
                   handleSelectModel={(model: string) => {
                     if (model) {
-                      setInput({ models: [model] })
-                      NiceModal.remove('modal')
+                      setInput({ models: [model] });
+                      NiceModal.remove('modal');
                     }
                   }}
                 />
               ),
               modalClassName: 'w-full md:min-w-[640px] max-w-[648px]'
-            })
+            });
           }}
         >
           <IconListDetails />
         </Button>
       </div>
     </OptionLabel>
-  )
+  );
 }

--- a/app/_components/AdvancedOptions/StylePresetSelect/index.tsx
+++ b/app/_components/AdvancedOptions/StylePresetSelect/index.tsx
@@ -1,64 +1,9 @@
-import {
-  CategoryPreset,
-  StylePresetConfigurations,
-  StylePreviewConfigurations
-} from '@/app/_types/HordeTypes'
-import StylePresetSelectComponent from './stylePresetSelectComponent'
-
-export async function getData(): Promise<{
-  success: boolean
-  categories: CategoryPreset
-  presets: StylePresetConfigurations
-  previews: StylePreviewConfigurations
-}> {
-  try {
-    const urls = [
-      'https://raw.githubusercontent.com/Haidra-Org/AI-Horde-Styles/main/categories.json',
-      'https://raw.githubusercontent.com/Haidra-Org/AI-Horde-Styles/main/styles.json',
-      'https://raw.githubusercontent.com/amiantos/AI-Horde-Styles-Previews/main/previews.json'
-    ]
-
-    const [categoriesRes, presetsRes, previewsRes] = await Promise.allSettled(
-      urls.map((url) => fetch(url))
-    )
-
-    const categories =
-      categoriesRes.status === 'fulfilled'
-        ? await categoriesRes.value.json()
-        : {}
-    const presets: StylePresetConfigurations =
-      presetsRes.status === 'fulfilled' ? await presetsRes.value.json() : {}
-    const previews: StylePreviewConfigurations =
-      previewsRes.status === 'fulfilled' ? await previewsRes.value.json() : {}
-
-    // Filter categories to include only those keys that exist in presets
-    // e.g., "Summer" category includes "Summer 2022" and "Summer 2023" categories
-    const filteredCategories = Object.keys(categories).reduce((acc, key) => {
-      acc[key] = categories[key].filter(
-        (category: string) => category in presets
-      )
-      return acc
-    }, {} as CategoryPreset)
-
-    return {
-      success: true,
-      categories: filteredCategories,
-      presets,
-      previews
-    }
-  } catch (err) {
-    console.log(err)
-    return {
-      success: false,
-      categories: {},
-      presets: {},
-      previews: {}
-    }
-  }
-}
+import StylePresetSelectComponent from './stylePresetSelectComponent';
+import { getPresetData } from '@/app/_api/presets';
 
 export default async function StylePresetSelect() {
-  const data = await getData()
+  const data = await getPresetData();
+
   return (
     <StylePresetSelectComponent
       hasError={data.success === false}
@@ -66,5 +11,5 @@ export default async function StylePresetSelect() {
       presets={data.presets}
       previews={data.previews}
     />
-  )
+  );
 }

--- a/app/_components/AdvancedOptions/StylePresetSelect/stylePresetSelectComponent.tsx
+++ b/app/_components/AdvancedOptions/StylePresetSelect/stylePresetSelectComponent.tsx
@@ -1,105 +1,38 @@
-'use client'
+'use client';
 
-import { useInput } from '@/app/_providers/PromptInputProvider'
-import OptionLabel from '../OptionLabel'
-import { IconAlertTriangle, IconWand, IconX } from '@tabler/icons-react'
-import Select from '../../Select'
-import NiceModal from '@ebay/nice-modal-react'
-import StylePresetModal from '../StylePresetModal'
-import Button from '../../Button'
+import { useInput } from '@/app/_providers/PromptInputProvider';
+import OptionLabel from '../OptionLabel';
+import { IconWand, IconX } from '@tabler/icons-react';
+import Select from '../../Select';
+import NiceModal from '@ebay/nice-modal-react';
+import StylePresetModal from '../StylePresetModal';
+import Button from '../../Button';
 import {
   CategoryPreset,
-  StylePresetConfig,
   StylePresetConfigurations,
   StylePreviewConfigurations
-} from '@/app/_types/HordeTypes'
-import { useCallback } from 'react'
-import PromptInput, { DEFAULT_TURBO_EULER_LORA } from '@/app/_data-models/PromptInput'
-import { SavedLora } from '@/app/_data-models/Civitai'
-import { useStore } from 'statery'
-import { ModelStore } from '@/app/_stores/ModelStore'
+} from '@/app/_types/HordeTypes';
+import { useApplyPreset } from '@/app/_hooks/useApplyPreset';
 
 export default function StylePresetSelectComponent({
   categories,
   presets,
-  previews,
-  hasError = false
+  previews
 }: {
-  categories: CategoryPreset
-  presets: StylePresetConfigurations
-  previews: StylePreviewConfigurations
-  hasError: boolean
+  categories: CategoryPreset;
+  presets: StylePresetConfigurations;
+  previews: StylePreviewConfigurations;
+  hasError: boolean;
 }) {
-  const { input, setInput } = useInput()
-  const { modelDetails } = useStore(ModelStore)
-
-  const handleSelectPreset = useCallback(
-    (option: string, presetSettings: StylePresetConfig) => {
-      const updateInput: Partial<PromptInput> = {}
-
-      Object.keys(presetSettings).forEach((key) => {
-        if (key === 'prompt') return
-
-        if (key === 'model') {
-          updateInput.models = [presetSettings.model]
-          updateInput.modelDetails = {
-            baseline: modelDetails[presetSettings.model].baseline,
-            version: modelDetails[presetSettings.model].version
-          }
-          return
-        }
-
-        if (key === 'height' || key === 'width') {
-          updateInput.imageOrientation = 'custom'
-        }
-
-        if (key === 'loras' && typeof presetSettings.loras !== 'undefined') {
-          updateInput.loras = []
-          presetSettings.loras.forEach((lora) => {
-            let updateLora: SavedLora
-            if (lora.name == DEFAULT_TURBO_EULER_LORA.versionId) {
-              updateLora = DEFAULT_TURBO_EULER_LORA
-            } else {
-              updateLora = new SavedLora({
-                id: lora.name,
-                versionId: lora.is_version ? Number(lora.name) : false,
-                versionName: lora.name,
-                isArtbotManualEntry: true,
-                name: lora.name,
-                strength: lora.model || 1,
-                clip: lora.clip_skip || 1
-              })
-            }
-
-            // @ts-expect-error updateInput.loras is defined right above this.
-            updateInput.loras.push({ ...updateLora })
-          })
-
-          return
-        }
-
-        if (key === 'enhance') return
-
-        // TODO: Better Handle Loras and tis?
-
-        // @ts-expect-error All fields should be handled properly as of this point.
-        updateInput[key as keyof PromptInput] = presetSettings[key]
-      })
-
-      setInput({
-        ...updateInput,
-        preset: [{ name: option, settings: { ...presetSettings } }]
-      })
-    },
-    [modelDetails, setInput]
-  )
+  const { input, setInput } = useInput();
+  const handleSelectPreset = useApplyPreset(setInput);
 
   let options = [
     {
       label: 'None',
       value: 'none'
     }
-  ]
+  ];
 
   if (input.preset.length > 0) {
     options = [
@@ -107,7 +40,7 @@ export default function StylePresetSelectComponent({
         label: input.preset[0].name,
         value: input.preset[0].name
       }
-    ]
+    ];
   }
 
   return (
@@ -115,11 +48,6 @@ export default function StylePresetSelectComponent({
       title={
         <span className="row font-bold text-sm text-white gap-1">
           Style preset
-          {hasError && (
-            <div style={{ color: 'orange' }}>
-              <IconAlertTriangle />
-            </div>
-          )}
         </span>
       }
     >
@@ -134,38 +62,32 @@ export default function StylePresetSelectComponent({
                   presets={presets}
                   previews={previews}
                   handleOnClick={(option: string) => {
-                    handleSelectPreset(option, presets[option])
-                    NiceModal.remove('modal')
+                    handleSelectPreset(option, presets[option]);
+                    NiceModal.remove('modal');
                   }}
                 />
               ),
               modalClassName: 'w-full md:min-w-[640px] max-w-[648px]'
-            })
+            });
           }}
-          onChange={() => { }}
+          onChange={() => {}}
           options={options}
           value={options[0]}
         />
         <Button
           onClick={() => {
-            const presetKeys = Object.keys(presets)
+            const presetKeys = Object.keys(presets);
             const randomPreset =
-              presetKeys[Math.floor(Math.random() * presetKeys.length)]
-
-            handleSelectPreset(randomPreset, presets[randomPreset])
+              presetKeys[Math.floor(Math.random() * presetKeys.length)];
+            handleSelectPreset(randomPreset, presets[randomPreset]);
           }}
         >
           <IconWand />
         </Button>
-        <Button
-          theme="danger"
-          onClick={() => {
-            setInput({ preset: [] })
-          }}
-        >
+        <Button theme="danger" onClick={() => setInput({ preset: [] })}>
           <IconX />
         </Button>
       </div>
     </OptionLabel>
-  )
+  );
 }

--- a/app/_components/AppInit/AppInitComponent.tsx
+++ b/app/_components/AppInit/AppInitComponent.tsx
@@ -1,111 +1,120 @@
-'use client'
+'use client';
 
 /**
  * This component is used to initialize various
  * functions when the web app first loads.
  */
 
-import useHordeApiKey from '../../_hooks/useHordeApiKey'
-import { AppSettings } from '../../_data-models/AppSettings'
-import { useEffectOnce } from '../../_hooks/useEffectOnce'
-import { initDexie } from '../../_db/dexie'
-import { AvailableImageModel, ImageModelDetails } from '@/app/_types/HordeTypes'
-import { useEffect } from 'react'
-import { setAvailableModels, setImageModels } from '@/app/_stores/ModelStore'
-import { AppConstants } from '@/app/_data-models/AppConstants'
-import { useRouter, useSearchParams } from 'next/navigation'
+import useHordeApiKey from '../../_hooks/useHordeApiKey';
+import { AppSettings } from '../../_data-models/AppSettings';
+import { useEffectOnce } from '../../_hooks/useEffectOnce';
+import { initDexie } from '../../_db/dexie';
+import {
+  AvailableImageModel,
+  ImageModelDetails
+} from '@/app/_types/HordeTypes';
+import { useEffect } from 'react';
+import { setAvailableModels, setImageModels } from '@/app/_stores/ModelStore';
+import { AppConstants } from '@/app/_data-models/AppConstants';
+import { useRouter, useSearchParams } from 'next/navigation';
 import {
   AppStore,
   setAppBuildId,
   setAppOnlineStatus
-} from '@/app/_stores/AppStore'
-import { appBasepath } from '@/app/_utils/browserUtils'
-import { loadPendingImagesFromDexie } from '@/app/_controllers/pendingJobs/loadPendingImages'
-import { initJobController } from '@/app/_controllers/pendingJobs'
-import { toastController } from '@/app/_controllers/toastController'
-import { updateUseSharedKey } from '@/app/_stores/UserStore'
+} from '@/app/_stores/AppStore';
+import { appBasepath } from '@/app/_utils/browserUtils';
+import { loadPendingImagesFromDexie } from '@/app/_controllers/pendingJobs/loadPendingImages';
+import { initJobController } from '@/app/_controllers/pendingJobs';
+import { toastController } from '@/app/_controllers/toastController';
+import { updateUseSharedKey } from '@/app/_stores/UserStore';
 
 export default function AppInitComponent({
   modelsAvailable,
   modelDetails
 }: {
-  modelsAvailable: AvailableImageModel[]
-  modelDetails: { [key: string]: ImageModelDetails }
+  modelsAvailable: AvailableImageModel[];
+  modelDetails: { [key: string]: ImageModelDetails };
 }) {
-  const router = useRouter()
-  const searchParams = useSearchParams()
-  const sharedKey = searchParams?.get('api_key')
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const sharedKey = searchParams?.get('api_key');
 
-  const [handleLogin] = useHordeApiKey()
+  const [handleLogin] = useHordeApiKey();
 
   const initHeartbeat = async () => {
     try {
-      const res = await fetch(`${appBasepath()}/api/heartbeat`)
-      const { success, buildId } = (await res.json()) || {}
+      const res = await fetch(`${appBasepath()}/api/heartbeat`);
+      const { success, buildId } = (await res.json()) || {};
       if (success) {
-        setAppOnlineStatus(true)
+        setAppOnlineStatus(true);
       } else {
-        setAppOnlineStatus(false)
+        setAppOnlineStatus(false);
       }
 
       if (buildId && !AppStore.state.buildId) {
-        setAppBuildId(buildId)
+        setAppBuildId(buildId);
       } else if (buildId && AppStore.state.buildId !== buildId) {
         toastController({
           type: 'error',
           message: 'ArtBot has been updated. Please refresh the page.',
           timeout: 86400000,
           id: 'artbot_updated'
-        })
+        });
       }
     } catch (err) {
-      setAppOnlineStatus(false)
+      setAppOnlineStatus(false);
     }
-  }
+  };
 
   const getUserInfoOnLoad = async () => {
-    const apikey = AppSettings.apikey()
+    const apikey = AppSettings.apikey();
 
     if (!apikey || !apikey.trim() || apikey === AppConstants.AI_HORDE_ANON_KEY)
-      return
+      return;
 
-    await handleLogin(apikey)
-  }
+    await handleLogin(apikey);
+  };
 
   useEffect(() => {
-    setAvailableModels(modelsAvailable)
-    setImageModels(modelDetails)
-  }, [modelDetails, modelsAvailable])
+    setAvailableModels(modelsAvailable);
+    setImageModels(modelDetails);
+  }, [modelDetails, modelsAvailable]);
 
   useEffectOnce(() => {
-    console.log(`ArtBot v2.0.0_beta is online: ${new Date().toLocaleString()}`)
+    console.log(`ArtBot v2.0.0_beta is online: ${new Date().toLocaleString()}`);
 
-    initDexie()
-    getUserInfoOnLoad()
-    loadPendingImagesFromDexie()
-    initJobController()
+    initDexie();
+    getUserInfoOnLoad();
+    loadPendingImagesFromDexie();
+    initJobController();
 
-    initHeartbeat()
-    const intervalHeartbeat = setInterval(initHeartbeat, 15 * 1000)
+    initHeartbeat();
+    const intervalHeartbeat = setInterval(initHeartbeat, 15 * 1000);
 
     return () => {
-      clearInterval(intervalHeartbeat)
-    }
-  })
+      clearInterval(intervalHeartbeat);
+    };
+  });
 
   useEffect(() => {
     if (sharedKey) {
-      updateUseSharedKey(sharedKey)
-      AppSettings.set('sharedKey', sharedKey)
+      updateUseSharedKey(sharedKey);
+      AppSettings.set('sharedKey', sharedKey);
+      toastController({
+        type: 'success',
+        message: 'Using shared API key. 👍',
+        timeout: 5000,
+        id: 'shared_key_applied'
+      });
     } else if (AppSettings.get('sharedKey')) {
-      updateUseSharedKey(AppSettings.get('sharedKey'))
+      updateUseSharedKey(AppSettings.get('sharedKey'));
     }
-  }, [sharedKey])
+  }, [sharedKey]);
 
   useEffect(() => {
-    router.prefetch('/create')
-    router.prefetch('/images')
-    router.prefetch('/settings')
-  }, [router])
-  return null
+    router.prefetch('/create');
+    router.prefetch('/images');
+    router.prefetch('/settings');
+  }, [router]);
+  return null;
 }

--- a/app/_controllers/pendingJobs/downloadPendingImages.ts
+++ b/app/_controllers/pendingJobs/downloadPendingImages.ts
@@ -1,29 +1,30 @@
 import downloadImage, {
   DownloadErrorResponse,
   DownloadSuccessResponse
-} from '@/app/_api/horde/download'
+} from '@/app/_api/horde/download';
 import imageStatus, {
   StatusErrorResponse,
   StatusSuccessResponse
-} from '@/app/_api/horde/status'
-import { AppSettings } from '@/app/_data-models/AppSettings'
-import { ArtBotHordeJob } from '@/app/_data-models/ArtBotHordeJob'
+} from '@/app/_api/horde/status';
+import { AppSettings } from '@/app/_data-models/AppSettings';
+import { ArtBotHordeJob } from '@/app/_data-models/ArtBotHordeJob';
 import {
   ImageFileInterface,
   ImageStatus,
   ImageType
-} from '@/app/_data-models/ImageFile_Dexie'
-import { checkImageExistsInDexie } from '@/app/_db/ImageFiles'
-import { addImageAndDefaultFavToDexie } from '@/app/_db/jobTransactions'
-import { ImageError } from '@/app/_types/ArtbotTypes'
-import { GenMetadata, HordeGeneration } from '@/app/_types/HordeTypes'
-import { updatePendingImage } from './updatePendingImage'
-import { fetchJobByArtbotId } from '@/app/_db/hordeJobs'
-import { TaskQueue } from '@/app/_data-models/TaskQueue'
+} from '@/app/_data-models/ImageFile_Dexie';
+import { checkImageExistsInDexie } from '@/app/_db/ImageFiles';
+import { addImageAndDefaultFavToDexie } from '@/app/_db/jobTransactions';
+import { ImageError } from '@/app/_types/ArtbotTypes';
+import { GenMetadata, HordeGeneration } from '@/app/_types/HordeTypes';
+import { updatePendingImage } from './updatePendingImage';
+import { fetchJobByArtbotId } from '@/app/_db/hordeJobs';
+import { TaskQueue } from '@/app/_data-models/TaskQueue';
+import { appBasepath } from '@/app/_utils/browserUtils';
 
-const STATUS_CHECK_INTERVAL = 6050 // ms
+const STATUS_CHECK_INTERVAL = 6050; // ms
 
-const queueSystems = new Map<string, TaskQueue<{ success: boolean }>>()
+const queueSystems = new Map<string, TaskQueue<{ success: boolean }>>();
 
 const getQueueSystem = (jobId: string): TaskQueue<{ success: boolean }> => {
   if (!queueSystems.has(jobId)) {
@@ -34,26 +35,26 @@ const getQueueSystem = (jobId: string): TaskQueue<{ success: boolean }> => {
         STATUS_CHECK_INTERVAL,
         { preventDuplicates: true }
       )
-    )
+    );
   }
-  return queueSystems.get(jobId)!
-}
+  return queueSystems.get(jobId)!;
+};
 
 export const downloadImages = async ({
   jobDetails,
   kudos
 }: {
-  jobDetails: ArtBotHordeJob
-  kudos: number
+  jobDetails: ArtBotHordeJob;
+  kudos: number;
 }): Promise<{ success: boolean }> => {
-  const queueSystem = getQueueSystem(jobDetails.artbot_id)
+  const queueSystem = getQueueSystem(jobDetails.artbot_id);
   try {
     return await queueSystem.enqueue(
       async () => {
-        const response = await imageStatus(jobDetails.horde_id)
+        const response = await imageStatus(jobDetails.horde_id);
         if (!isValidResponse(response) || !response.generations) {
-          console.log(`Invalid response for jobId: ${jobDetails.artbot_id}`)
-          return { success: false }
+          console.log(`Invalid response for jobId: ${jobDetails.artbot_id}`);
+          return { success: false };
         }
 
         const {
@@ -66,7 +67,7 @@ export const downloadImages = async ({
         } = await processImageGenerations(
           jobDetails.artbot_id,
           response.generations
-        )
+        );
 
         await handleSettledImageDownloads({
           downloadImagesPromise,
@@ -74,7 +75,7 @@ export const downloadImages = async ({
           images_completed,
           jobDetails,
           kudos
-        })
+        });
 
         await updatePendingImage(jobDetails.artbot_id, {
           images_completed,
@@ -82,17 +83,17 @@ export const downloadImages = async ({
           errors: imageErrors,
           gen_metadata,
           api_response: response
-        })
+        });
 
-        return { success: true }
+        return { success: true };
       },
       jobDetails.artbot_id // Use artbot_id as the unique taskId
-    )
+    );
   } catch (error) {
-    console.error('Error in downloadImages:', error)
-    return { success: false }
+    console.error('Error in downloadImages:', error);
+    return { success: false };
   }
-}
+};
 
 const isValidResponse = (
   response: StatusSuccessResponse | StatusErrorResponse
@@ -101,65 +102,75 @@ const isValidResponse = (
     response.success &&
     'generations' in response &&
     Array.isArray(response.generations)
-  )
-}
+  );
+};
 
 const handleCensoredImage = (allowNsfw: boolean): ImageError => {
   if (!allowNsfw) {
-    return { type: 'nsfw', message: 'Image blocked due to user NSFW setting.' }
+    return { type: 'nsfw', message: 'Image blocked due to user NSFW setting.' };
   }
   return {
     type: 'csam',
     message:
       'The GPU worker was unable to complete this request. Try again? (Error code: X)'
-  }
-}
+  };
+};
 
 const processImageGenerations = async (
   jobId: string,
   generations: HordeGeneration[]
 ): Promise<{
-  completedGenerations: HordeGeneration[]
+  completedGenerations: HordeGeneration[];
   downloadImagesPromise: Promise<
     DownloadSuccessResponse | DownloadErrorResponse | null
-  >[]
-  gen_metadata: GenMetadata[]
-  imageErrors: ImageError[]
-  images_completed: number
-  images_failed: number
+  >[];
+  gen_metadata: GenMetadata[];
+  imageErrors: ImageError[];
+  images_completed: number;
+  images_failed: number;
 }> => {
-  const gen_metadata: GenMetadata[] = []
-  const imageErrors: ImageError[] = []
+  const gen_metadata: GenMetadata[] = [];
+  const imageErrors: ImageError[] = [];
 
-  const jobDetails = (await fetchJobByArtbotId(jobId)) || ({} as ArtBotHordeJob)
+  const jobDetails =
+    (await fetchJobByArtbotId(jobId)) || ({} as ArtBotHordeJob);
 
-  let images_completed = jobDetails.images_completed || 0
-  let images_failed = jobDetails.images_failed || 0
+  let images_completed = jobDetails.images_completed || 0;
+  let images_failed = jobDetails.images_failed || 0;
 
   const downloadImagesPromise: Promise<
     DownloadSuccessResponse | DownloadErrorResponse | null
-  >[] = []
-  const completedGenerations: HordeGeneration[] = []
+  >[] = [];
+  const completedGenerations: HordeGeneration[] = [];
 
-  const allowNsfw = AppSettings.get('allowNsfwImages')
+  const allowNsfw = AppSettings.get('allowNsfwImages');
 
   for (const generation of generations) {
     if (generation.censored) {
-      images_failed++
-      imageErrors.push(handleCensoredImage(allowNsfw))
-      completedGenerations.push(generation)
-      downloadImagesPromise.push(Promise.resolve(null)) // Add a placeholder for censored images
+      images_failed++;
+      imageErrors.push(handleCensoredImage(allowNsfw));
+      completedGenerations.push(generation);
+      downloadImagesPromise.push(Promise.resolve(null)); // Add a placeholder for censored images
     } else {
-      const exists = await checkImageExistsInDexie({ image_id: generation.id })
+      const exists = await checkImageExistsInDexie({ image_id: generation.id });
       if (!exists) {
-        images_completed++
-        gen_metadata.push(generation.gen_metadata as unknown as GenMetadata)
-        downloadImagesPromise.push(downloadImage(generation.img))
-        completedGenerations.push(generation)
+        images_completed++;
+        gen_metadata.push(generation.gen_metadata as unknown as GenMetadata);
+        downloadImagesPromise.push(downloadImage(generation.img));
+        completedGenerations.push(generation);
+
+        // Update ArtBot completed image count
+        fetch(`${appBasepath()}/api/status`, {
+          method: 'POST',
+          cache: 'no-store',
+          body: JSON.stringify({
+            type: 'image_done'
+          })
+        });
       } else {
         // Handle case for existing images
-        completedGenerations.push(generation)
-        downloadImagesPromise.push(Promise.resolve(null)) // Add a placeholder for existing images
+        completedGenerations.push(generation);
+        downloadImagesPromise.push(Promise.resolve(null)); // Add a placeholder for existing images
       }
     }
   }
@@ -171,8 +182,8 @@ const processImageGenerations = async (
     imageErrors,
     images_completed,
     images_failed
-  }
-}
+  };
+};
 
 const createImageFile = (
   jobDetails: ArtBotHordeJob,
@@ -193,16 +204,16 @@ const createImageFile = (
   worker_name: generation.worker_name,
   kudos: imageKudos.toFixed(2),
   apiResponse: JSON.stringify(generation)
-})
+});
 
 const handleSettledImageDownloads = async (params: {
   downloadImagesPromise: Promise<
     DownloadSuccessResponse | DownloadErrorResponse | null
-  >[]
-  completedGenerations: HordeGeneration[]
-  images_completed: number
-  jobDetails: ArtBotHordeJob
-  kudos: number
+  >[];
+  completedGenerations: HordeGeneration[];
+  images_completed: number;
+  jobDetails: ArtBotHordeJob;
+  kudos: number;
 }): Promise<void> => {
   const {
     downloadImagesPromise,
@@ -210,12 +221,12 @@ const handleSettledImageDownloads = async (params: {
     images_completed,
     jobDetails,
     kudos
-  } = params
-  const results = await Promise.allSettled(downloadImagesPromise)
-  const imageKudos = images_completed > 0 ? kudos / images_completed : 0
+  } = params;
+  const results = await Promise.allSettled(downloadImagesPromise);
+  const imageKudos = images_completed > 0 ? kudos / images_completed : 0;
 
   for (let index = 0; index < results.length; index++) {
-    const result = results[index]
+    const result = results[index];
     if (
       result.status === 'fulfilled' &&
       result.value &&
@@ -229,8 +240,8 @@ const handleSettledImageDownloads = async (params: {
         completedGenerations[index],
         result.value as DownloadSuccessResponse,
         imageKudos
-      )
-      await addImageAndDefaultFavToDexie(image)
+      );
+      await addImageAndDefaultFavToDexie(image);
     }
   }
-}
+};

--- a/app/_hooks/useApplyPreset.tsx
+++ b/app/_hooks/useApplyPreset.tsx
@@ -1,0 +1,78 @@
+import { useCallback } from 'react';
+import PromptInput, {
+  DEFAULT_TURBO_EULER_LORA
+} from '@/app/_data-models/PromptInput';
+import { SavedLora } from '@/app/_data-models/Civitai';
+import { useStore } from 'statery';
+import { ModelStore } from '@/app/_stores/ModelStore';
+import { StylePresetConfig } from '../_types/HordeTypes';
+
+export const useApplyPreset = (
+  setInput: (input: Partial<PromptInput>) => void
+) => {
+  const { modelDetails } = useStore(ModelStore);
+
+  const handleSelectPreset = useCallback(
+    (option: string, presetSettings: StylePresetConfig) => {
+      const updateInput: Partial<PromptInput> = {};
+
+      Object.keys(presetSettings).forEach((key) => {
+        if (key === 'prompt') return;
+
+        if (key === 'model') {
+          updateInput.models = [presetSettings.model];
+
+          // Safely check if modelDetails[presetSettings.model] exists
+          const modelDetail = modelDetails[presetSettings.model];
+          if (modelDetail) {
+            updateInput.modelDetails = {
+              baseline: modelDetail.baseline,
+              version: modelDetail.version
+            };
+          }
+          return;
+        }
+
+        if (key === 'height' || key === 'width') {
+          updateInput.imageOrientation = 'custom';
+        }
+
+        if (key === 'loras' && typeof presetSettings.loras !== 'undefined') {
+          updateInput.loras = [];
+          presetSettings.loras.forEach((lora) => {
+            let updateLora: SavedLora;
+            if (lora.name === DEFAULT_TURBO_EULER_LORA.versionId) {
+              updateLora = DEFAULT_TURBO_EULER_LORA;
+            } else {
+              updateLora = new SavedLora({
+                id: lora.name,
+                versionId: lora.is_version ? Number(lora.name) : false,
+                versionName: lora.name,
+                isArtbotManualEntry: true,
+                name: lora.name,
+                strength: lora.model || 1,
+                clip: lora.clip_skip || 1
+              });
+            }
+
+            updateInput.loras?.push({ ...updateLora });
+          });
+          return;
+        }
+
+        if (key === 'enhance') return;
+
+        // @ts-expect-error All fields should be handled properly as of this point.
+        updateInput[key as keyof PromptInput] = presetSettings[key];
+      });
+
+      setInput({
+        ...updateInput,
+        preset: [{ name: option, settings: { ...presetSettings } }]
+      });
+    },
+    [modelDetails, setInput]
+  );
+
+  return handleSelectPreset;
+};

--- a/app/_hooks/useCustomQueryParams.tsx
+++ b/app/_hooks/useCustomQueryParams.tsx
@@ -1,0 +1,80 @@
+import { useSearchParams } from 'next/navigation';
+import { useCallback, useEffect, useState } from 'react';
+import { useApplyPreset } from './useApplyPreset';
+import PromptInput from '../_data-models/PromptInput';
+import {
+  CategoryPreset,
+  StylePresetConfigurations,
+  StylePreviewConfigurations
+} from '../_types/HordeTypes';
+import { getPresetData } from '../_api/presets';
+
+const validQueryParams = ['preset', 'model', 'steps', 'cfg_scale', 'clip'];
+
+const queryParamMap: Record<string, keyof PromptInput> = {
+  model: 'models',
+  steps: 'steps',
+  cfg_scale: 'cfg_scale',
+  clip: 'clipskip'
+};
+
+export const useCustomQueryParams = (
+  setInput: (input: Partial<PromptInput>) => void
+) => {
+  const searchParams = useSearchParams();
+  const [presetData, setPresetData] = useState<{
+    categories: CategoryPreset;
+    presets: StylePresetConfigurations;
+    previews: StylePreviewConfigurations;
+  } | null>(null);
+
+  const handleSelectPreset = useApplyPreset(setInput);
+
+  const handleQueryParams = useCallback(async () => {
+    const preset = searchParams.get('preset');
+
+    if (preset) {
+      // Fetch preset data only if a preset query param exists
+      const data = await getPresetData();
+      if (data.success && data.presets[preset]) {
+        handleSelectPreset(preset, data.presets[preset]);
+        setPresetData(data); // Save the data for other potential use
+        return;
+      }
+    }
+
+    // Handle other query params if no preset is present
+    const queryParams: Partial<
+      Record<keyof PromptInput, string | number | string[]>
+    > = {};
+
+    searchParams.forEach((value, param) => {
+      if (validQueryParams.includes(param)) {
+        const propName = queryParamMap[param as keyof typeof queryParamMap];
+        if (propName) {
+          if (propName === 'models') {
+            queryParams[propName] = [value];
+          } else if (
+            propName === 'steps' ||
+            propName === 'cfg_scale' ||
+            propName === 'clipskip'
+          ) {
+            queryParams[propName] = Number(value);
+          } else {
+            queryParams[propName] = value;
+          }
+        }
+      }
+    });
+
+    if (Object.keys(queryParams).length > 0) {
+      setInput(queryParams as Partial<PromptInput>);
+    }
+  }, [searchParams, setInput, handleSelectPreset]);
+
+  useEffect(() => {
+    handleQueryParams();
+  }, [handleQueryParams]);
+
+  return presetData; // Return preset data if needed elsewhere
+};

--- a/app/_providers/PromptInputProvider.tsx
+++ b/app/_providers/PromptInputProvider.tsx
@@ -1,4 +1,4 @@
-'use client'
+'use client';
 
 import React, {
   createContext,
@@ -8,36 +8,36 @@ import React, {
   useRef,
   useReducer,
   useState
-} from 'react'
+} from 'react';
 
-import PromptInput from '../_data-models/PromptInput'
-import { debounce } from '../_utils/debounce'
-import { ImageFileInterface } from '../_data-models/ImageFile_Dexie'
-import { getImagesForArtbotJobFromDexie } from '../_db/ImageFiles'
-import { useStore } from 'statery'
-import { CreateImageStore } from '../_stores/CreateImageStore'
-import { decodeAndDecompress, getHashData } from '../_utils/urlUtils'
-import { ImageParamsForHordeApi } from '../_data-models/ImageParamsForHordeApi'
-import { AppSettings } from '../_data-models/AppSettings'
-import { clientHeader } from '../_data-models/ClientHeader'
-import { AppConstants } from '../_data-models/AppConstants'
+import PromptInput from '../_data-models/PromptInput';
+import { debounce } from '../_utils/debounce';
+import { ImageFileInterface } from '../_data-models/ImageFile_Dexie';
+import { getImagesForArtbotJobFromDexie } from '../_db/ImageFiles';
+import { useStore } from 'statery';
+import { CreateImageStore } from '../_stores/CreateImageStore';
+import { decodeAndDecompress, getHashData } from '../_utils/urlUtils';
+import { ImageParamsForHordeApi } from '../_data-models/ImageParamsForHordeApi';
+import { AppSettings } from '../_data-models/AppSettings';
+import { clientHeader } from '../_data-models/ClientHeader';
+import { AppConstants } from '../_data-models/AppConstants';
 
 type PromptInputContextType = {
-  input: PromptInput
-  kudos: number
-  pageLoaded: boolean
-  setInput: React.Dispatch<Partial<PromptInput>>
-  setPageLoaded: React.Dispatch<React.SetStateAction<boolean>>
-  setSourceImages: React.Dispatch<React.SetStateAction<ImageFileInterface[]>>
-  sourceImages: ImageFileInterface[]
-}
+  input: PromptInput;
+  kudos: number;
+  pageLoaded: boolean;
+  setInput: React.Dispatch<Partial<PromptInput>>;
+  setPageLoaded: React.Dispatch<React.SetStateAction<boolean>>;
+  setSourceImages: React.Dispatch<React.SetStateAction<ImageFileInterface[]>>;
+  sourceImages: ImageFileInterface[];
+};
 
-type InputState = InstanceType<typeof PromptInput>
-type InputAction = Partial<InputState>
-type InputReducer = React.Reducer<InputState, InputAction>
+type InputState = InstanceType<typeof PromptInput>;
+type InputAction = Partial<InputState>;
+type InputReducer = React.Reducer<InputState, InputAction>;
 
 interface PromptProviderProps {
-  children: React.ReactNode
+  children: React.ReactNode;
 }
 
 const defaultInputContext: PromptInputContextType = {
@@ -48,53 +48,53 @@ const defaultInputContext: PromptInputContextType = {
   setPageLoaded: () => {},
   setSourceImages: () => {},
   sourceImages: []
-}
+};
 
-const InputContext = createContext<PromptInputContextType>(defaultInputContext)
+const InputContext = createContext<PromptInputContextType>(defaultInputContext);
 
 const updateSessionStorage = (value: string) => {
-  sessionStorage.setItem('userInput', value)
-}
+  sessionStorage.setItem('userInput', value);
+};
 
-const debouncedUpdate = debounce(updateSessionStorage, 300)
+const debouncedUpdate = debounce(updateSessionStorage, 300);
 
 export const useInput = () => {
-  return useContext(InputContext)
-}
+  return useContext(InputContext);
+};
 
 export const PromptInputProvider: React.FC<PromptProviderProps> = ({
   children
 }) => {
-  const { inputUpdated } = useStore(CreateImageStore)
-  const [pageLoaded, setPageLoaded] = useState(false)
-  const [kudos, setKudos] = useState(0)
-  const [sourceImages, setSourceImages] = useState<ImageFileInterface[]>([])
+  const { inputUpdated } = useStore(CreateImageStore);
+  const [pageLoaded, setPageLoaded] = useState(false);
+  const [kudos, setKudos] = useState(0);
+  const [sourceImages, setSourceImages] = useState<ImageFileInterface[]>([]);
 
-  const kudosTimeoutRef = useRef<NodeJS.Timeout | null>(null)
+  const kudosTimeoutRef = useRef<NodeJS.Timeout | null>(null);
 
   const fetchUpdatedKudos = useCallback(
     async (input: PromptInput) => {
       if (kudosTimeoutRef.current) {
-        clearTimeout(kudosTimeoutRef.current)
+        clearTimeout(kudosTimeoutRef.current);
       }
 
       kudosTimeoutRef.current = setTimeout(async () => {
         try {
-          const { apiParams } = await ImageParamsForHordeApi.build(input)
-          apiParams.dry_run = true
+          const { apiParams } = await ImageParamsForHordeApi.build(input);
+          apiParams.dry_run = true;
 
           if (!input.prompt.trim() && !input.negative.trim() && kudos > 0) {
-            return
+            return;
           } else if (
             !input.prompt.trim() &&
             !input.negative.trim() &&
             kudos === 0
           ) {
-            apiParams.prompt = '_'
+            apiParams.prompt = '_';
           }
 
           const apikey =
-            AppSettings.apikey()?.trim() || AppConstants.AI_HORDE_ANON_KEY
+            AppSettings.apikey()?.trim() || AppConstants.AI_HORDE_ANON_KEY;
           const response = await fetch(
             `https://aihorde.net/api/v2/generate/async`,
             {
@@ -107,83 +107,75 @@ export const PromptInputProvider: React.FC<PromptProviderProps> = ({
                 apikey: apikey
               }
             }
-          )
+          );
 
           if (response.ok) {
-            const data = await response.json()
-            setKudos(data.kudos)
+            const data = await response.json();
+            setKudos(data.kudos);
           } else {
-            console.error('Failed to fetch kudos:', response.statusText)
+            console.error('Failed to fetch kudos:', response.statusText);
           }
         } catch (error) {
-          console.error('Error fetching kudos:', error)
+          console.error('Error fetching kudos:', error);
         }
-      }, 1050)
+      }, 1050);
     },
     [kudos]
-  )
+  );
 
   const inputReducer: InputReducer = (
     state: PromptInput,
     newState: Partial<PromptInput>
   ) => {
-    const updatedInputState = { ...state, ...newState }
+    const updatedInputState = { ...state, ...newState };
 
     // Save input to session storage
-    const jsonString = JSON.stringify(updatedInputState)
-    debouncedUpdate(jsonString)
+    const jsonString = JSON.stringify(updatedInputState);
+    debouncedUpdate(jsonString);
 
     // Call kudos API
-    fetchUpdatedKudos(updatedInputState)
+    fetchUpdatedKudos(updatedInputState);
 
-    return updatedInputState
-  }
+    return updatedInputState;
+  };
 
-  const [input, setInput] = useReducer(inputReducer, new PromptInput())
+  const [input, setInput] = useReducer(inputReducer, new PromptInput());
 
   useEffect(() => {
-    const retrievedString = sessionStorage.getItem('userInput')
+    const retrievedString = sessionStorage.getItem('userInput');
     if (retrievedString) {
-      const retrievedObject = JSON.parse(retrievedString)
-      setInput(retrievedObject)
+      const retrievedObject = JSON.parse(retrievedString);
+      setInput(retrievedObject);
     }
-  }, [inputUpdated])
+  }, [inputUpdated]);
 
   const loadUploadedImages = useCallback(async () => {
     const images = await getImagesForArtbotJobFromDexie(
       AppConstants.IMAGE_UPLOAD_TEMP_ID
-    )
-    setSourceImages(images)
-  }, [])
+    );
+    setSourceImages(images);
+  }, []);
 
   useEffect(() => {
-    loadUploadedImages()
-  }, [loadUploadedImages])
+    loadUploadedImages();
+  }, [loadUploadedImages]);
 
   useEffect(() => {
-    const windowHash = window.location.hash
+    const windowHash = window.location.hash;
     if (windowHash.startsWith('#share=')) {
-      const hashData = getHashData(window.location.hash) || ''
-      const formData = decodeAndDecompress(hashData)
+      const hashData = getHashData(window.location.hash) || '';
+      const formData = decodeAndDecompress(hashData);
 
       // Cleanup properties that are automatically created
       // when adding to the database.
-      delete formData.id
-      delete formData.artbot_id
+      delete formData.id;
+      delete formData.artbot_id;
 
-      setInput({ ...formData })
+      setInput({ ...formData });
     }
     // We only want this to run once, on initial page load.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [])
-
-  useEffect(() => {
-    const params = new URLSearchParams(window.location.search)
-    const model = params.get('model')
-    if (model) {
-      setInput({ models: [model] })
-    }
-  }, [])
+  }, []);
 
   return (
     <InputContext.Provider
@@ -199,5 +191,5 @@ export const PromptInputProvider: React.FC<PromptProviderProps> = ({
     >
       {children}
     </InputContext.Provider>
-  )
-}
+  );
+};

--- a/app/api/status/route.ts
+++ b/app/api/status/route.ts
@@ -1,0 +1,32 @@
+import 'dotenv/config';
+import { NextRequest } from 'next/server';
+
+const statusApi = process.env.ARTBOT_STATUS_API;
+
+export async function POST(request: NextRequest) {
+  const { type } = await request.json();
+
+  if (type === 'image_done' && statusApi) {
+    console.log(`DO WE GET HERE?!`);
+    console.log(`statusApi`, statusApi);
+    fetch(`${statusApi}/status`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json'
+      },
+      body: JSON.stringify({
+        type: 'image',
+        service: 'ArtBot_v2'
+      })
+
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    }).catch((err) => {
+      console.log(`Errr sup?`, err);
+      // Do nothing
+    });
+  }
+
+  return Response.json({
+    success: true
+  });
+}

--- a/app/changelog/_updates/2024.09.06.md
+++ b/app/changelog/_updates/2024.09.06.md
@@ -1,6 +1,11 @@
-# 2024.08.29 (v2.0.6-beta)
+# 2024.09.12 (v2.0.6-beta)
 
 - (fix) Update default TurboMix LoRA due to change in default sampler (k_euler_a)
 - (fix) Padding issues with footer
 - (feat) Add build ID to footer
 - (feat) Update "Made with" message in footer to use random rotating emoji
+- (fix) disable automated settings adjustment when choosing various models
+- (chore) integrate React Testing Library to begin writing some more robut tests for various interactive components
+- (refactor) whole bunch of refactoring to split some business logic from prentation logic in model select components, preset components
+- (feat) add ability to set models or presets via a query parameter (e.g., "/create?model=Dreamshaper" or "/create?preset=flux")
+- (chore) implement image counter service from ArtBot_v1 (no tracking of user info -- just like ArtBot_v1, when it image is finished, it calls an API simply says "hey, add +1 to your completed images counter")

--- a/app/create/_component/CustomQueryParamsHandler.tsx
+++ b/app/create/_component/CustomQueryParamsHandler.tsx
@@ -1,0 +1,10 @@
+'use client';
+import { useCustomQueryParams } from '@/app/_hooks/useCustomQueryParams';
+import { useInput } from '@/app/_providers/PromptInputProvider';
+
+// It doesn't render anything, it just handles the query params
+export default function CustomQueryParamsHandler() {
+  const { setInput } = useInput(); // Get setInput from the context
+  useCustomQueryParams(setInput);
+  return null;
+}

--- a/app/create/page.tsx
+++ b/app/create/page.tsx
@@ -1,21 +1,25 @@
-import { Metadata } from 'next'
-import PageTitle from '../_components/PageTitle'
-import { PromptInputProvider } from '../_providers/PromptInputProvider'
-import PromptInputForm from './_component/PromptInputForm'
-import PromptActionPanel from './_component/PromptActionPanel'
-import PendingImagesPanel from '../_components/PendingImagesPanel'
-import AdvancedOptions from '../_components/AdvancedOptions'
-import PromptStickyCreate from './_component/PromptStickyCreate'
+import { Metadata } from 'next';
+import PageTitle from '../_components/PageTitle';
+import { PromptInputProvider } from '../_providers/PromptInputProvider';
+import PromptInputForm from './_component/PromptInputForm';
+import PromptActionPanel from './_component/PromptActionPanel';
+import PendingImagesPanel from '../_components/PendingImagesPanel';
+import AdvancedOptions from '../_components/AdvancedOptions';
+import PromptStickyCreate from './_component/PromptStickyCreate';
+import { Suspense } from 'react';
+import CustomQueryParamsHandler from './_component/CustomQueryParamsHandler';
 
 export const metadata: Metadata = {
   title: 'Create | ArtBot for Stable Diffusion'
-}
+};
 
 // TODO: Figure out why I need to overiride Tailwind functions using "!".
-
-export default async function CreatePage() {
+export default function CreatePage() {
   return (
     <PromptInputProvider>
+      <Suspense fallback={null}>
+        <CustomQueryParamsHandler />
+      </Suspense>
       <div className="col md:row justify-start !items-start !gap-4">
         <div className="sm:min-w-[448px] w-full md:max-w-[512px] col gap-2">
           <PageTitle>Create</PageTitle>
@@ -36,5 +40,5 @@ export default async function CreatePage() {
         </div>
       </div>
     </PromptInputProvider>
-  )
+  );
 }

--- a/jest.config.js
+++ b/jest.config.js
@@ -7,7 +7,7 @@ module.exports = {
   // moduleNameMapper needs to match compilerOptions.paths in tsconfig
   moduleNameMapper: {
     '^@/(.*)$': '<rootDir>/$1',
-    "\\.(css|scss|sass)$": "identity-obj-proxy" // Mock CSS module imports
+    '\\.(css|scss|sass)$': 'identity-obj-proxy' // Mock CSS module imports
   },
   testPathIgnorePatterns: [
     '<rootDir>/.next/',
@@ -16,7 +16,17 @@ module.exports = {
     '<rootDir>/__mocks__/*'
   ],
   transform: {
+    // This is necessary because next.js forces { "jsx": "preserve" }, but
+    // ts-jest appears to require { "jsx": "react" }
+    '^.+\\.[jt]sx?$': [
+      'ts-jest',
+      {
+        tsconfig: {
+          jsx: 'react-jsx'
+        }
+      }
+    ],
     '\\.tsx?$': ['ts-jest', {}] // TypeScript files
   },
   transformIgnorePatterns: ['/node_modules/', '^.+\\.module\\.(css)$']
-}
+};

--- a/jest.config.js
+++ b/jest.config.js
@@ -6,7 +6,8 @@ module.exports = {
 
   // moduleNameMapper needs to match compilerOptions.paths in tsconfig
   moduleNameMapper: {
-    '^@/(.*)$': '<rootDir>/$1'
+    '^@/(.*)$': '<rootDir>/$1',
+    "\\.(css|scss|sass)$": "identity-obj-proxy" // Mock CSS module imports
   },
   testPathIgnorePatterns: [
     '<rootDir>/.next/',
@@ -15,7 +16,7 @@ module.exports = {
     '<rootDir>/__mocks__/*'
   ],
   transform: {
-    '\\.tsx?$': ['ts-jest', {}]
+    '\\.tsx?$': ['ts-jest', {}] // TypeScript files
   },
   transformIgnorePatterns: ['/node_modules/', '^.+\\.module\\.(css)$']
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
         "clsx": "2.1.1",
         "dexie": "4.0.8",
         "dirty-json": "0.9.2",
+        "dotenv": "16.4.5",
         "embla-carousel-react": "8.2.0",
         "file-saver": "2.0.5",
         "gray-matter": "4.0.3",
@@ -4332,6 +4333,17 @@
       "version": "3.1.6",
       "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.1.6.tgz",
       "integrity": "sha512-cTOAhc36AalkjtBpfG6O8JimdTMWNXjiePT2xQH/ppBGi/4uIpmj8eKyIkMJErXWARyINV/sB38yf8JCLF5pbQ=="
+    },
+    "node_modules/dotenv": {
+      "version": "16.4.5",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.4.5.tgz",
+      "integrity": "sha512-ZmdL2rui+eB2YwhsWzjInR8LldtZHGDoQ1ugH85ppHKwpUHL7j7rN0Ti9NCnGiQbhaZ11FpR+7ao1dNsmduNUg==",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
     },
     "node_modules/duplexer": {
       "version": "0.1.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -50,6 +50,8 @@
         "statery": "0.7.1"
       },
       "devDependencies": {
+        "@testing-library/dom": "10.4.0",
+        "@testing-library/react": "16.0.1",
         "@types/clone-deep": "4.0.4",
         "@types/file-saver": "2.0.7",
         "@types/jest": "29.5.12",
@@ -63,6 +65,7 @@
         "eslint-config-next": "14.2.7",
         "eslint-config-prettier": "9.1.0",
         "husky": "9.1.5",
+        "identity-obj-proxy": "3.0.0",
         "jest": "29.7.0",
         "jest-environment-jsdom": "29.7.0",
         "lint-staged": "15.2.9",
@@ -2215,6 +2218,84 @@
         "url": "https://github.com/sponsors/tannerlinsley"
       }
     },
+    "node_modules/@testing-library/dom": {
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.0.tgz",
+      "integrity": "sha512-pemlzrSESWbdAloYml3bAJMEfNh1Z7EduzqPKprCH5S341frlpYnUEW0H72dLxa6IsYr+mPno20GiSm+h9dEdQ==",
+      "dev": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "5.3.0",
+        "chalk": "^4.1.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.5.0",
+        "pretty-format": "^27.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@testing-library/dom/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@testing-library/dom/node_modules/pretty-format": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^17.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/@testing-library/dom/node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true
+    },
+    "node_modules/@testing-library/react": {
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-16.0.1.tgz",
+      "integrity": "sha512-dSmwJVtJXmku+iocRhWOUFbrERC76TX2Mnf0ATODz8brzAZrMBbzLwQixlBSanZxR6LddK3eiwpSFZgDET1URg==",
+      "dev": true,
+      "dependencies": {
+        "@babel/runtime": "^7.12.5"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": "^10.0.0",
+        "@types/react": "^18.0.0",
+        "@types/react-dom": "^18.0.0",
+        "react": "^18.0.0",
+        "react-dom": "^18.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@tootallnate/once": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.0.tgz",
@@ -2223,6 +2304,12 @@
       "engines": {
         "node": ">= 10"
       }
+    },
+    "node_modules/@types/aria-query": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
+      "dev": true
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -4222,6 +4309,12 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/dom-accessibility-api": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
+      "dev": true
+    },
     "node_modules/domexception": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/domexception/-/domexception-4.0.0.tgz",
@@ -5791,6 +5884,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/harmony-reflect": {
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/harmony-reflect/-/harmony-reflect-1.6.2.tgz",
+      "integrity": "sha512-HIp/n38R9kQjDEziXyDTuW3vvoxxyxjxFzXLrBr18uB47GnSt+G9D29fqrpM5ZkspMcPICud3XsBJQ4Y2URg8g==",
+      "dev": true
+    },
     "node_modules/has-bigints": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.0.2.tgz",
@@ -6007,6 +6106,18 @@
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/idb/-/idb-8.0.0.tgz",
       "integrity": "sha512-l//qvlAKGmQO31Qn7xdzagVPPaHTxXx199MhrAFuVBTPqydcPYBWjkrbv4Y0ktB+GmWOiwHl237UUOrLmQxLvw=="
+    },
+    "node_modules/identity-obj-proxy": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/identity-obj-proxy/-/identity-obj-proxy-3.0.0.tgz",
+      "integrity": "sha512-00n6YnVHKrinT9t0d9+5yZC6UBNJANpYEQvL2LlX6Ab9lnmxzIRcEmTPuyGScvl1+jKuCICX1Z0Ab1pPKKdikA==",
+      "dev": true,
+      "dependencies": {
+        "harmony-reflect": "^1.4.6"
+      },
+      "engines": {
+        "node": ">=4"
+      }
     },
     "node_modules/ieee754": {
       "version": "1.2.1",
@@ -8272,6 +8383,15 @@
       "integrity": "sha512-9hp3Vp2/hFQUiIwKo8XCeFVnrg8Pk3TYNPIR7tJADKi5YfcF7vEaK7avFHTlSy3kOKYaJQaalfEo6YuXdceBOQ==",
       "engines": {
         "node": "14 || >=16.14"
+      }
+    },
+    "node_modules/lz-string": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+      "dev": true,
+      "bin": {
+        "lz-string": "bin/bin.js"
       }
     },
     "node_modules/make-dir": {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "build": "node generateBuildId.js && next build",
     "dev": "next dev",
     "lint": "next lint",
-    "postbuild": "cp -R public .next/standalone && cp -R .next/static .next/standalone/.next && cp ecosystem.config.js .next/standalone",
+    "postbuild": "cp -R public .next/standalone && cp -R .next/static .next/standalone/.next && cp ecosystem.config.js .next/standalone && cp .env .next/standalone",
     "prepare": "husky",
     "prettier": "prettier --write \"app/**/*.{js,jsx,ts,tsx}\"",
     "prod:serve": "pm2 stop artbot && pm2 delete artbot && pm2 start ecosystem.config.js --env production --only artbot && pm2 save",

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "clsx": "2.1.1",
     "dexie": "4.0.8",
     "dirty-json": "0.9.2",
+    "dotenv": "16.4.5",
     "embla-carousel-react": "8.2.0",
     "file-saver": "2.0.5",
     "gray-matter": "4.0.3",

--- a/package.json
+++ b/package.json
@@ -70,6 +70,8 @@
     "statery": "0.7.1"
   },
   "devDependencies": {
+    "@testing-library/dom": "10.4.0",
+    "@testing-library/react": "16.0.1",
     "@types/clone-deep": "4.0.4",
     "@types/file-saver": "2.0.7",
     "@types/jest": "29.5.12",
@@ -83,6 +85,7 @@
     "eslint-config-next": "14.2.7",
     "eslint-config-prettier": "9.1.0",
     "husky": "9.1.5",
+    "identity-obj-proxy": "3.0.0",
     "jest": "29.7.0",
     "jest-environment-jsdom": "29.7.0",
     "lint-staged": "15.2.9",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,7 +10,7 @@
     "moduleResolution": "node",
     "incremental": true,
     "isolatedModules": true,
-    "jsx": "preserve",
+    "jsx": "react-jsx",
     "plugins": [
       {
         "name": "next"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,11 +1,6 @@
 {
   "compilerOptions": {
-    "lib": [
-      "dom",
-      "dom.iterable",
-      "esnext",
-      "webworker"
-    ],
+    "lib": ["dom", "dom.iterable", "esnext", "webworker"],
     "allowJs": true,
     "skipLibCheck": true,
     "strict": true,
@@ -15,16 +10,14 @@
     "moduleResolution": "node",
     "incremental": true,
     "isolatedModules": true,
-    "jsx": "preserve",
+    "jsx": "react-jsx",
     "plugins": [
       {
         "name": "next"
       }
     ],
     "paths": {
-      "@/*": [
-        "./*"
-      ]
+      "@/*": ["./*"]
     },
     "resolveJsonModule": true,
     "target": "es2015",
@@ -45,8 +38,5 @@
     "generateBuildId.js",
     "global.d.ts"
   ],
-  "exclude": [
-    "node_modules",
-    "public/sw.js"
-  ]
+  "exclude": ["node_modules", "public/sw.js"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,11 @@
 {
   "compilerOptions": {
-    "lib": ["dom", "dom.iterable", "esnext", "webworker"],
+    "lib": [
+      "dom",
+      "dom.iterable",
+      "esnext",
+      "webworker"
+    ],
     "allowJs": true,
     "skipLibCheck": true,
     "strict": true,
@@ -10,14 +15,16 @@
     "moduleResolution": "node",
     "incremental": true,
     "isolatedModules": true,
-    "jsx": "react-jsx",
+    "jsx": "preserve",
     "plugins": [
       {
         "name": "next"
       }
     ],
     "paths": {
-      "@/*": ["./*"]
+      "@/*": [
+        "./*"
+      ]
     },
     "resolveJsonModule": true,
     "target": "es2015",
@@ -38,5 +45,8 @@
     "generateBuildId.js",
     "global.d.ts"
   ],
-  "exclude": ["node_modules", "public/sw.js"]
+  "exclude": [
+    "node_modules",
+    "public/sw.js"
+  ]
 }


### PR DESCRIPTION
- (fix) disable automated settings adjustment when choosing various models
- (chore) integrate React Testing Library to begin writing some more robut tests for various interactive components
- (refactor) whole bunch of refactoring to split some business logic from prentation logic in model select components, preset components
- (feat) add ability to set models or presets via a query parameter (e.g., "/create?model=Dreamshaper" or "/create?preset=flux")
- (chore) implement image counter service from ArtBot_v1 (no tracking of user info -- just like ArtBot_v1, when it image is finished, it calls an API simply says "hey, add +1 to your completed images counter")
